### PR TITLE
Fix a bug of AdductType view

### DIFF
--- a/src/Common/CommonStandard/DataObj/Property/AdductIon.cs
+++ b/src/Common/CommonStandard/DataObj/Property/AdductIon.cs
@@ -146,6 +146,12 @@ namespace CompMs.Common.DataObj.Property
             public AdductIons() {
                 _dictionary = new ConcurrentDictionary<string, AdductIon>();
                 _dictionary.TryAdd(Default.AdductIonName, Default);
+                var hac = GetAdductIonCore("[M+CH3COO]-");
+                _dictionary.TryAdd("[M+CH3COO]-", hac);
+                _dictionary.TryAdd("[M+Hac-H]-", hac);
+                var fa = GetAdductIonCore("[M+HCOO]-");
+                _dictionary.TryAdd("[M+HCOO]-", fa);
+                _dictionary.TryAdd("[M+FA-H]-", fa);
             }
 
             public AdductIon GetOrAdd(string adduct) {


### PR DESCRIPTION
[M+CH3COO]- and [M+Hac-H]-, [M+HCOO]- and [M+FA-H]- not identified as identical