### PR TITLE
Code improvement and bug fix.

### DIFF
--- a/src/MSDIAL5/MsdialCore/DataObj/MsdialDataStorage.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/MsdialDataStorage.cs
@@ -63,10 +63,25 @@ namespace CompMs.MsdialCore.DataObj
 
             using (var stream = await streamManager.Create(MsdialSerializer.Combine(prefix, projectTitle)).ConfigureAwait(false)) {
                 var mspList = MspDB;
-                MspDB = new List<MoleculeMsReference>();
+                MspDB = [];
                 foreach (var file in AnalysisFiles) file.RetentionTimeCorrectionBean.ClearCache();
+                List<List<ChromatogramPeak>>[] tmp = new List<List<ChromatogramPeak>>[AnalysisFiles.Count];
+                for (int i = 0; i < AnalysisFiles.Count; i++) {
+                    var f = AnalysisFiles[i];
+                    tmp[i] = f.RetentionTimeCorrectionBean.StandardList.Select(s => s.Chromatogram).ToList();
+                    foreach (var s in f.RetentionTimeCorrectionBean.StandardList) {
+                        s.Chromatogram = null;
+                    }
+                }
+
                 SaveMsdialDataStorageCore(stream);
                 MspDB = mspList;
+                for (int i = 0; i < AnalysisFiles.Count; i++) {
+                    var f = AnalysisFiles[i];
+                    for (int j = 0; j < f.RetentionTimeCorrectionBean.StandardList.Count; j++) {
+                        f.RetentionTimeCorrectionBean.StandardList[j].Chromatogram = tmp[i][j];
+                    }
+                }
             }
         }
 

