### PR TITLE
Updated Alignment Chromatogram View to Use Class-Based Colors

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/AlignmentEicModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/AlignmentEicModel.cs
@@ -21,6 +21,7 @@ namespace CompMs.App.Msdial.Model.Chart
             IObservable<AlignedChromatograms?> spotChromatograms,
             List<AnalysisFileBean> analysisFiles,
             ParameterBase parameter,
+            FilePropertiesModel filePropertiesModel,
             Func<PeakItem, double> horizontalSelector,
             Func<PeakItem, double> verticalSelector) {
 
@@ -70,7 +71,7 @@ namespace CompMs.App.Msdial.Model.Chart
                 }.CombineLatestValuesAreAllTrue().StartWith(false), Observable.Return(false))
                 .Switch().ToReactiveProperty().AddTo(Disposables);
 
-            SampleTableViewerInAlignmentModelLegacy = new SampleTableViewerInAlignmentModelLegacy(spotChromatograms, analysisFiles, parameter).AddTo(Disposables);
+            SampleTableViewerInAlignmentModelLegacy = new SampleTableViewerInAlignmentModelLegacy(spotChromatograms, analysisFiles, parameter, filePropertiesModel).AddTo(Disposables);
             AlignedChromatogramModificationModelLegacy = new AlignedChromatogramModificationModelLegacy(spotChromatograms, analysisFiles, parameter).AddTo(Disposables);
         }
 
@@ -92,6 +93,7 @@ namespace CompMs.App.Msdial.Model.Chart
             AlignmentEicLoader loader,
             List<AnalysisFileBean> AnalysisFiles,
             ParameterBase Param,
+            FilePropertiesModel filePropertiesModel,
             Func<PeakItem, double> horizontalSelector,
             Func<PeakItem, double> verticalSelector) {
 
@@ -99,9 +101,9 @@ namespace CompMs.App.Msdial.Model.Chart
                 source.DefaultIfNull(s => new AlignedChromatograms(s, loader.LoadEicAsObservable(s))),
                 AnalysisFiles,
                 Param,
+                filePropertiesModel,
                 horizontalSelector,
-                verticalSelector
-            );
+                verticalSelector);
         }
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/AlignmentEicModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/AlignmentEicModel.cs
@@ -72,7 +72,7 @@ namespace CompMs.App.Msdial.Model.Chart
                 .Switch().ToReactiveProperty().AddTo(Disposables);
 
             SampleTableViewerInAlignmentModelLegacy = new SampleTableViewerInAlignmentModelLegacy(spotChromatograms, analysisFiles, parameter, filePropertiesModel).AddTo(Disposables);
-            AlignedChromatogramModificationModelLegacy = new AlignedChromatogramModificationModelLegacy(spotChromatograms, analysisFiles, parameter).AddTo(Disposables);
+            AlignedChromatogramModificationModelLegacy = new AlignedChromatogramModificationModelLegacy(spotChromatograms, analysisFiles, parameter, filePropertiesModel).AddTo(Disposables);
         }
 
         public IObservable<bool> CanShow { get; }

--- a/src/MSDIAL5/MsdialGuiApp/Model/Dims/DimsAlignmentModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Dims/DimsAlignmentModel.cs
@@ -172,7 +172,9 @@ namespace CompMs.App.Msdial.Model.Dims
             var eicLoader = alignmentFileModel.CreateEicLoader(CHROMATOGRAM_SPOT_SERIALIZER, fileCollection, projectBaseParameter).AddTo(Disposables);
             AlignmentEicModel = AlignmentEicModel.Create(
                 target, eicLoader,
-                files, parameter,
+                files,
+                parameter,
+                projectBaseParameter,
                 spot => spot.Time,
                 spot => spot.Intensity).AddTo(Disposables);
             AlignmentEicModel.Elements.GraphTitle = "TIC, EIC or BPC chromatograms";

