### PR TITLE
Enhanced File Type Support Messaging in Dataset File Settings

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/DatasetFileSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/DatasetFileSettingModel.cs
@@ -48,7 +48,7 @@ namespace CompMs.App.Msdial.Model.Setting
         }
         private AcquisitionType _selectedAcquisiolationType = AcquisitionType.DDA;
 
-        public string FileTypeInfo {
+        public string SupportingMessage {
             get => _filetypeInfo;
             set => SetProperty(ref _filetypeInfo, value);
         }
@@ -87,7 +87,7 @@ namespace CompMs.App.Msdial.Model.Setting
             }
 
             ProjectFolderPath = FileModels.AnalysisFiles.Select(f => Path.GetDirectoryName(f.AnalysisFilePath)).Distinct().SingleOrDefault() ?? string.Empty;
-            FileTypeInfo = checker.GetSupportMessage();
+            SupportingMessage = checker.GetSupportMessage();
         }
 
         public void SetSelectedAquisitionTypeToAll() {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/DatasetFileSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/DatasetFileSettingModel.cs
@@ -141,13 +141,13 @@ namespace CompMs.App.Msdial.Model.Setting
 
             public void CheckFileType(string path) {
                 var ext = Path.GetExtension(path);
-                if (ext == ".cdf") {
+                if (string.Equals(ext, ".cdf", StringComparison.CurrentCultureIgnoreCase)) {
                     ContainsNetCdf = true;
                 }
-                else if (ext == ".lcd") {
+                else if (string.Equals(ext, ".lcd", StringComparison.CurrentCultureIgnoreCase)) {
                     ContainsShimadzuLcd = true;
                 }
-                else if (ext == ".d") {
+                else if (string.Equals(ext, ".d", StringComparison.CurrentCultureIgnoreCase)) {
                     if (Directory.Exists(Path.Combine(path, "AcqData"))) {
                         ContainsAgilentD = true;
                     }

--- a/src/MSDIAL5/MsdialGuiApp/View/Setting/DatasetFileSettingView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Setting/DatasetFileSettingView.xaml
@@ -44,7 +44,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="40"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="40"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Horizontal"
@@ -237,5 +237,12 @@
 
             </DataGrid.Columns>
         </DataGrid>
+
+        <TextBox Text="{Binding SupportingMessage.Value, Mode=OneWay}"
+                 TextWrapping="WrapWithOverflow"
+                 Foreground="DeepPink"
+                 Style="{StaticResource ReadOnlyTextBox}"
+                 Margin="8,0"
+                 Grid.Row="2"/>
     </Grid>
 </UserControl>

--- a/src/MSDIAL5/MsdialGuiApp/View/Setting/DatasetFileSettingView.xaml.cs
+++ b/src/MSDIAL5/MsdialGuiApp/View/Setting/DatasetFileSettingView.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using CompMs.App.Msdial.ViewModel.Setting;
 using Microsoft.Win32;
 using Reactive.Bindings.Notifiers;
-using System;
 using System.IO;
 using System.Linq;
 using System.Windows;

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DatasetFileSettingViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DatasetFileSettingViewModel.cs
@@ -68,6 +68,10 @@ namespace CompMs.App.Msdial.ViewModel.Setting
                 .WithSubscribe(SetSelectedAquisitionTypeToAll)
                 .AddTo(Disposables);
 
+            SupportingMessage = model.ObserveProperty(m => m.FileTypeInfo)
+                .ToReadOnlyReactivePropertySlim(initialValue: string.Empty)
+                .AddTo(Disposables);
+
             ObserveHasErrors = new[]
             {
                 analysisFileHasError,
@@ -102,6 +106,8 @@ namespace CompMs.App.Msdial.ViewModel.Setting
 
         public ReactivePropertySlim<AcquisitionType> SelectedAcquisitionType { get; }
         public ReactiveCommand SetSelectedAcquisitionTypeCommand { get; }
+
+        public ReadOnlyReactivePropertySlim<string> SupportingMessage { get; }
 
         public bool IsReadOnly { get; }
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DatasetFileSettingViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DatasetFileSettingViewModel.cs
@@ -68,7 +68,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
                 .WithSubscribe(SetSelectedAquisitionTypeToAll)
                 .AddTo(Disposables);
 
-            SupportingMessage = model.ObserveProperty(m => m.FileTypeInfo)
+            SupportingMessage = model.ObserveProperty(m => m.SupportingMessage)
                 .ToReadOnlyReactivePropertySlim(initialValue: string.Empty)
                 .AddTo(Disposables);
 


### PR DESCRIPTION
#### PR Classification
New feature to enhance file type support messaging in the dataset file settings.

#### PR Summary
Introduced a mechanism to check file types and display support messages in the UI.
- `DatasetFileSettingModel`: Added `SupportingMessage` property and `FileTypeChecker` class.
- `SetFiles` method: Modified to use `FileTypeChecker` and set `SupportingMessage`.
- `DatasetFileSettingView.xaml`: Updated layout and added `TextBox` for support messages.
- `DatasetFileSettingViewModel`: Added `SupportingMessage` property as a read-only reactive property.