### PR TITLE
Fix bug in LBM file import when lipid class is not selected

### DIFF
--- a/src/Common/CommonStandard/Parser/MspFileParcer.cs
+++ b/src/Common/CommonStandard/Parser/MspFileParcer.cs
@@ -167,7 +167,7 @@ namespace CompMs.Common.Parser
         public static List<MoleculeMsReference> ReadSerializedLbmLibrary(string file, List<LbmQuery> queries,
             IonMode ionMode, SolventType solventType, CollisionType collisionType) {
             var tQueries = getTrueQueryStrings(queries);
-            if (tQueries.Count == 0) return null;
+            if (tQueries.Count == 0) return new List<MoleculeMsReference>();
 
             var usedMspDB = new List<MoleculeMsReference>();
             var mspDB = ReadSerializedMspObject(file);


### PR DESCRIPTION
Addressed a bug causing a crash during LBM file import when the lipid class is not selected.