--- a/src/MSDIAL5/MsdialGuiApp/Model/Gcms/GcmsAlignmentModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Gcms/GcmsAlignmentModel.cs
@@ -185,7 +185,9 @@ namespace CompMs.App.Msdial.Model.Gcms
             AlignmentEicModel = AlignmentEicModel.Create(
                 target,
                 alignmentFileBean.CreateEicLoader(chromatogramSpotSerializer, fileCollection, projectBaseParameter).AddTo(Disposables),
-                files, parameter,
+                files,
+                parameter,
+                projectBaseParameter,
                 peak => peak.Time,
                 peak => peak.Intensity).AddTo(Disposables);
             AlignmentEicModel.Elements.GraphTitle = "EIC";

--- a/src/MSDIAL5/MsdialGuiApp/Model/Imms/ImmsAlignmentModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Imms/ImmsAlignmentModel.cs
@@ -158,7 +158,10 @@ namespace CompMs.App.Msdial.Model.Imms
             var fileIdToFileName = files.ToDictionary(file => file.AnalysisFileId, file => file.AnalysisFileName);
             var eicLoader = alignmentFileModel.CreateEicLoader(CHROMATOGRAM_SPOT_SERIALIZER, fileCollection, projectBaseParameter).AddTo(Disposables);
             AlignmentEicModel = AlignmentEicModel.Create(
-                Target, eicLoader, files, parameter,
+                Target, eicLoader,
+                files,
+                parameter,
+                projectBaseParameter,
                 peak => peak.Time,
                 peak => peak.Intensity).AddTo(Disposables);
             AlignmentEicModel.Elements.GraphTitle = "TIC, EIC, or BPC chromatograms";

--- a/src/MSDIAL5/MsdialGuiApp/Model/Lcimms/LcimmsAlignmentModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Lcimms/LcimmsAlignmentModel.cs
@@ -182,7 +182,11 @@ namespace CompMs.App.Msdial.Model.Lcimms
             var fileIdToFileName = files.ToDictionary(file => file.AnalysisFileId, file => file.AnalysisFileName);
             var eicLoader = alignmentFileBean.CreateEicLoader(RT_CHROMATOGRAM_SPOT_SERIALIZER, fileCollection, projectBaseParameter).AddTo(Disposables);
             RtAlignmentEicModel = AlignmentEicModel.Create(
-                accumulatedTarget, eicLoader, files, parameter,
+                accumulatedTarget,
+                eicLoader,
+                files,
+                parameter,
+                projectBaseParameter,
                 peak => peak.Time,
                 peak => peak.Intensity).AddTo(Disposables);
             RtAlignmentEicModel.Elements.GraphTitle = "TIC, EIC, or BPC chromatograms";
@@ -208,7 +212,11 @@ namespace CompMs.App.Msdial.Model.Lcimms
                 .AddTo(Disposables);
             var dtEicLoader = alignmentFileBean.CreateEicLoader(DRIFT_CHROMATOGRAM_SPOT_SERIALIZER, fileCollection, projectBaseParameter).AddTo(Disposables);
             DtAlignmentEicModel = AlignmentEicModel.Create(
-                target, dtEicLoader, files, parameter,
+                target,
+                dtEicLoader,
+                files,
+                parameter,
+                projectBaseParameter,
                 peak => peak.Time,
                 peak => peak.Intensity).AddTo(Disposables);
             DtAlignmentEicModel.Elements.GraphTitle = "TIC, EIC, or BPC chromatograms";

--- a/src/MSDIAL5/MsdialGuiApp/Model/Lcms/LcmsAlignmentModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Lcms/LcmsAlignmentModel.cs
@@ -198,7 +198,9 @@ namespace CompMs.App.Msdial.Model.Lcms
             AlignmentEicModel = AlignmentEicModel.Create(
                 Target,
                 alignmentFileBean.CreateEicLoader(CHROMATOGRAM_SPOT_SERIALIZER, fileCollection, projectBaseParameter).AddTo(Disposables),
-                files, parameter,
+                files,
+                parameter,
+                projectBaseParameter,
                 peak => peak.Time,
                 peak => peak.Intensity).AddTo(Disposables);
             AlignmentEicModel.Elements.GraphTitle = "TIC, EIC, or BPC chromatograms";

