### PR TITLE
MsdialConsoleApp - added support for multiple CPU threads

### DIFF
--- a/src/MSDIAL4/MsdialConsoleAppCore/Parser/ConfigParser.cs
+++ b/src/MSDIAL4/MsdialConsoleAppCore/Parser/ConfigParser.cs
@@ -177,6 +177,9 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Parser
                 //Isotope
                 case "maximum charged number": if (int.TryParse(value, out i)) param.MaxChargeNumber = i; return;
 
+                // max number of CPU threads
+                case "number of threads": if (int.TryParse(value, out i)) param.NumThreads = i; Console.WriteLine("Asked for {0} threads", i); return;
+
                 //Retentiontime correction
                 case "excute rt correction": if (value.ToUpper() == "TRUE" || value.ToUpper() == "FALSE") param.RetentionTimeCorrectionCommon.RetentionTimeCorrectionParam.ExcuteRtCorrection = bool.Parse(value); return;
                 case "rt correction with smoothing for rt diff": if (value.ToUpper() == "TRUE" || value.ToUpper() == "FALSE") param.RetentionTimeCorrectionCommon.RetentionTimeCorrectionParam.doSmoothing = bool.Parse(value); return;

--- a/src/MSDIAL4/MsdialConsoleAppCore/Process/LcmsDdaProcess.cs
+++ b/src/MSDIAL4/MsdialConsoleAppCore/Process/LcmsDdaProcess.cs
@@ -12,6 +12,11 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Reflection;
+
 
 namespace Riken.Metabolomics.MsdialConsoleApp.Process
 {
@@ -19,10 +24,12 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Process
     {
         public int Run(string inputFolder, string outputFolder, string methodFile, bool isProjectStore, float targetMz)
         {
-            Console.WriteLine("Loading library files..");
+            Console.WriteLine("Loading library files...");
+
 
             var analysisFiles = AnalysisFilesParser.ReadInput(inputFolder);
-            if (analysisFiles == null || analysisFiles.Count == 0) {
+            if (analysisFiles == null || analysisFiles.Count == 0)
+            {
                 Console.WriteLine("There is no input file to be imported.");
                 return -1;
             }
@@ -49,14 +56,19 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Process
             var mspDB = new List<MspFormatCompoundInformationBean>();
             if (projectProp.LibraryFilePath != null && projectProp.LibraryFilePath != string.Empty)
             {
-				if (!System.IO.File.Exists(projectProp.LibraryFilePath)) {
-					return fileNoExistError(projectProp.LibraryFilePath);
-				} else {
-					mspDB = DatabaseLcUtility.GetMspDbQueries(projectProp.LibraryFilePath, iupacDB);
-                    if (mspDB != null && mspDB.Count >= 0) {
+                if (!System.IO.File.Exists(projectProp.LibraryFilePath))
+                {
+                    return fileNoExistError(projectProp.LibraryFilePath);
+                }
+                else
+                {
+                    mspDB = DatabaseLcUtility.GetMspDbQueries(projectProp.LibraryFilePath, iupacDB);
+                    if (mspDB != null && mspDB.Count >= 0)
+                    {
                         mspDB = mspDB.OrderBy(n => n.PrecursorMz).ToList();
                         var counter = 0;
-                        foreach (var query in mspDB) {
+                        foreach (var query in mspDB)
+                        {
                             query.Id = counter; counter++;
                         }
                     }
@@ -66,35 +78,46 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Process
             var txtDB = new List<PostIdentificatioinReferenceBean>();
             if (projectProp.PostIdentificationLibraryFilePath != null && projectProp.PostIdentificationLibraryFilePath != string.Empty)
             {
-				if (!System.IO.File.Exists(projectProp.PostIdentificationLibraryFilePath)) {
-					return fileNoExistError(projectProp.PostIdentificationLibraryFilePath);
-				} else {
-					txtDB = DatabaseLcUtility.GetTxtDbQueries(projectProp.PostIdentificationLibraryFilePath);
-				}
+                if (!System.IO.File.Exists(projectProp.PostIdentificationLibraryFilePath))
+                {
+                    return fileNoExistError(projectProp.PostIdentificationLibraryFilePath);
+                }
+                else
+                {
+                    txtDB = DatabaseLcUtility.GetTxtDbQueries(projectProp.PostIdentificationLibraryFilePath);
+                }
             }
 
             var error = string.Empty;
-            if (projectProp.CompoundListInTargetModePath != null && projectProp.CompoundListInTargetModePath != string.Empty) {
+            if (projectProp.CompoundListInTargetModePath != null && projectProp.CompoundListInTargetModePath != string.Empty)
+            {
                 if (!System.IO.File.Exists(projectProp.CompoundListInTargetModePath))
                     return fileNoExistError(projectProp.CompoundListInTargetModePath);
                 lcmsParam.CompoundListInTargetMode = TextLibraryParcer.CompoundListInTargetModeReader(projectProp.CompoundListInTargetModePath, out error);
-                if (error != string.Empty) {
+                if (error != string.Empty)
+                {
                     Console.WriteLine(error);
                 }
             }
 
-            if (targetMz > 0) {
-                if (lcmsParam.CompoundListInTargetMode == null || lcmsParam.CompoundListInTargetMode.Count == 0) {
+            if (targetMz > 0)
+            {
+                if (lcmsParam.CompoundListInTargetMode == null || lcmsParam.CompoundListInTargetMode.Count == 0)
+                {
                     lcmsParam.CompoundListInTargetMode = new List<TextFormatCompoundInformationBean>();
                 }
                 lcmsParam.CompoundListInTargetMode.Add(new TextFormatCompoundInformationBean() { MetaboliteName = "Target", AccurateMass = targetMz, AccurateMassTolerance = lcmsParam.MassSliceWidth });
             }
 
             // iSTDs are added to targeted compound list
-            if (targetMz > 0 || (lcmsParam.CompoundListInTargetMode != null && lcmsParam.CompoundListInTargetMode.Count > 0)) {
-                if (lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary != null && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count > 0 && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count(x => x.IsTarget == true) > 0) {
-                    foreach (var iSTD in lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary) {
-                        if (iSTD.IsTarget) {
+            if (targetMz > 0 || (lcmsParam.CompoundListInTargetMode != null && lcmsParam.CompoundListInTargetMode.Count > 0))
+            {
+                if (lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary != null && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count > 0 && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count(x => x.IsTarget == true) > 0)
+                {
+                    foreach (var iSTD in lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary)
+                    {
+                        if (iSTD.IsTarget)
+                        {
                             lcmsParam.CompoundListInTargetMode.Add(new TextFormatCompoundInformationBean() { MetaboliteName = iSTD.MetaboliteName, AccurateMass = iSTD.AccurateMass, AccurateMassTolerance = iSTD.AccurateMassTolerance });
                         }
                     }
@@ -103,17 +126,20 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Process
 
             Console.WriteLine("Start processing..");
             if (lcmsParam.RetentionTimeCorrectionCommon.RetentionTimeCorrectionParam.ExcuteRtCorrection == true && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary != null &&
-                lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count > 0 && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count(x => x.IsTarget == true) > 0) {
+                lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count > 0 && lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary.Count(x => x.IsTarget == true) > 0)
+            {
                 Console.WriteLine("Excute RT correction");
-                foreach (var analysisFile in analysisFiles) {
+                foreach (var analysisFile in analysisFiles)
+                {
                     Console.WriteLine(analysisFile.AnalysisFilePropertyBean.AnalysisFileName);
                     analysisFile.RetentionTimeCorrectionBean = new Rfx.Riken.OsakaUniv.RetentionTimeCorrection.RetentionTimeCorrectionBean();
                     Msdial.Lcms.Dataprocess.Algorithm.RetentionTimeCorrection.Execute(projectProp, rdamProperty, analysisFile, lcmsParam, lcmsParam.RetentionTimeCorrectionCommon.StandardLibrary, lcmsParam.RetentionTimeCorrectionCommon.RetentionTimeCorrectionParam);
                 }
             }
 
-            return Execute(projectProp, rdamProperty, analysisFiles, lcmsParam, mspDB,
-                txtDB, iupacDB, alignmentFile, outputFolder, isProjectStore);
+            // get results, wait for all
+            int result = Execute(projectProp, rdamProperty, analysisFiles, lcmsParam, mspDB, txtDB, iupacDB, alignmentFile, outputFolder, isProjectStore).GetAwaiter().GetResult();
+            return result;          // return int, expected 0
         }
 
         private ProjectPropertyBean getFilePropertyDictionaryFromAnalysisFiles(ProjectPropertyBean projectProp, List<AnalysisFileBean> analysisFiles)
@@ -128,47 +154,98 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Process
             return projectProp;
         }
 
-        private int Execute(ProjectPropertyBean projectProp, RdamPropertyBean rdamProperty, List<AnalysisFileBean> analysisFiles, 
-            AnalysisParametersBean lcmsParam, List<MspFormatCompoundInformationBean> mspDB, List<PostIdentificatioinReferenceBean> txtDB, 
-            IupacReferenceBean iupacDB, AlignmentFileBean alignmentFile, string outputfolder, bool isProjectStore)
+        private async Task<int> Execute(ProjectPropertyBean projectProp, RdamPropertyBean rdamProperty, List<AnalysisFileBean> analysisFiles,
+    AnalysisParametersBean lcmsParam, List<MspFormatCompoundInformationBean> mspDB, List<PostIdentificatioinReferenceBean> txtDB,
+    IupacReferenceBean iupacDB, AlignmentFileBean alignmentFile, string outputfolder, bool isProjectStore)
         {
-            foreach (var file in analysisFiles) {
-                var error = string.Empty;
-                ProcessFile.Execute(projectProp, rdamProperty, file, lcmsParam, iupacDB, mspDB, txtDB, out error, null);
-                if (error != string.Empty) {
-                    Console.WriteLine(error);
-                }
 
-                #region//export
-                var filepath = file.AnalysisFilePropertyBean.AnalysisFilePath;
-                var rdamID = rdamProperty.RdamFilePath_RdamFileID[filepath];
-                var fileID = file.AnalysisFilePropertyBean.AnalysisFileId;
-                var measurementID = rdamProperty.RdamFileContentBeanCollection[rdamID].FileID_MeasurementID[fileID];
-
-                Console.WriteLine("Exporting deconvolution results...");
-                using (var rawDataAccess = new RawDataAccess(filepath, measurementID, false, false, true, file.RetentionTimeCorrectionBean.PredictedRt)) {
-                    var raw_measurment = DataAccessLcUtility.GetRawDataMeasurement(rawDataAccess);
-                    var spectrumCollection = DataAccessLcUtility.GetAllSpectrumCollection(raw_measurment);
-                    var accumulatedMs1SpecCollection = DataAccessLcUtility.GetAccumulatedMs1SpectrumCollection(raw_measurment);
-                    ResultExportForLC.ExportMs2DecResult(file, outputfolder, accumulatedMs1SpecCollection, spectrumCollection, mspDB, txtDB, lcmsParam, projectProp);
+            int cumulativeDelay = 100;                      // wait to start a thread
+            int askedThreads = lcmsParam.NumThreads;        // parameter file variable, user asks to use this number of threads
+            var numThreads = 1;                             //for single thread machines
+            if (askedThreads > 1)
+            {
+                var lp = Environment.ProcessorCount;
+                if (askedThreads > lp + 1)
+                {
+                    askedThreads = lp;                      //use max available threads if possible
                 }
-                #endregion
-                Console.WriteLine(file.AnalysisFilePropertyBean.AnalysisFilePath + " finished");
+                numThreads = askedThreads;
+            }
+            Console.WriteLine("Max threads {0}. Looking for {1} threads...", Environment.ProcessorCount, numThreads);
+
+            var semaphore = new SemaphoreSlim(numThreads);      // prepare semaphore, asks for a specific number of threads
+            var tasks = new List<Task>();
+            var filesToProcess = new List<AnalysisFileBean>(analysisFiles);     // a copy of analysisFiles
+            var filesToRemove = new ConcurrentBag<AnalysisFileBean>();          // list of finished files
+
+            foreach (var file in filesToProcess)
+            {
+                await semaphore.WaitAsync();                // acquire a semaphore slot
+
+                tasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        var error = string.Empty;
+                        await Task.Delay(cumulativeDelay);
+                        cumulativeDelay += 10;                  // add a mini delay to each subsequent file processing, could be probably removed compeltely
+                        var localFile = file;
+                        int threadId = Thread.CurrentThread.ManagedThreadId;
+                        Console.WriteLine($"Processing file {localFile.AnalysisFilePropertyBean.AnalysisFilePath} on Thread ID: {threadId}");   // keep track on threads used                        
+                        ProcessFile.Execute(projectProp, rdamProperty, localFile, lcmsParam, iupacDB, mspDB, txtDB, out error, null);           // standard Execute for MS-DIAL
+                        if (error != string.Empty)
+                        {
+                            Console.WriteLine(error);
+                        }
+                        Console.WriteLine($"Finished processing {file.AnalysisFilePropertyBean.AnalysisFilePath}, consider 1/2 DONE");
+
+                        // Export logic
+                        var filepath = localFile.AnalysisFilePropertyBean.AnalysisFilePath;
+                        var rdamID = rdamProperty.RdamFilePath_RdamFileID[filepath];
+                        var fileID = localFile.AnalysisFilePropertyBean.AnalysisFileId;
+                        var measurementID = rdamProperty.RdamFileContentBeanCollection[rdamID].FileID_MeasurementID[fileID];
+
+                        Console.WriteLine("Exporting deconvolution results...");
+
+                        using (var rawDataAccess = new RawDataAccess(filepath, measurementID, false, false, true, localFile.RetentionTimeCorrectionBean.PredictedRt))
+                        {
+                            var raw_measurment = DataAccessLcUtility.GetRawDataMeasurement(rawDataAccess);
+                            var spectrumCollection = DataAccessLcUtility.GetAllSpectrumCollection(raw_measurment);
+                            var accumulatedMs1SpecCollection = DataAccessLcUtility.GetAccumulatedMs1SpectrumCollection(raw_measurment);
+                            ResultExportForLC.ExportMs2DecResult(localFile, outputfolder, accumulatedMs1SpecCollection, spectrumCollection, mspDB, txtDB, lcmsParam, projectProp);
+                        }
+
+                        Console.WriteLine($"Finished {file.AnalysisFilePropertyBean.AnalysisFilePath}, consider DONE");
+
+                        filesToRemove.Add(file);
+                    }
+                    finally
+                    {
+                        semaphore.Release();                        // release the semaphore slot
+                    }
+                }));
+            }
+
+            await Task.WhenAll(tasks);                              // wait for all finished
+
+            foreach (var fileToRemove in filesToRemove)             // cleaning
+            {
+                filesToProcess.Remove(fileToRemove);
             }
 
             AlignmentResultBean alignmentResult = null;
             if (analysisFiles.Count > 1 && lcmsParam.TogetherWithAlignment)
             {
                 alignmentResult = new AlignmentResultBean();
-                ProcessJointAligner.Execute(rdamProperty, projectProp, new ObservableCollection<AnalysisFileBean>(analysisFiles), 
+                ProcessJointAligner.Execute(rdamProperty, projectProp, new ObservableCollection<AnalysisFileBean>(analysisFiles),
                     lcmsParam, alignmentResult, null);
                 Console.WriteLine("Joint aligner finished");
 
-                ProcessGapFilling.Execute(projectProp, rdamProperty, new ObservableCollection<AnalysisFileBean>(analysisFiles), alignmentFile, lcmsParam, 
+                ProcessGapFilling.Execute(projectProp, rdamProperty, new ObservableCollection<AnalysisFileBean>(analysisFiles), alignmentFile, lcmsParam,
                     iupacDB, alignmentResult, null);
                 Console.WriteLine("Gap filling finished");
 
-                ProcessAlignmentFinalization.Execute(new ObservableCollection<AnalysisFileBean>(analysisFiles), alignmentFile.SpectraFilePath, 
+                ProcessAlignmentFinalization.Execute(new ObservableCollection<AnalysisFileBean>(analysisFiles), alignmentFile.SpectraFilePath,
                     alignmentResult, lcmsParam, projectProp, mspDB, null, null);
                 Console.WriteLine("Finalization finished");
 
@@ -177,12 +254,13 @@ namespace Riken.Metabolomics.MsdialConsoleApp.Process
                 ResultExportForLC.ExportAlignmentResult(outputFile, alignmentFile, alignmentResult, mspDB, txtDB, analysisFiles, lcmsParam);
             }
 
-            if (isProjectStore) {
+            if (isProjectStore)
+            {
                 Console.WriteLine("Now saving the project to be used in MSDIAL GUI...");
                 ProjectSave.SaveForLcmsProject(projectProp, rdamProperty, mspDB,
                   iupacDB, lcmsParam, analysisFiles, alignmentFile, alignmentResult,
                   txtDB, new List<PostIdentificatioinReferenceBean>());
-             
+
                 ////just for Hiroshi use
                 #region
                 //var matFolder = outputfolder + "\\Mat files";

--- a/src/MSDIAL4/MsdialConsoleAppCore/Properties/Resources.Designer.cs
+++ b/src/MSDIAL4/MsdialConsoleAppCore/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace MsdialConsoleAppCore.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -61,7 +61,7 @@ namespace MsdialConsoleAppCore.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MS-DIAL console ver. 4.70.
+        ///   Looks up a localized string similar to MS-DIAL console ver. 4.92_27012024.
         /// </summary>
         internal static string VERSION {
             get {

--- a/src/MSDIAL4/MsdialConsoleAppCore/Properties/Resources.resx
+++ b/src/MSDIAL4/MsdialConsoleAppCore/Properties/Resources.resx
@@ -118,6 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VERSION" xml:space="preserve">
-    <value>MS-DIAL console ver. 4.70</value>
+    <value>MS-DIAL console ver. 4.92_27012024</value>
+    <comment>multi cpu support for lcmsdda</comment>
   </data>
 </root>


### PR DESCRIPTION
Added support for multiple CPU threads in _lcmsdda_ mode for MsdialConsoleApp, version 4.9.27012024. E.g. use `number of threads:64` in the parameter file to run processing on 64 threads. For efficiency and not to violate job scheduler rules, the actual number of threads is limited to the maximum number of cores available.
Successfully processed both mzML and abf files in positive and negative modes on Windows and linux-x64 versions. 