### PR TITLE
Fix Null Formula Handling in MoleculeProperty

### DIFF
--- a/src/MSDIAL5/MsdialCore/Export/NistRecordBuilder.cs
+++ b/src/MSDIAL5/MsdialCore/Export/NistRecordBuilder.cs
@@ -159,7 +159,7 @@ public sealed class NistRecordBuilder
         if (molecule is null) {
             return;
         }
-        _contents["FORMULA"] = molecule.Formula.FormulaString;
+        _contents["FORMULA"] = molecule.Formula?.FormulaString ?? string.Empty;
         _contents["ONTOLOGY"] = molecule.Ontology;
         _contents["INCHIKEY"] = molecule.InChIKey;
         _contents["SMILES"] = molecule.SMILES;

--- a/tests/MSDIAL5/MsdialCoreTests/Export/NistRecordBuilderTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/NistRecordBuilderTests.cs
@@ -237,6 +237,16 @@ Num Peaks: 3
         Assert.AreEqual(expects, actual, "The exported NIST format data does not match the expected output.");
     }
 
+    [TestMethod]
+    public void SetMoleculeProperties_NullFormula()
+    {
+        var builder = new NistRecordBuilder();
+        var molecule = new MoleculeProperty(
+            name:string.Empty, formula:null, ontology:string.Empty, smiles:string.Empty, inchikey:string.Empty
+            );
+        builder.SetMoleculeProperties(molecule);
+    }
+
     class MockRefer(MoleculeMsReference reference) : IMatchResultRefer<MoleculeMsReference, MsScanMatchResult>
     {
         public string Key => "";


### PR DESCRIPTION
Fix bug in MoleculeProperty where null Formula causes errors

- Updated the SetMoleculeProperty method to automatically set the Formula to `string.Empty` if a null value is encountered.
- Added a new test case that specifically passes a null Formula to the method to verify that the issue is resolved and that no errors occur.