--- a/src/MSDIAL5/MsdialGuiApp/View/PeakCuration/AlignedPeakCorrectionWinLegacy.xaml.cs
+++ b/src/MSDIAL5/MsdialGuiApp/View/PeakCuration/AlignedPeakCorrectionWinLegacy.xaml.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Windows;
-using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace CompMs.App.Msdial.View.PeakCuration
 {
@@ -43,7 +43,7 @@ namespace CompMs.App.Msdial.View.PeakCuration
         public List<AnalysisFileBean> Files { get; }
         public ReadOnlyReactivePropertySlim<PeakPropertiesLegacy?> ObservablePeakProperties { get; }
 
-        public AlignedChromatogramModificationModelLegacy(IObservable<AlignedChromatograms?> spotChromatograms, List<AnalysisFileBean> files, ParameterBase parameter) {
+        public AlignedChromatogramModificationModelLegacy(IObservable<AlignedChromatograms?> spotChromatograms, List<AnalysisFileBean> files, ParameterBase parameter, FilePropertiesModel filePropertiesModel) {
             if (files is null) {
                 throw new ArgumentNullException(nameof(files));
             }
@@ -51,7 +51,7 @@ namespace CompMs.App.Msdial.View.PeakCuration
             IsRI = spotChromatograms.Select(s => s?.Spot.ChromXType == ChromXType.RI).ToReactiveProperty().AddTo(Disposables);
             IsDrift = spotChromatograms.Select(s => s?.Spot.ChromXType == ChromXType.Drift).ToReactiveProperty().AddTo(Disposables);
             Files = files;
-            ObservablePeakProperties = LoadPeakProperty(spotChromatograms, files, parameter).ToReadOnlyReactivePropertySlim().AddTo(Disposables);
+            ObservablePeakProperties = LoadPeakProperty(spotChromatograms, files, parameter, filePropertiesModel).ToReadOnlyReactivePropertySlim().AddTo(Disposables);
         }
 
         public void UpdatePeakInfo() {
@@ -62,27 +62,38 @@ namespace CompMs.App.Msdial.View.PeakCuration
             ObservablePeakProperties.Value?.ClearRtAlignment();
         }
        
-        public static IObservable<PeakPropertiesLegacy?> LoadPeakProperty(IObservable<AlignedChromatograms?> spotChromatograms, List<AnalysisFileBean> files, ParameterBase parameter) {
+        public static IObservable<PeakPropertiesLegacy?> LoadPeakProperty(IObservable<AlignedChromatograms?> spotChromatograms, List<AnalysisFileBean> files, ParameterBase parameter, FilePropertiesModel fileProeprtiesModel) {
             var classnameToBytes = parameter.ClassnameToColorBytes;
             var classnameToBrushes = ChartBrushes.ConvertToSolidBrushDictionary(classnameToBytes);
             var handlers = (parameter as MsdialGcmsParameter)?.GetRIHandlers();
             return spotChromatograms.DefaultIfNull(s => s.Chromatograms.CombineLatest(s.Spot.AlignedPeakPropertiesModelProperty, (chromatograms, peaks) => {
                 if (peaks is null) {
-                    return null;
+                    return Observable.Return<PeakPropertiesLegacy?>(null);
                 }
+                var cls2clr = fileProeprtiesModel.ClassProperties.ToDictionary(p => p.Name, p => p.ObserveProperty(p_ => p_.Color));
                 var peakPropArr = files.ZipInternal(peaks).Where(pair => pair.Item1.AnalysisFileIncluded)
                     .Zip(chromatograms, (pair, chromatogram) => {
-                        var brush = classnameToBrushes.TryGetValue(pair.Item1.AnalysisFileClass, out var b) ? b : ChartBrushes.GetChartBrush(pair.Item1.AnalysisFileId);
+                        var brush = Observable.Return(ChartBrushes.GetChartBrush(pair.Item1.AnalysisFileId));
+                        if (cls2clr.TryGetValue(pair.Item1.AnalysisFileClass, out var c)) {
+                            brush = c.Select(c_ => {
+                                var b = new SolidColorBrush(c_);
+                                b.Freeze();
+                                return b;
+                            });
+                        }
                         using var smoothed = chromatogram.Convert().ChromatogramSmoothing(parameter.SmoothingMethod, parameter.SmoothingLevel);
                         var handler = (handlers?.TryGetValue(pair.Item1.AnalysisFileId, out var h) ?? false) ? h : null;
-                        var peakProp = new PeakPropertyLegacy(pair.Item2, brush, smoothed.AsPeakArray(), handler);
                         var offset = pair.Item2.ChromXsTop.Value - s.Spot.TimesCenter;
-                        peakProp.SetAlignOffSet(offset);
-                        peakProp.AverageRt = s.Spot.TimesCenter;
-                        return peakProp;
-                    }).ToArray();
-                return new PeakPropertiesLegacy(s.Spot, peakPropArr);
-            }).Prepend(null), Observable.Return<PeakPropertiesLegacy?>(null)).Switch();
+                        var speaks = smoothed.AsPeakArray();
+                        return brush.Select(b => {
+                            var peakProp = new PeakPropertyLegacy(pair.Item2, b, speaks, handler);
+                            peakProp.SetAlignOffSet(offset);
+                            peakProp.AverageRt = s.Spot.TimesCenter;
+                            return peakProp;
+                        });
+                    }).CombineLatest();
+                return peakPropArr.Select(arr => new PeakPropertiesLegacy(s.Spot, arr.ToArray()));
+            }).Switch().Prepend(null), Observable.Return<PeakPropertiesLegacy?>(null)).Switch();
         }
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/View/PeakCuration/AlignedPeakCorrectionWinLegacy.xaml.cs
+++ b/src/MSDIAL5/MsdialGuiApp/View/PeakCuration/AlignedPeakCorrectionWinLegacy.xaml.cs
@@ -62,7 +62,7 @@ namespace CompMs.App.Msdial.View.PeakCuration
             ObservablePeakProperties.Value?.ClearRtAlignment();
         }
        
