### PR TITLE
Add net48 to TargetFrameworks to avoid using netstandard version of Accord

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/PeakSpottingCore.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/PeakSpottingCore.cs
@@ -1,5 +1,4 @@
-﻿using Accord.Diagnostics;
-using CompMs.Common.Algorithm.PeakPick;
+﻿using CompMs.Common.Algorithm.PeakPick;
 using CompMs.Common.Components;
 using CompMs.Common.DataObj;
 using CompMs.Common.Enum;

--- a/src/MSDIAL5/MsdialCore/MsdialCore.csproj
+++ b/src/MSDIAL5/MsdialCore/MsdialCore.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Accord" Version="3.8.0" />
     <PackageReference Include="Accord.Math" Version="3.8.0" />
     <PackageReference Include="Accord.Statistics" Version="3.8.0" />
-	  <PackageReference Include="RawDataHandler" Version="1.2.*" Condition="'$(Configuration)'=='Release'" />
+	  <PackageReference Include="RawDataHandler" Version="1.2.9180.705" Condition="'$(Configuration)'=='Release'" />
 	  <PackageReference Include="RawDataHandler" Version="1.2.*-*" Condition="'$(Configuration)'=='Debug'" />
 	  <PackageReference Include="RawDataHandler-Vendor-UnSupported" Version="1.2.*-*" Condition="'$(Configuration)'=='Debug vendor unsupported'" />
 	  <PackageReference Include="RawDataHandler-Vendor-UnSupported" Version="1.2.*" Condition="'$(Configuration)'=='Release vendor unsupported'" />

--- a/src/MSDIAL5/MsdialDimsCore/MsdialDimsCore.csproj
+++ b/src/MSDIAL5/MsdialDimsCore/MsdialDimsCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialDimsCore</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/src/MSDIAL5/MsdialGcMsApi/MsdialGcMsApi.csproj
+++ b/src/MSDIAL5/MsdialGcMsApi/MsdialGcMsApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialGcMsApi</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/src/MSDIAL5/MsdialImmsCore/MsdialImmsCore.csproj
+++ b/src/MSDIAL5/MsdialImmsCore/MsdialImmsCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialImmsCore</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/src/MSDIAL5/MsdialImmsImagingCore/MsdialImmsImagingCore.csproj
+++ b/src/MSDIAL5/MsdialImmsImagingCore/MsdialImmsImagingCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialImmsImagingCore</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/src/MSDIAL5/MsdialIntegrate/MsdialIntegrate.csproj
+++ b/src/MSDIAL5/MsdialIntegrate/MsdialIntegrate.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialIntegrate</RootNamespace>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/src/MSDIAL5/MsdialLcImMsApi/MsdialLcImMsApi.csproj
+++ b/src/MSDIAL5/MsdialLcImMsApi/MsdialLcImMsApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialLcImMsApi</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>

--- a/src/MSDIAL5/MsdialLcMsApi/MsdialLcMsApi.csproj
+++ b/src/MSDIAL5/MsdialLcMsApi/MsdialLcMsApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
     <RootNamespace>CompMs.MsdialLcMsApi</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Add net48 to TargetFrameworks to avoid using netstandard version of Accord

To address the issue in Accord (https://github.com/accord-net/framework/issues/1426),
added net48 to the TargetFrameworks of each project. This ensures that the netstandard
version of Accord is not used.