--- a/src/MSDIAL5/MsdialCore/DataObj/ProjectDataStorage.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/ProjectDataStorage.cs
@@ -190,7 +190,7 @@ namespace CompMs.MsdialCore.DataObj
             }
             foreach (var file in storage.AnalysisFiles) {
                 var rtbean = file.RetentionTimeCorrectionBean;
-                if (!rtbean.OriginalRt.IsEmptyOrNull()) {
+                if (rtbean.IsLoaded) {
                     RetentionTimeCorrectionMethod.SaveRetentionCorrectionResult(rtbean.RetentionTimeCorrectionResultFilePath, rtbean.OriginalRt, rtbean.RtDiff, rtbean.PredictedRt);
                 }
             }

--- a/src/MSDIAL5/MsdialCore/DataObj/RetentionTimeCorrectionBean.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/RetentionTimeCorrectionBean.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Schema;
-using Accord.Statistics.Models.Fields.Learning;
-using CompMs.Common.Components;
+﻿using CompMs.Common.Components;
 using CompMs.Common.Extension;
 using CompMs.Common.Interfaces;
 using CompMs.Common.Utility;
 using CompMs.MsdialCore.Algorithm;
-using CompMs.MsdialCore.Enum;
 using MessagePack;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
-namespace CompMs.MsdialCore.DataObj {
+namespace CompMs.MsdialCore.DataObj
+{
     public enum InterpolationMethod { Linear }
     public enum ExtrapolationMethodBegin { UserSetting, FirstPoint, LinearExtrapolation }
     public enum ExtrapolationMethodEnd { LastPoint, LinearExtrapolation }
@@ -24,8 +22,20 @@ namespace CompMs.MsdialCore.DataObj {
     [MessagePackObject]
     public class RetentionTimeCorrectionBean
     {
+        /// <summary>
+        /// This property is intended for MessagePack serialization only.
+        /// Do not use this property directly; instead, use <see cref="OriginalRt"/>.
+        /// 
+        /// This property exists solely for ensuring compatibility with older data.
+        /// </summary>
         [Key(0)]
-        //public List<double> OriginalRt { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<double> OriginalRtForSerialization {
+            get => originalRt;
+            set => originalRt = value;
+        }
+
+        [IgnoreMember]
         public List<double> OriginalRt { 
             get {
                 if (originalRt.IsEmptyOrNull()) {
@@ -42,8 +52,21 @@ namespace CompMs.MsdialCore.DataObj {
             } 
         }
         private List<double> originalRt;
+
+        /// <summary>
+        /// This property is intended for MessagePack serialization only.
+        /// Do not use this property directly; instead, use <see cref="RtDiff"/>.
+        /// 
+        /// This property exists solely for ensuring compatibility with older data.
+        /// </summary>
         [Key(1)]
-        //public List<double> RtDiff { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<double> RtDiffForSerialization {
+            get => rtDiff;
+            set => rtDiff = value;
+        }
+
+        [IgnoreMember]
         public List<double> RtDiff { 
             get {
                 if (rtDiff.IsEmptyOrNull()) {
@@ -59,8 +82,21 @@ namespace CompMs.MsdialCore.DataObj {
             } 
         }
         private List<double> rtDiff;
+
+        /// <summary>
+        /// This property is intended for MessagePack serialization only.
+        /// Do not use this property directly; instead, use <see cref="PredictedRt"/>.
+        /// 
+        /// This property exists solely for ensuring compatibility with older data.
+        /// </summary>
         [Key(2)]
-        //public List<double> PredictedRt { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<double> PredictedRtForSerialization {
+            get => predictedRt;
+            set => predictedRt = value;
+        }
+
+        [IgnoreMember]
         public List<double> PredictedRt {
             get {
                 if (predictedRt.IsEmptyOrNull()) {
@@ -76,6 +112,7 @@ namespace CompMs.MsdialCore.DataObj {
             }
         }
         private List<double> predictedRt;
+
         [Key(3)]
         public List<StandardPair> StandardList { get; set; } = new List<StandardPair>();
         [Key(4)]
@@ -83,7 +120,9 @@ namespace CompMs.MsdialCore.DataObj {
         [Key(5)]
         public string RetentionTimeCorrectionResultFilePath { get; set; } = string.Empty; // *.rtc
 
+        [SerializationConstructor]
         public RetentionTimeCorrectionBean() { }
+
         public RetentionTimeCorrectionBean(string retentionTimeCorrectionResultFilePath) {
             RetentionTimeCorrectionResultFilePath = retentionTimeCorrectionResultFilePath;
         }
@@ -91,13 +130,6 @@ namespace CompMs.MsdialCore.DataObj {
         public RetentionTimeCorrectionBean(string retentionTimeCorrectionResultFilePath, List<double> originalRt) {
             RetentionTimeCorrectionResultFilePath = retentionTimeCorrectionResultFilePath;
             this.originalRt = originalRt;
-        }
-
-        [SerializationConstructor]
-        public RetentionTimeCorrectionBean(List<double> OriginalRt, List<double> RtDiff, List<double> PredictedRt) {
-            this.originalRt = OriginalRt;
-            this.rtDiff = RtDiff;
-            this.predictedRt = PredictedRt;
         }
 
         public void ClearCache() {

--- a/src/MSDIAL5/MsdialCore/DataObj/RetentionTimeCorrectionBean.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/RetentionTimeCorrectionBean.cs
@@ -120,6 +120,9 @@ namespace CompMs.MsdialCore.DataObj
         [Key(5)]
         public string RetentionTimeCorrectionResultFilePath { get; set; } = string.Empty; // *.rtc
 
+        [IgnoreMember]
+        public bool IsLoaded => originalRt is not null;
+
         [SerializationConstructor]
         public RetentionTimeCorrectionBean() { }
 


### PR DESCRIPTION
This pull request improves data storage handling and fixes a condition check for retention correction results.
- `MsdialDataStorage.cs`: Initialize `MspDB` as an empty array and manage temporary storage for `Chromatogram` properties.
- `ProjectDataStorage.cs`: Update condition for saving retention correction results to check `rtbean.IsLoaded`.
- `RetentionTimeCorrectionBean.cs`: Add serialization properties, `IsLoaded` property, and adjust `SerializationConstructor` usage.
