### PR TITLE
Refactor and add null checks in spectra processing

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/Internal/PrecursorMzSelectedDataProvider.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Internal/PrecursorMzSelectedDataProvider.cs
@@ -7,18 +7,11 @@ using System.Threading.Tasks;
 
 namespace CompMs.MsdialCore.Algorithm.Internal;
 
-internal sealed class PrecursorMzSelectedDataProvider : IDataProvider
+internal sealed class PrecursorMzSelectedDataProvider(IDataProvider other, double mz, double tolerance) : IDataProvider
 {
-    private readonly IDataProvider _other;
-    private readonly double _mz;
-    private readonly double _tolerance;
-
-    public PrecursorMzSelectedDataProvider(IDataProvider other, double mz, double tolerance)
-    {
-        _other = other;
-        _mz = mz;
-        _tolerance = tolerance;
-    }
+    private readonly IDataProvider _other = other;
+    private readonly double _mz = mz;
+    private readonly double _tolerance = tolerance;
 
     public ReadOnlyCollection<RawSpectrum> LoadMs1Spectrums() => _other.LoadMs1Spectrums();
 
@@ -29,7 +22,7 @@ internal sealed class PrecursorMzSelectedDataProvider : IDataProvider
         if (level <= 1) {
             return spectra;
         }
-        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => Math.Abs(s.Precursor.SelectedIonMz - _mz) <= _tolerance).ToArray());
+        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => IsNearBy(s.Precursor, _mz, _tolerance)).ToArray());
     }
 
     public async Task<ReadOnlyCollection<RawSpectrum>> LoadMsNSpectrumsAsync(int level, CancellationToken token) {
@@ -37,16 +30,20 @@ internal sealed class PrecursorMzSelectedDataProvider : IDataProvider
         if (level <= 1) {
             return spectra;
         }
-        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => Math.Abs(s.Precursor.SelectedIonMz - _mz) <= _tolerance).ToArray());
+        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => IsNearBy(s.Precursor, _mz, _tolerance)).ToArray());
     }
 
     public ReadOnlyCollection<RawSpectrum> LoadMsSpectrums() {
         var spectra = _other.LoadMsSpectrums();
-        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => s.MsLevel <= 1 || Math.Abs(s.Precursor.SelectedIonMz - _mz) <= _tolerance).ToArray());
+        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => s.MsLevel <= 1 || IsNearBy(s.Precursor, _mz, _tolerance)).ToArray());
     }
 
     public async Task<ReadOnlyCollection<RawSpectrum>> LoadMsSpectrumsAsync(CancellationToken token) {
         var spectra = await _other.LoadMsSpectrumsAsync(token).ConfigureAwait(false);
-        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => s.MsLevel <= 1 || Math.Abs(s.Precursor.SelectedIonMz - _mz) <= _tolerance).ToArray());
+        return new ReadOnlyCollection<RawSpectrum>(spectra.Where(s => s.MsLevel <= 1 || IsNearBy(s.Precursor, _mz, _tolerance)).ToArray());
+    }
+
+    private static bool IsNearBy(RawPrecursorIon p, double mz, double tolerance) {
+        return p is not null && Math.Abs(p.SelectedIonMz - mz) <= tolerance;
     }
 }

--- a/src/MSDIAL5/MsdialCore/DataObj/DriftTimeTypedSpectra.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/DriftTimeTypedSpectra.cs
@@ -141,6 +141,7 @@ internal class DriftTimeTypedSpectra : IChromatogramTypedSpectra
         var results = new List<ValuePeak>();
         for (int i = startIndex; i < endIndex; i++) {
             if (_spectra[i].MsLevel != 2 ||
+                _spectra[i].Precursor is null ||
                 !_spectra[i].Precursor.ContainsMz(precursor.Mz, precursor.Tolerance, _acquisitionType) ||
                 _spectra[i].ScanPolarity != _polarity) {
                 continue;

--- a/src/MSDIAL5/MsdialCore/DataObj/RetentionTimeTypedSpectra.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/RetentionTimeTypedSpectra.cs
@@ -160,6 +160,7 @@ internal sealed class RetentionTimeTypedSpectra : IChromatogramTypedSpectra
         var results = new List<ValuePeak>();
         for (int i = startIndex; i < endIndex; i++) {
             if (_spectra[i].MsLevel != 2 ||
+                _spectra[i].Precursor is null ||
                 !_spectra[i].Precursor.ContainsMz(precursor.Mz, precursor.Tolerance, _acquisitionType) ||
                 _spectra[i].ScanPolarity != _polarity) {
                 continue;


### PR DESCRIPTION
Refactor and add null checks in spectra processing

Refactored `PrecursorMzSelectedDataProvider` to use a constructor initializer and introduced a private static method `IsNearBy` to encapsulate m/z tolerance logic. Added null checks for the `Precursor` property in `DriftTimeTypedSpectra` and `RetentionTimeTypedSpectra` to prevent null reference exceptions.