### PR TITLE
Replace `Zip` with `ZipInternal` across codebase

### DIFF
--- a/src/Common/ChartDrawing/Behavior/AreaSelectBehavior.cs
+++ b/src/Common/ChartDrawing/Behavior/AreaSelectBehavior.cs
@@ -253,7 +253,7 @@ namespace CompMs.Graphics.Behavior
                     }
                     adorners.RemoveAdornerAll(adorner_ => !adorner_.IsSelected);
                     adorners.AddAdorner(adorner);
-                    foreach ((var adorner_, var color) in adorners.Adorners.Zip(GetAreaColors(fe))) {
+                    foreach ((var adorner_, var color) in adorners.Adorners.ZipInternal(GetAreaColors(fe))) {
                         adorner_.ChangeColor(color);
                     }
                 }
@@ -341,7 +341,7 @@ namespace CompMs.Graphics.Behavior
             }
 
             private void RefreshColors() {
-                foreach ((var adorner, var color) in Adorners.Zip(colors)) {
+                foreach ((var adorner, var color) in Adorners.ZipInternal(colors)) {
                     adorner.ChangeColor(color);
                 }
             }

--- a/src/Common/ChartDrawing/Chart/ErrorBar.cs
+++ b/src/Common/ChartDrawing/Chart/ErrorBar.cs
@@ -89,7 +89,7 @@ namespace CompMs.Graphics.Chart
 
                 if (herrors != null) {
                     var b = haxis.TranslateToAxisValue(0d);
-                    foreach ((var herr, var item) in herrors.Zip(items)) {
+                    foreach ((var herr, var item) in herrors.ZipInternal(items)) {
                         item.HorizontalLower = item.HorizontalCenter + b - haxis.TranslateToAxisValue(herr.Item1);
                         item.HorizontalUpper = item.HorizontalCenter - b + haxis.TranslateToAxisValue(herr.Item2);
                     }
@@ -97,7 +97,7 @@ namespace CompMs.Graphics.Chart
 
                 if (verrors != null) {
                     var b = vaxis.TranslateToAxisValue(0d);
-                    foreach ((var verr, var item) in verrors.Zip(items)) {
+                    foreach ((var verr, var item) in verrors.ZipInternal(items)) {
                         item.VerticalLower = item.VerticalCenter + b - vaxis.TranslateToAxisValue(verr.Item1);
                         item.VerticalUpper = item.VerticalCenter - b + vaxis.TranslateToAxisValue(verr.Item2);
                     }

--- a/src/Common/CommonStandard/Extension/IEnumerableExtension.cs
+++ b/src/Common/CommonStandard/Extension/IEnumerableExtension.cs
@@ -21,9 +21,14 @@ namespace CompMs.Common.Extension {
             yield return value;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
-        public static IEnumerable<(T1, T2)> Zip<T1, T2>(this IEnumerable<T1> xs, IEnumerable<T2> ys) {
+#if !NET6_0_OR_GREATER
+        public static IEnumerable<(T1, T2)> ZipInternal<T1, T2>(this IEnumerable<T1> xs, IEnumerable<T2> ys) {
             return xs.Zip(ys, (x, y) => (x, y));
+        }
+#else
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static IEnumerable<(T1, T2)> ZipInternal<T1, T2>(this IEnumerable<T1> xs, IEnumerable<T2> ys) {
+            return xs.Zip(ys);
         }
 #endif
 

--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
@@ -100,7 +100,7 @@ public class PeakAligner {
         // from 40 to 80
         var counter = 0;
         ReportProgress reporter = ReportProgress.FromLength(Progress, 40.0, 40.0);
-        foreach (var (analysisFile, file_) in analysisFiles.Zip(tempFiles)) {
+        foreach (var (analysisFile, file_) in analysisFiles.ZipInternal(tempFiles)) {
             var peaks = new List<AlignmentChromPeakFeature>(spots.Count);
             foreach (var spot in spots) {
                 peaks.Add(spot.AlignedPeakProperties.FirstOrDefault(peak => peak.FileID == analysisFile.AnalysisFileId));
@@ -133,7 +133,7 @@ public class PeakAligner {
         }
         var ms1Spectra = new Ms1Spectra(spectra, Param.IonMode, analysisFile.AcquisitionType);
         var rawSpectra = new RawSpectra(spectra, Param.IonMode, analysisFile.AcquisitionType);
-        var peakInfos = peaks.Zip(spots)
+        var peakInfos = peaks.ZipInternal(spots)
             .AsParallel()
             .AsOrdered()
             .WithDegreeOfParallelism(Param.NumThreads)

--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner3D.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner3D.cs
@@ -45,7 +45,7 @@ namespace CompMs.MsdialCore.Algorithm.Alignment
             var dtRange = new ChromatogramRange(double.MinValue, double.MaxValue, ChromXType.Drift, ChromXUnit.Msec);
 
             var peakInfos = new List<ChromatogramPeakInfo>();
-            foreach ((var peak, var spot) in peaks.Zip(spots)) {
+            foreach ((var peak, var spot) in peaks.ZipInternal(spots)) {
                 var rawSpectra = rawSpectras[peak.IonMode].Value;
                 if (spot.AlignedPeakProperties.FirstOrDefault(p => p.FileID == analysisFile.AnalysisFileId).MasterPeakID < 0) {
                     Filler3d.GapFillFirst(rawSpectra, spot, analysisFile.AnalysisFileId);

--- a/src/MSDIAL5/MsdialCore/Algorithm/PeakSpottingCore.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/PeakSpottingCore.cs
@@ -774,7 +774,7 @@ namespace CompMs.MsdialCore.Algorithm {
             var minDatapoint = 3;
             // var counter = 0;
             var rawSpectra = new RawSpectra(provider.LoadMs1Spectrums(), _parameter.IonMode, type);
-            foreach ((ChromatogramPeakFeature peakFeature, IChromatogramPeakFeature peak) in chromPeakFeatures.Zip(chromPeakFeatures)) {
+            foreach ((ChromatogramPeakFeature peakFeature, IChromatogramPeakFeature peak) in chromPeakFeatures.ZipInternal(chromPeakFeatures)) {
                 //get EIC chromatogram
                 var peakWidth = peak.PeakWidth();
                 var peakWidthMargin = peakWidth * .5;

--- a/src/MSDIAL5/MsdialGuiApp/View/PeakCuration/AlignedPeakCorrectionWinLegacy.xaml.cs
+++ b/src/MSDIAL5/MsdialGuiApp/View/PeakCuration/AlignedPeakCorrectionWinLegacy.xaml.cs
@@ -70,7 +70,7 @@ namespace CompMs.App.Msdial.View.PeakCuration
                 if (peaks is null) {
                     return null;
                 }
-                var peakPropArr = files.Zip(peaks).Where(pair => pair.Item1.AnalysisFileIncluded)
+                var peakPropArr = files.ZipInternal(peaks).Where(pair => pair.Item1.AnalysisFileIncluded)
                     .Zip(chromatograms, (pair, chromatogram) => {
                         var brush = classnameToBrushes.TryGetValue(pair.Item1.AnalysisFileClass, out var b) ? b : ChartBrushes.GetChartBrush(pair.Item1.AnalysisFileId);
                         using var smoothed = chromatogram.Convert().ChromatogramSmoothing(parameter.SmoothingMethod, parameter.SmoothingLevel);

--- a/src/MSDIAL5/MsdialImmsCore/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialImmsCore/Algorithm/Ms2Dec.cs
@@ -181,7 +181,7 @@ public sealed class Ms2Dec
         var ms2ChromPeaksList = DataAccess.GetMs2ValuePeaks(provider, precursorMz, peaks.First().ID, peaks.Last().ID, productMz, parameter, type, targetCE, ChromXType.Drift, ChromXUnit.Msec);
 
         var smoothedMs2ChromPeaksList = new List<ExtractedIonChromatogram>(ms2ChromPeaksList.Count);
-        foreach (var (chromPeaks, mz) in ms2ChromPeaksList.Zip(productMz)) {
+        foreach (var (chromPeaks, mz) in ms2ChromPeaksList.ZipInternal(productMz)) {
             var sChromPeaks = new ExtractedIonChromatogram(chromPeaks, ChromXType.Drift, ChromXUnit.Msec, mz).ChromatogramSmoothing(parameter.SmoothingMethod, parameter.SmoothingLevel);
             smoothedMs2ChromPeaksList.Add(sChromPeaks);
         }

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Ms2Dec.cs
@@ -126,7 +126,7 @@ namespace CompMs.MsdialLcMsApi.Algorithm {
             List<double> productMzs = curatedSpectra.Select(x => (double)x.Mass).ToList();
             var ms2ValuePeaksList = DataAccess.GetMs2ValuePeaks(provider, precursorMz, startIndex, endIndex, productMzs, param, file.AcquisitionType, targetCE);
             var sMs2Chromatograms = new List<ExtractedIonChromatogram>();
-            foreach (var (ms2Peaks, productMz) in ms2ValuePeaksList.Zip(productMzs)) {
+            foreach (var (ms2Peaks, productMz) in ms2ValuePeaksList.ZipInternal(productMzs)) {
                 ExtractedIonChromatogram chromatogram = new ExtractedIonChromatogram(ms2Peaks, ChromXType.RT, ChromXUnit.Min, productMz).ChromatogramSmoothing(param.SmoothingMethod, param.SmoothingLevel);
                 sMs2Chromatograms.Add(chromatogram);
             }

--- a/tests/Common/CommonStandardTests/Algorithm/ChromSmoothing/SmoothingTests.cs
+++ b/tests/Common/CommonStandardTests/Algorithm/ChromSmoothing/SmoothingTests.cs
@@ -82,7 +82,7 @@ public class SmoothingTests
         Console.WriteLine($"new method: {timer.ElapsedMilliseconds}");
         timer.Reset();
 
-        foreach ((var peak1, var peak2) in expected.Zip(actual)) {
+        foreach ((var peak1, var peak2) in expected.ZipInternal(actual)) {
             Assert.AreEqual(peak1.ID, peak2.ID);
             Assert.AreEqual(peak1.ChromXs.Value, peak2.ChromXs.Value);
             Assert.AreEqual(peak1.Mass, peak2.Mass);
@@ -102,7 +102,7 @@ public class SmoothingTests
         var expected = Original_SimpleMovingAverage(chrom, 5);
         var actual = Smoothing.SimpleMovingAverage(chrom, 5);
 
-        foreach ((var peak1, var peak2) in expected.Zip(actual)) {
+        foreach ((var peak1, var peak2) in expected.ZipInternal(actual)) {
             Assert.AreEqual(peak1.ID, peak2.ID);
             Assert.AreEqual(peak1.ChromXs.Value, peak2.ChromXs.Value);
             Assert.AreEqual(peak1.Mass, peak2.Mass);
@@ -132,7 +132,7 @@ public class SmoothingTests
         Console.WriteLine($"new method: {timer.ElapsedMilliseconds}");
         timer.Reset();
 
-        foreach ((var peak1, var peak2) in expected.Zip(actual)) {
+        foreach ((var peak1, var peak2) in expected.ZipInternal(actual)) {
             Assert.AreEqual(peak1.ID, peak2.ID);
             Assert.AreEqual(peak1.ChromXs.Value, peak2.ChromXs.Value);
             Assert.AreEqual(peak1.Mass, peak2.Mass);
@@ -153,7 +153,7 @@ public class SmoothingTests
         var expected = Original_LinearWeightedMovingAverage(chrom, 5);
         var actual = Smoothing.LinearWeightedMovingAverage(chrom, 5);
 
-        foreach ((var peak1, var peak2) in expected.Zip(actual)) {
+        foreach ((var peak1, var peak2) in expected.ZipInternal(actual)) {
             Assert.AreEqual(peak1.ID, peak2.ID);
             Assert.AreEqual(peak1.ChromXs.Value, peak2.ChromXs.Value);
             Assert.AreEqual(peak1.Mass, peak2.Mass);
@@ -189,7 +189,7 @@ public class SmoothingTests
         }
 
         // Simple width ∘ Simple width equals to LinearWeighted (width * 2) except at the begins and ends width * 2.
-        foreach ((var peak1, var peak2) in expected.Zip(actual).Skip(width * 2).Take(actual.Count - width * 4)) {
+        foreach ((var peak1, var peak2) in expected.ZipInternal(actual).Skip(width * 2).Take(actual.Count - width * 4)) {
             Assert.AreEqual(peak1.ID, peak2.ID);
             Assert.AreEqual(peak1.ChromXs.Value, peak2.ChromXs.Value);
             Assert.AreEqual(peak1.Mass, peak2.Mass);

--- a/tests/Common/CommonStandardTests/Extension/IEnumerableExtensionTests.cs
+++ b/tests/Common/CommonStandardTests/Extension/IEnumerableExtensionTests.cs
@@ -171,13 +171,13 @@ namespace CompMs.Common.Extension.Tests
             var actuals = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Chunk(3);
             var expects = new List<int[]> { new[] { 1, 2, 3, }, new[] { 4, 5, 6, }, new[] { 7, 8, 9 } };
 
-            foreach (var (actual, expect) in actuals.Zip(expects)) {
+            foreach (var (actual, expect) in actuals.ZipInternal(expects)) {
                 CollectionAssert.AreEqual(expect, actual);
             }
 
             actuals = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.Chunk(4);
             expects = new List<int[]> { new[] { 1, 2, 3, 4, }, new[] { 5, 6, 7, 8, }, new[] { 9, 10, } };
-            foreach (var (actual, expect) in actuals.Zip(expects)) {
+            foreach (var (actual, expect) in actuals.ZipInternal(expects)) {
                 CollectionAssert.AreEqual(expect, actual);
             }
         }
@@ -187,7 +187,7 @@ namespace CompMs.Common.Extension.Tests
             var actuals = new List<int> { 1, 2, 3 }.Zip(new List<int> { 4, 5, 6 }, new List<int> { 7, 8, 9 });
             var expects = new List<(int, int, int)> { (1, 4, 7), (2, 5, 8), (3, 6, 9) };
 
-            foreach ((var expect, var actual) in expects.Zip(actuals)) {
+            foreach ((var expect, var actual) in expects.ZipInternal(actuals)) {
                 (var e1, var e2, var e3) = expect;
                 (var a1, var a2, var a3) = actual;
                 Assert.AreEqual(e1, a1);
@@ -212,7 +212,7 @@ namespace CompMs.Common.Extension.Tests
                 new List<int> {  5, 10, 15, 20},
             };
 
-            foreach ((var expect, var actual) in expects.Zip(actuals)) {
+            foreach ((var expect, var actual) in expects.ZipInternal(actuals)) {
                 CollectionAssert.AreEqual(expect, actual);
             }
         }

--- a/tests/Common/CommonStandardTests/Lipidomics/CeramidesSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/CeramidesSpectrumGeneratorTests.cs
@@ -97,7 +97,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -186,7 +186,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -303,7 +303,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -414,7 +414,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -519,7 +519,7 @@ namespace CompMs.Common.Lipidomics.Tests
                             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -629,7 +629,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -720,7 +720,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -808,7 +808,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/EtherPCSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/EtherPCSpectrumGeneratorTests.cs
@@ -134,7 +134,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass))) {
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass))) {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
         }
@@ -255,7 +255,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass))) {
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass))) {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
         }
@@ -382,7 +382,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -507,7 +507,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/EtherPESpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/EtherPESpectrumGeneratorTests.cs
@@ -314,7 +314,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -415,7 +415,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -516,7 +516,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -616,7 +616,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/HexCerSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/HexCerSpectrumGeneratorTests.cs
@@ -113,7 +113,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -218,7 +218,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -320,7 +320,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/LPXSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/LPXSpectrumGeneratorTests.cs
@@ -88,7 +88,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -168,7 +168,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -257,7 +257,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -338,7 +338,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -429,7 +429,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -511,7 +511,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -602,7 +602,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -691,7 +691,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -771,7 +771,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/OadSpectrumPeakGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/OadSpectrumPeakGeneratorTests.cs
@@ -61,7 +61,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected.Zip(actualList))
+            foreach ((var e, var a) in expected.ZipInternal(actualList))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }
@@ -97,7 +97,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected.Zip(actual))
+            foreach ((var e, var a) in expected.ZipInternal(actual))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }
@@ -155,7 +155,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected.Zip(actual))
+            foreach ((var e, var a) in expected.ZipInternal(actual))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }
@@ -191,7 +191,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected.Zip(actual))
+            foreach ((var e, var a) in expected.ZipInternal(actual))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }
@@ -234,7 +234,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected.Zip(actualList))
+            foreach ((var e, var a) in expected.ZipInternal(actualList))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }
@@ -281,7 +281,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected.Zip(actualList))
+            foreach ((var e, var a) in expected.ZipInternal(actualList))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }
@@ -321,7 +321,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 Console.WriteLine($"Mass {item.Mass}, Intensity {item.Intensity}, Comment {item.Comment}");
             }
 
-            foreach ((var e, var a) in expected02.Zip(actual02))
+            foreach ((var e, var a) in expected02.ZipInternal(actual02))
             {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/Omega3nChainGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/Omega3nChainGeneratorTests.cs
@@ -57,7 +57,7 @@ namespace CompMs.Common.Lipidomics.Tests
             Console.WriteLine("source: {0}", chain);
             actual.ToList().ForEach(a => Console.WriteLine(a));
             Assert.AreEqual(expected.Length, actual.Length);
-            foreach ((var e, var a) in expected.Zip(actual))
+            foreach ((var e, var a) in expected.ZipInternal(actual))
             {
                 Assert.That.AreChainsEqual(e, a);
             }
@@ -127,7 +127,7 @@ namespace CompMs.Common.Lipidomics.Tests
             Console.WriteLine("source: {0}", chain);
             actual.ToList().ForEach(a => Console.WriteLine(a));
             Assert.AreEqual(expected.Length, actual.Length);
-            foreach ((var e, var a) in expected.Zip(actual))
+            foreach ((var e, var a) in expected.ZipInternal(actual))
             {
                 Assert.That.AreChainsEqual(e, a);
             }
@@ -206,7 +206,7 @@ namespace CompMs.Common.Lipidomics.Tests
             var generator = new Omega3nChainGenerator();
             var actual = generator.Generate(chain).ToArray();
             Assert.AreEqual(expected.Length, actual.Length);
-            foreach ((var e, var a) in expected.Zip(actual))
+            foreach ((var e, var a) in expected.ZipInternal(actual))
             {
                 Assert.That.AreChainsEqual(e, a);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/OtherLipidSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/OtherLipidSpectrumGeneratorTests.cs
@@ -140,7 +140,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -276,7 +276,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -408,7 +408,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -540,7 +540,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -671,7 +671,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -795,7 +795,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -886,7 +886,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -973,7 +973,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1054,7 +1054,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1158,7 +1158,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1259,7 +1259,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1353,7 +1353,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 520.3632664521699,//Precursor  
             };
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1445,7 +1445,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 520.3632664521699,//Precursor  
             };
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1517,7 +1517,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1586,7 +1586,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1666,7 +1666,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/PCSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/PCSpectrumGeneratorTests.cs
@@ -237,7 +237,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -354,7 +354,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/PXSpectrumGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/PXSpectrumGeneratorTests.cs
@@ -142,7 +142,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -280,7 +280,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -428,7 +428,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -519,7 +519,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -603,7 +603,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -749,7 +749,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -896,7 +896,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1037,7 +1037,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1169,7 +1169,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1297,7 +1297,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }
@@ -1387,7 +1387,7 @@ namespace CompMs.Common.Lipidomics.Tests
             };
 
             scan.Spectrum.ForEach(spec => System.Console.WriteLine($"Mass {spec.Mass}, Intensity {spec.Intensity}, Comment {spec.Comment}"));
-            foreach ((var expect, var actual) in expects.Zip(scan.Spectrum.Select(spec => spec.Mass)))
+            foreach ((var expect, var actual) in expects.ZipInternal(scan.Spectrum.Select(spec => spec.Mass)))
             {
                 Assert.AreEqual(expect, actual, 0.01d);
             }

--- a/tests/Common/CommonStandardTests/Lipidomics/SpectrumPeakGeneratorTests.cs
+++ b/tests/Common/CommonStandardTests/Lipidomics/SpectrumPeakGeneratorTests.cs
@@ -25,7 +25,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 return;
             }
 
-            foreach ((var e, var a) in expected.Zip(actual)) {
+            foreach ((var e, var a) in expected.ZipInternal(actual)) {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
                 //Assert.AreEqual(e.Intensity, a.Intensity, 0.1);
             }
@@ -185,7 +185,7 @@ namespace CompMs.Common.Lipidomics.Tests
                 return;
             }
 
-            foreach ((var e, var a) in expected.Zip(actual)) {
+            foreach ((var e, var a) in expected.ZipInternal(actual)) {
                 Assert.AreEqual(e.Mass, a.Mass, 0.001);
                 //Assert.AreEqual(e.Intensity, a.Intensity, 0.1);
             }

--- a/tests/Common/CommonStandardTests/Parser/TextLibraryParserTests.cs
+++ b/tests/Common/CommonStandardTests/Parser/TextLibraryParserTests.cs
@@ -85,7 +85,7 @@ Cer 33:1;2O(d7)|Cer 18:1;2O/15:0(d7)	531.5476588	9.34	[M+H]+	HBULQAPKKLNTLT-BXLQ
             var results = references.Select(reference => reference.AdductType).ToList();
             var expected = data.Split('\n').Skip(1).Select(row => AdductIon.GetAdductIon(row.TrimEnd('\r').Split('\t')[3])).ToList();
 
-            foreach ((AdductIon a, AdductIon b) in expected.Zip(results))
+            foreach ((AdductIon a, AdductIon b) in expected.ZipInternal(results))
             {
                 Debug.WriteLine($"{a.AdductIonName}\t{b.AdductIonName}");
                 Assert.AreEqual(a.AdductIonAccurateMass, b.AdductIonAccurateMass);
@@ -127,7 +127,7 @@ Cer 33:1;2O(d7)|Cer 18:1;2O/15:0(d7)	531.5476588	9.34	[M+H]+	HBULQAPKKLNTLT-BXLQ
             });
             results.Sort((a, b) => a.Mass.CompareTo(b.Mass));
             expected.Sort((a, b) => a.Mass.CompareTo(b.Mass));
-            foreach ((Formula a, Formula b) in expected.Zip(results))
+            foreach ((Formula a, Formula b) in expected.ZipInternal(results))
             {
                 Assert.AreEqual(a.FormulaString, b.FormulaString);
                 Assert.AreEqual(a.Mass, b.Mass);
@@ -160,7 +160,7 @@ Cer 33:1;2O(d7)|Cer 18:1;2O/15:0(d7)	531.5476588	9.34	[M+H]+	HBULQAPKKLNTLT-BXLQ
             var expected = formulas.Select(formula => IsotopeCalculator.GetAccurateIsotopeProperty(formula.FormulaString, 2, iupacDb).IsotopeProfile).ToList();
             results.Sort((a, b) => a.Sum(e => e.MassDifferenceFromMonoisotopicIon).CompareTo(b.Sum(e => e.MassDifferenceFromMonoisotopicIon)));
             expected.Sort((a, b) => a.Sum(e => e.MassDifferenceFromMonoisotopicIon).CompareTo(b.Sum(e => e.MassDifferenceFromMonoisotopicIon)));
-            foreach ((List<IsotopicPeak> a, List<IsotopicPeak> b) in expected.Zip(results))
+            foreach ((List<IsotopicPeak> a, List<IsotopicPeak> b) in expected.ZipInternal(results))
             {
                 CollectionAssert.AreEqual(a.Select(peak => peak.RelativeAbundance).ToArray(), b.Select(peak => peak.RelativeAbundance).ToArray());
                 CollectionAssert.AreEqual(a.Select(peak => peak.Mass).ToArray(), b.Select(peak => peak.Mass).ToArray());

--- a/tests/Common/CommonStandardTests/Utility/SearchCollectionTest.cs
+++ b/tests/Common/CommonStandardTests/Utility/SearchCollectionTest.cs
@@ -367,7 +367,7 @@ namespace CompMs.Common.Utility.Tests
             };
             var actuals = SearchCollection.CartesianProduct(collection);
 
-            foreach ((var exp, var act) in expects.Zip(actuals)) {
+            foreach ((var exp, var act) in expects.ZipInternal(actuals)) {
                 CollectionAssert.AreEqual(exp, act);
             }
         }
@@ -388,7 +388,7 @@ namespace CompMs.Common.Utility.Tests
             ];
             var actuals = SearchCollection.CartesianProduct(collection);
 
-            foreach ((var exp, var act) in expects.Zip(actuals))
+            foreach ((var exp, var act) in expects.ZipInternal(actuals))
             {
                 CollectionAssert.AreEqual(exp, act);
             }


### PR DESCRIPTION
#### PR Classification
Code cleanup to maintain compatibility across different .NET versions and optimize performance.

#### PR Summary
Replaced the `Zip` method with a custom `ZipInternal` method across multiple files to ensure compatibility and performance optimization.
- `IEnumerableExtension.cs`: Introduced `ZipInternal` method with conditional implementation based on the target framework.
- `CompMs.Graphics.Behavior`, `CompMs.Graphics.Chart`, `CompMs.Common.Extension`, `CompMs.MsdialCore.Algorithm`, `CompMs.App.Msdial.View.PeakCuration`: Replaced `Zip` with `ZipInternal`.
- `CompMs.Common.Lipidomics.Tests`: Updated test methods to use `ZipInternal` for pairing elements from two sequences.
- `TextLibraryParserTests.cs` and `SearchCollectionTest.cs`: Replaced `Zip` with `ZipInternal` in multiple foreach loops for element comparison.
