### PR TITLE
Fix a bug of the SplashSetModel.Find method.

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/DataObj/StandardCompoundModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/DataObj/StandardCompoundModel.cs
@@ -35,7 +35,7 @@ namespace CompMs.App.Msdial.Model.DataObj
         }
 
         public bool TrySetIdIfMatch(AlignmentSpotProperty spotProperty) {
-            if (!string.IsNullOrEmpty(spotProperty?.Name) && !spotProperty.Name.Contains("w/o") && spotProperty.Name.Contains(StandardName)) {
+            if (!string.IsNullOrEmpty(spotProperty?.Name) && spotProperty.Name.Contains(StandardName)) {
                 PeakID = spotProperty.MasterAlignmentID;
                 return true;
             }

--- a/src/MSDIAL5/MsdialGuiApp/Model/Statistics/SplashSetModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Statistics/SplashSetModel.cs
@@ -94,7 +94,7 @@ namespace CompMs.App.Msdial.Model.Statistics
         public void Find() {
             foreach (var lipid in SplashProduct.Lipids) {
                 foreach (var spot in _spots) {
-                    if (lipid.TrySetIdIfMatch(spot)) {
+                    if (spot.IsReferenceMatched(_evaluator) && lipid.TrySetIdIfMatch(spot)) {
                         break;
                     }
                 }


### PR DESCRIPTION
Even spots that were not Ref Matched were used for normalization.