### PR TITLE
Fixed Retention Index Calculation Issues and Added Validation Checks

### DIFF
--- a/src/MSDIAL5/MsdialCore/Utility/DataObjConverter.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataObjConverter.cs
@@ -162,7 +162,7 @@ namespace CompMs.MsdialCore.Utility
             spot.TimesCenter = new ChromXs() {
                 MainType = chromXType,
                 RT = new RetentionTime(alignedPeaks.Average(peak => peak.ChromXsTop.RT.Value), representative.ChromXsTop.RT.Unit),
-                RI = new RetentionIndex(alignedPeaks.Average(peak => peak.ChromXsTop.RI.Value), representative.ChromXsTop.RI.Unit),
+                RI = new RetentionIndex(alignedPeaks.Select(peak => peak.ChromXsTop.RI.Value).Where(v => v >= 0).DefaultIfEmpty().Average(), representative.ChromXsTop.RI.Unit),
                 Mz = new MzValue(spot.MassCenter, representative.ChromXsTop.Mz.Unit),
                 Drift = new DriftTime(alignedPeaks.Average(peak => peak.ChromXsTop.Drift.Value), representative.ChromXsTop.Drift.Unit),
             };

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/GcmsIdentificationSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/GcmsIdentificationSettingModel.cs
@@ -36,6 +36,10 @@ namespace CompMs.App.Msdial.Model.Setting
         private string _dictionaryPath = string.Empty;
 
         public List<RiDictionaryError> Validate(RiCompoundType compoundType) {
+            if (_dictionaryInfo.RiDictionary.Any()) {
+                return [];
+            }
+
             var result = new List<RiDictionaryError>();
             if (!System.IO.File.Exists(DictionaryPath)) {
                 result.Add(RiDictionaryError.FileNotFound(DictionaryPath));
@@ -54,9 +58,11 @@ namespace CompMs.App.Msdial.Model.Setting
         }
 
         public void Commit() {
-            var dictionary = RiDictionaryInfo.FromDictionaryFile(DictionaryPath);
-            _dictionaryInfo.DictionaryFilePath = dictionary.DictionaryFilePath;
-            _dictionaryInfo.RiDictionary = dictionary.RiDictionary;
+            if (!string.IsNullOrWhiteSpace(DictionaryPath)) {
+                var dictionary = RiDictionaryInfo.FromDictionaryFile(DictionaryPath);
+                _dictionaryInfo.DictionaryFilePath = dictionary.DictionaryFilePath;
+                _dictionaryInfo.RiDictionary = dictionary.RiDictionary;
+            }
         }
 
         public class RiDictionaryError {


### PR DESCRIPTION
#### PR Classification
Bug fix and enhancement to improve retention index (RI) calculations and validation.

#### PR Summary
This pull request addresses issues with retention index (RI) calculations and adds validation checks.
- `DataObjConverter.cs`: Modified RI calculation for `TimesCenter` to exclude negative values before averaging.
- `GcmsGapFiller.cs`: Added `_fileIdToHandler` dictionary for RI conversions and updated `GetCenter` method to use it.
- `GcmsIdentificationSettingModel.cs`: Added validation to ensure `_dictionaryInfo.RiDictionary` is not empty and updated `Commit` method to check `DictionaryPath` before loading the dictionary file.
