### PR TITLE
Change Export Executability Property to ReactivePropertySlim in Proteomics

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Export/ProteinGroupExportViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Export/ProteinGroupExportViewModel.cs
@@ -10,7 +10,7 @@ namespace CompMs.App.Msdial.ViewModel.Export
     {
         public ProteinGroupExportViewModel(ProteinGroupExportModel model) {
             IsSelected = model.ToReactivePropertySlimAsSynchronized(m => m.IsSelected).AddTo(Disposables);
-            CanExport = Observable.Return(true).ToReadOnlyReactivePropertySlim().AddTo(Disposables);
+            CanExport = new ReactivePropertySlim<bool>(initialValue: true).AddTo(Disposables);
         }
 
         public ReactivePropertySlim<bool> IsSelected { get; }


### PR DESCRIPTION
Change Export Executability Property to ReactivePropertySlim in Proteomics

Replaced ReadOnlyReactivePropertySlim with ReactivePropertySlim for controlling export executability in Proteomics. This change ensures the initial state is correctly notified upon subscription, addressing cases where ReadOnlyReactivePropertySlim may not emit the initial value.