### PR TITLE
Fix bug: resolve display issue in file specific MS/MS view

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/MsSpectrumModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/MsSpectrumModel.cs
@@ -45,7 +45,7 @@ namespace CompMs.App.Msdial.Model.Chart
             {
                 upperSpectrumModel.GetHorizontalRange(),
                 lowerSpectrumModel.GetHorizontalRange(),
-            }.CombineLatest(xs => xs.Aggregate((x, y) => (Math.Min(x.Item1, y.Item1), Math.Max(x.Item2, x.Item2))))
+            }.CombineLatest(xs => xs.Aggregate((x, y) => (Math.Min(x.Item1, y.Item1), Math.Max(x.Item2, y.Item2))))
             .ToReactiveContinuousAxisManager(new ConstantMargin(40))
             .AddTo(Disposables);
             HorizontalAxis = Observable.Return(horizontalAxis);


### PR DESCRIPTION
Address a bug where the reference spectrum is not displayed for peaks with suggested annotation.