-        public static IObservable<PeakPropertiesLegacy?> LoadPeakProperty(IObservable<AlignedChromatograms?> spotChromatograms, List<AnalysisFileBean> files, ParameterBase parameter, FilePropertiesModel fileProeprtiesModel) {
+        public static IObservable<PeakPropertiesLegacy?> LoadPeakProperty(IObservable<AlignedChromatograms?> spotChromatograms, List<AnalysisFileBean> files, ParameterBase parameter, FilePropertiesModel filePropertiesModel) {
             var classnameToBytes = parameter.ClassnameToColorBytes;
             var classnameToBrushes = ChartBrushes.ConvertToSolidBrushDictionary(classnameToBytes);
             var handlers = (parameter as MsdialGcmsParameter)?.GetRIHandlers();
@@ -70,7 +70,7 @@ namespace CompMs.App.Msdial.View.PeakCuration
                 if (peaks is null) {
                     return Observable.Return<PeakPropertiesLegacy?>(null);
                 }
-                var cls2clr = fileProeprtiesModel.ClassProperties.ToDictionary(p => p.Name, p => p.ObserveProperty(p_ => p_.Color));
+                var cls2clr = filePropertiesModel.ClassProperties.ToDictionary(p => p.Name, p => p.ObserveProperty(p_ => p_.Color));
                 var peakPropArr = files.ZipInternal(peaks).Where(pair => pair.Item1.AnalysisFileIncluded)
                     .Zip(chromatograms, (pair, chromatogram) => {
                         var brush = Observable.Return(ChartBrushes.GetChartBrush(pair.Item1.AnalysisFileId));


### PR DESCRIPTION
#### PR Classification
API change to enhance handling of file properties for color and brush mappings.

#### PR Summary
Added `FilePropertiesModel filePropertiesModel` parameter to constructors and methods to improve dynamic and reactive management of file properties.
- `AlignmentEicModel` constructor and `Create` method updated to include `filePropertiesModel`.
- Updated instantiation in `SampleTableViewerInAlignmentModelLegacy` and `AlignedChromatogramModificationModelLegacy` to pass `filePropertiesModel`.
- Similar updates in `DimsAlignmentModel.cs`, `GcmsAlignmentModel.cs`, `ImmsAlignmentModel.cs`, `LcimmsAlignmentModel.cs`, `LcmsAlignmentModel.cs`.
- `AlignedPeakCorrectionWinLegacy.xaml.cs` updated to include `filePropertiesModel` in constructor and `LoadPeakProperty` method.
- Removed unused `using System.Windows.Controls;` directive and added `using System.Windows.Media;` in `AlignedPeakCorrectionWinLegacy.xaml.cs`.
