### PR TITLE
Added Option to Perform Alignment Using Only Ref. Matched Peaks

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/IPeakJoiner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/IPeakJoiner.cs
@@ -1,12 +1,9 @@
 ﻿using CompMs.MsdialCore.DataObj;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
-namespace CompMs.MsdialCore.Algorithm.Alignment
+namespace CompMs.MsdialCore.Algorithm.Alignment;
+
+public interface IPeakJoiner
 {
-    public interface IPeakJoiner
-    {
-        List<AlignmentSpotProperty> Join(IReadOnlyList<AnalysisFileBean> asnalysisFiles, int referenceId, DataAccessor accessor);
-    }
+    List<AlignmentSpotProperty> Join(IReadOnlyList<AnalysisFileBean> asnalysisFiles, int referenceId, DataAccessor accessor);
 }

--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
@@ -34,7 +34,6 @@ public class PeakAligner {
         Refiner = factory.CreateAlignmentRefiner();
         Param = factory.Parameter;
         Progress = progress;
-            
     }
 
     public AlignmentResultContainer Alignment(

--- a/src/MSDIAL5/MsdialCore/Algorithm/DataAccessor.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/DataAccessor.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace CompMs.MsdialCore.Algorithm
 {
-    public abstract class DataAccessor {
+    public abstract class DataAccessor : IFeatureAccessor<IMSScanProperty> {
         public abstract List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile);
         public abstract ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance);
     }

--- a/src/MSDIAL5/MsdialCore/Algorithm/IFeatureAccessor.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/IFeatureAccessor.cs
@@ -1,0 +1,10 @@
+﻿using CompMs.Common.DataObj;
+using CompMs.MsdialCore.DataObj;
+using System.Collections.Generic;
+
+namespace CompMs.MsdialCore.Algorithm;
+
+public interface IFeatureAccessor<TScan> {
+    List<TScan> GetMSScanProperties(AnalysisFileBean analysisFile);
+    ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance);
+}

--- a/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
+++ b/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
@@ -1156,6 +1156,8 @@ namespace CompMs.MsdialCore.Parameter
         public float AlignmentScoreCutOff { get; set; } = 50;
         [Key(8)]
         public bool TogetherWithAlignment { get; set; } = true;
+        [Key(9)]
+        public bool UseRefMatchedPeaksOnly { get; set; } = false;
     }
 
     [MessagePackObject]
@@ -1250,7 +1252,6 @@ namespace CompMs.MsdialCore.Parameter
         public bool IsKeepSuggestedMetaboliteFeatures { get; set; } = false;
         [Key(11)]
         public float FoldChangeForBlankFiltering { get; set; } = 5;
-
     }
 
     [MessagePackObject]

--- a/src/MSDIAL5/MsdialGcMsApi/Algorithm/Alignment/GcmsAlignmentProcessFactory.cs
+++ b/src/MSDIAL5/MsdialGcMsApi/Algorithm/Alignment/GcmsAlignmentProcessFactory.cs
@@ -56,7 +56,9 @@ public class GcmsAlignmentProcessFactory : AlignmentProcessFactory
                     GcmsParameter.MspSearchParam,
                     GcmsParameter,
                     _evaluator,
-                    _refer);
+                    _refer,
+                    new GcmsDataAccessor(GcmsParameter),
+                    Progress);
             case Common.Enum.AlignmentIndexType.RI:
             default:
                 return GcmsPeakJoiner.CreateRIJoiner(
@@ -64,7 +66,9 @@ public class GcmsAlignmentProcessFactory : AlignmentProcessFactory
                     GcmsParameter.RetentionIndexAlignmentTolerance,
                     GcmsParameter,
                     _evaluator,
-                    _refer);
+                    _refer,
+                    new GcmsDataAccessor(GcmsParameter),
+                    Progress);
         }
     }
 }

--- a/src/MSDIAL5/MsdialGcMsApi/Algorithm/GcmsDataAccessor.cs
+++ b/src/MSDIAL5/MsdialGcMsApi/Algorithm/GcmsDataAccessor.cs
@@ -5,110 +5,103 @@ using CompMs.Common.Interfaces;
 using CompMs.Common.Utility;
 using CompMs.MsdialCore.Algorithm;
 using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.MSDec;
 using CompMs.MsdialCore.Parser;
 using CompMs.MsdialGcMsApi.Parameter;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CompMs.MsdialGcMsApi.Algorithm
+namespace CompMs.MsdialGcMsApi.Algorithm;
+
+internal sealed class GcmsDataAccessor(MsdialGcmsParameter parameter) : DataAccessor, IFeatureAccessor<MSDecResult>, IFeatureAccessor<SpectrumFeature>
 {
-    internal sealed class GcmsDataAccessor : DataAccessor
+    private readonly IGcmsDataAccessor _accessorImpl = parameter.AlignmentIndexType switch
     {
-        private readonly IGcmsDataAccessor _accessorImpl;
+        AlignmentIndexType.RI => new RiGcmsDataAccessorImpl(parameter),
+        AlignmentIndexType.RT => new RtGcmsDataAccessorImpl(parameter),
+        _ => new RtGcmsDataAccessorImpl(parameter),
+    };
 
-        public GcmsDataAccessor(MsdialGcmsParameter parameter) {
-            switch (parameter.AlignmentIndexType) {
-                case AlignmentIndexType.RI:
-                    _accessorImpl = new RiGcmsDataAccessorImpl(parameter);
-                    break;
-                case AlignmentIndexType.RT:
-                default:
-                    _accessorImpl = new RtGcmsDataAccessorImpl(parameter);
-                    break;
-            }
+    public override List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile) {
+        return new List<IMSScanProperty>(_accessorImpl.GetMSScanProperties(analysisFile));
+    }
+
+    List<MSDecResult> IFeatureAccessor<MSDecResult>.GetMSScanProperties(AnalysisFileBean analysisFile) {
+        return _accessorImpl.GetMSScanProperties(analysisFile);
+    }
+
+    List<SpectrumFeature> IFeatureAccessor<SpectrumFeature>.GetMSScanProperties(AnalysisFileBean analysisFile) {
+        var collection = analysisFile.LoadSpectrumFeatures();
+        return new List<SpectrumFeature>(collection.Items);
+    }
+
+    public override ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
+        return _accessorImpl.AccumulateChromatogram(peak, spot, ms1Spectra, spectrum, ms1MassTolerance);
+    }
+
+    interface IGcmsDataAccessor {
+        List<MSDecResult> GetMSScanProperties(AnalysisFileBean analysisFile);
+        ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance);
+    }
+
+    class RtGcmsDataAccessorImpl(MsdialGcmsParameter parameter) : IGcmsDataAccessor {
+        private readonly MsdialGcmsParameter _parameter = parameter;
+        private static readonly IComparer<IMSScanProperty> _comparer = ChromXsComparer.RTComparer;
+
+        public List<MSDecResult> GetMSScanProperties(AnalysisFileBean analysisFile) {
+            var msdecResults = MsdecResultsReader.ReadMSDecResults(analysisFile.DeconvolutionFilePath, out _, out _);
+            msdecResults.Sort(_comparer);
+            return msdecResults;
         }
 
-        public override List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile) {
-            return _accessorImpl.GetMSScanProperties(analysisFile);
+        public ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
+            var detected = spot.AlignedPeakProperties.Where(x => x.MasterPeakID >= 0).ToArray();
+            var rtMin = detected.Min(x => x.ChromXsTop.RT.Value);
+            var rtMax = detected.Max(x => x.ChromXsTop.RT.Value);
+            var rtPeakWidth = detected.Average(x => x.PeakWidth(ChromXType.RT));
+            var rtLeft = rtMin - rtPeakWidth * 2F;
+            var rtRight = rtMax + rtPeakWidth * 2F;
+            if (rtRight - rtLeft > 5 && _parameter.AlignmentBaseParam.RetentionTimeAlignmentTolerance <= 2.5) {
+                rtLeft = spot.TimesCenter.Value - 2.5;
+                rtRight = spot.TimesCenter.Value + 2.5;
+            }
+            var chromatogramRange = new ChromatogramRange(rtLeft, rtRight, ChromXType.RT, ChromXUnit.Min);
+            var chromatogram = ms1Spectra.GetMs1ExtractedChromatogram(spot.QuantMass, ms1MassTolerance, chromatogramRange);
+            return new ChromatogramPeakInfo(
+                peak.FileID, chromatogram.ChromatogramSmoothing(_parameter.PeakPickBaseParam.SmoothingMethod, _parameter.PeakPickBaseParam.SmoothingLevel).AsPeakArray(),
+                (float)peak.ChromXsTop.RT.Value, (float)peak.ChromXsLeft.RT.Value, (float)peak.ChromXsRight.RT.Value);
+        }
+    }
+
+    class RiGcmsDataAccessorImpl(MsdialGcmsParameter parameter) : IGcmsDataAccessor {
+        private readonly MsdialGcmsParameter _parameter = parameter;
+        private static readonly IComparer<IMSScanProperty> _comparer = ChromXsComparer.RIComparer;
+        private readonly Dictionary<int, RetentionIndexHandler> _fileIdToHandler = parameter.GetRIHandlers();
+
+        public List<MSDecResult> GetMSScanProperties(AnalysisFileBean analysisFile) {
+            var msdecResults = MsdecResultsReader.ReadMSDecResults(analysisFile.DeconvolutionFilePath, out _, out _);
+            msdecResults.Sort(_comparer);
+            return msdecResults;
         }
 
-        public override ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
-            return _accessorImpl.AccumulateChromatogram(peak, spot, ms1Spectra, spectrum, ms1MassTolerance);
-        }
-
-        interface IGcmsDataAccessor {
-            List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile);
-            ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance);
-        }
-
-        class RtGcmsDataAccessorImpl : IGcmsDataAccessor {
-            private readonly MsdialGcmsParameter _parameter;
-            private static readonly IComparer<IMSScanProperty> _comparer = ChromXsComparer.RTComparer;
-
-            public RtGcmsDataAccessorImpl(MsdialGcmsParameter parameter) {
-                _parameter = parameter;
+        public ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
+            var detected = spot.AlignedPeakProperties.Where(x => x.MasterPeakID >= 0).ToArray();
+            var riMin = detected.Min(x => x.ChromXsTop.RI);
+            var riMax = detected.Max(x => x.ChromXsTop.RI);
+            var riPeakWidth = detected.Average(x => x.PeakWidth(ChromXType.RI));
+            var riLeft = riMin - riPeakWidth * 2F;
+            var riRight = riMax + riPeakWidth * 2F;
+            var handler = _fileIdToHandler[peak.FileID];
+            
+            var chromatogramRange = ChromatogramRange.FromTimes(handler.ConvertBack(riLeft), handler.ConvertBack(riRight));
+            var chromatogram = ms1Spectra.GetMs1ExtractedChromatogram(spot.QuantMass, ms1MassTolerance, chromatogramRange);
+            var smoothedChromatogram = chromatogram.ChromatogramSmoothing(_parameter.PeakPickBaseParam.SmoothingMethod, _parameter.PeakPickBaseParam.SmoothingLevel).AsPeakArray();
+            foreach (var p in smoothedChromatogram) {
+                p.ChromXs.RI = handler.Convert(p.ChromXs.RT);
+                p.ChromXs.MainType = ChromXType.RI;
             }
-
-            public List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile) {
-                var msdecResults = MsdecResultsReader.ReadMSDecResults(analysisFile.DeconvolutionFilePath, out _, out _);
-                msdecResults.Sort(_comparer);
-                return msdecResults.Cast<IMSScanProperty>().ToList();
-            }
-
-            public ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
-                var detected = spot.AlignedPeakProperties.Where(x => x.MasterPeakID >= 0);
-                var rtMin = detected.Min(x => x.ChromXsTop.RT.Value);
-                var rtMax = detected.Max(x => x.ChromXsTop.RT.Value);
-                var rtPeakWidth = detected.Average(x => x.PeakWidth(ChromXType.RT));
-                var rtLeft = rtMin - rtPeakWidth * 2F;
-                var rtRight = rtMax + rtPeakWidth * 2F;
-                if (rtRight - rtLeft > 5 && _parameter.AlignmentBaseParam.RetentionTimeAlignmentTolerance <= 2.5) {
-                    rtLeft = spot.TimesCenter.Value - 2.5;
-                    rtRight = spot.TimesCenter.Value + 2.5;
-                }
-                var chromatogramRange = new ChromatogramRange(rtLeft, rtRight, ChromXType.RT, ChromXUnit.Min);
-                var chromatogram = ms1Spectra.GetMs1ExtractedChromatogram(spot.QuantMass, ms1MassTolerance, chromatogramRange);
-                return new ChromatogramPeakInfo(
-                    peak.FileID, chromatogram.ChromatogramSmoothing(_parameter.PeakPickBaseParam.SmoothingMethod, _parameter.PeakPickBaseParam.SmoothingLevel).AsPeakArray(),
-                    (float)peak.ChromXsTop.RT.Value, (float)peak.ChromXsLeft.RT.Value, (float)peak.ChromXsRight.RT.Value);
-            }
-        }
-
-        class RiGcmsDataAccessorImpl : IGcmsDataAccessor {
-            private readonly MsdialGcmsParameter _parameter;
-            private static readonly IComparer<IMSScanProperty> _comparer = ChromXsComparer.RIComparer;
-            private readonly Dictionary<int, RetentionIndexHandler> _fileIdToHandler;
-
-            public RiGcmsDataAccessorImpl(MsdialGcmsParameter parameter) {
-                _parameter = parameter;
-                _fileIdToHandler = parameter.GetRIHandlers();
-            }
-
-            public List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile) {
-                var msdecResults = MsdecResultsReader.ReadMSDecResults(analysisFile.DeconvolutionFilePath, out _, out _);
-                msdecResults.Sort(_comparer);
-                return msdecResults.Cast<IMSScanProperty>().ToList();
-            }
-
-            public ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
-                var detected = spot.AlignedPeakProperties.Where(x => x.MasterPeakID >= 0);
-                var riMin = detected.Min(x => x.ChromXsTop.RI);
-                var riMax = detected.Max(x => x.ChromXsTop.RI);
-                var riPeakWidth = detected.Average(x => x.PeakWidth(ChromXType.RI));
-                var riLeft = riMin - riPeakWidth * 2F;
-                var riRight = riMax + riPeakWidth * 2F;
-                var handler = _fileIdToHandler[peak.FileID];
-                
-                var chromatogramRange = ChromatogramRange.FromTimes(handler.ConvertBack(riLeft), handler.ConvertBack(riRight));
-                var chromatogram = ms1Spectra.GetMs1ExtractedChromatogram(spot.QuantMass, ms1MassTolerance, chromatogramRange);
-                var smoothedChromatogram = chromatogram.ChromatogramSmoothing(_parameter.PeakPickBaseParam.SmoothingMethod, _parameter.PeakPickBaseParam.SmoothingLevel).AsPeakArray();
-                foreach (var p in smoothedChromatogram) {
-                    p.ChromXs.RI = handler.Convert(p.ChromXs.RT);
-                    p.ChromXs.MainType = ChromXType.RI;
-                }
-                var peakInfo = new ChromatogramPeakInfo(peak.FileID, smoothedChromatogram, (float)peak.ChromXsTop.RI.Value, (float)peak.ChromXsLeft.RI.Value, (float)peak.ChromXsRight.RI.Value);
-                return peakInfo;
-            }
+            var peakInfo = new ChromatogramPeakInfo(peak.FileID, smoothedChromatogram, (float)peak.ChromXsTop.RI.Value, (float)peak.ChromXsLeft.RI.Value, (float)peak.ChromXsRight.RI.Value);
+            return peakInfo;
         }
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/AlignmentParameterSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/AlignmentParameterSettingModel.cs
@@ -45,6 +45,7 @@ namespace CompMs.App.Msdial.Model.Setting
             IsKeepSuggestedMetaboliteFeatures = parameter.PostProcessBaseParam.IsKeepSuggestedMetaboliteFeatures;
             IsKeepRemovableFeaturesAndAssignedTagForChecking = parameter.PostProcessBaseParam.IsKeepRemovableFeaturesAndAssignedTagForChecking;
             IsForceInsertForGapFilling = parameter.PostProcessBaseParam.IsForceInsertForGapFilling;
+            UseRefMatchedPeaksOnly = parameter.AlignmentBaseParam.UseRefMatchedPeaksOnly;
             ShouldRunAlignment = AnalysisFiles.Count > 1 && !IsReadOnly;
             this.parameter = parameter;
         }
@@ -124,6 +125,12 @@ namespace CompMs.App.Msdial.Model.Setting
         }
         private bool isForceInsertForGapFilling;
 
+        public bool UseRefMatchedPeaksOnly {
+            get => _useRefMatchedPeaksOnly;
+            set => SetProperty(ref _useRefMatchedPeaksOnly, value);
+        }
+        private bool _useRefMatchedPeaksOnly;
+
         public bool ShouldRunAlignment {
             get => shouldRunAlignment;
             set => SetProperty(ref shouldRunAlignment, value);
@@ -169,6 +176,7 @@ namespace CompMs.App.Msdial.Model.Setting
                 ProteinAssembledResultFilePath = Path.Combine(projectFolder, alignmentResultFileName + "." + MsdialDataStorageFormat.prf),
             });
             parameter.AlignmentBaseParam.AlignmentReferenceFileID = ReferenceFile.AnalysisFileId;
+            parameter.AlignmentBaseParam.UseRefMatchedPeaksOnly = UseRefMatchedPeaksOnly;
             var postProcessParameter = parameter.PostProcessBaseParam;
             postProcessParameter.PeakCountFilter = PeakCountFilter;
             postProcessParameter.NPercentDetectedInOneGroup = NPercentDetectedInOneGroup;
@@ -202,6 +210,7 @@ namespace CompMs.App.Msdial.Model.Setting
             IsKeepSuggestedMetaboliteFeatures = parameter.PostProcessBaseParam.IsKeepSuggestedMetaboliteFeatures;
             IsKeepRemovableFeaturesAndAssignedTagForChecking = parameter.PostProcessBaseParam.IsKeepRemovableFeaturesAndAssignedTagForChecking;
             IsForceInsertForGapFilling = parameter.PostProcessBaseParam.IsForceInsertForGapFilling;
+            UseRefMatchedPeaksOnly = parameter.AlignmentBaseParam.UseRefMatchedPeaksOnly;
         }
 
         private static List<IPeakEqualityParameterSetting> PrepareEqualityParameterSettings(ParameterBase parameter) {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/GcmsAlignmentParameterSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/GcmsAlignmentParameterSettingModel.cs
@@ -44,6 +44,7 @@ namespace CompMs.App.Msdial.Model.Setting
             IsKeepRefMatchedMetaboliteFeatures = parameter.PostProcessBaseParam.IsKeepRefMatchedMetaboliteFeatures;
             IsKeepRemovableFeaturesAndAssignedTagForChecking = parameter.PostProcessBaseParam.IsKeepRemovableFeaturesAndAssignedTagForChecking;
             IsForceInsertForGapFilling = parameter.PostProcessBaseParam.IsForceInsertForGapFilling;
+            UseRefMatchedPeaksOnly = parameter.AlignmentBaseParam.UseRefMatchedPeaksOnly;
             ShouldRunAlignment = files.Count > 1 && !IsReadOnly;
 
             IndexType = parameter.AlignmentIndexType;
@@ -100,6 +101,12 @@ namespace CompMs.App.Msdial.Model.Setting
             set => SetProperty(ref _isForceInsertForGapFilling, value);
         }
         private bool _isForceInsertForGapFilling;
+
+        public bool UseRefMatchedPeaksOnly {
+            get => _useRefMatchedPeaksOnly;
+            set => SetProperty(ref _useRefMatchedPeaksOnly, value);
+        }
+        private bool _useRefMatchedPeaksOnly;
 
         public bool IsRepresentativeQuantMassBasedOnBasePeakMz {
             get => _isRepresentativeQuantMassBasedOnBasePeakMz;
@@ -194,6 +201,7 @@ namespace CompMs.App.Msdial.Model.Setting
                 ProteinAssembledResultFilePath = Path.Combine(projectFolder, AlignmentResultFileName + "." + MsdialDataStorageFormat.prf),
             });
             _parameter.AlignmentBaseParam.AlignmentReferenceFileID = ReferenceFile.AnalysisFileId;
+            _parameter.AlignmentBaseParam.UseRefMatchedPeaksOnly = UseRefMatchedPeaksOnly;
             var postProcessParameter = _parameter.PostProcessBaseParam;
             postProcessParameter.PeakCountFilter = PeakCountFilter;
             postProcessParameter.NPercentDetectedInOneGroup = NPercentDetectedInOneGroup;
@@ -231,6 +239,7 @@ namespace CompMs.App.Msdial.Model.Setting
             IsKeepRemovableFeaturesAndAssignedTagForChecking = parameter.PostProcessBaseParam.IsKeepRemovableFeaturesAndAssignedTagForChecking;
             IsForceInsertForGapFilling = parameter.PostProcessBaseParam.IsForceInsertForGapFilling;
             IsIdentificationOnlyPerformedForAlignmentFile = parameter.RefSpecMatchBaseParam.IsIdentificationOnlyPerformedForAlignmentFile;
+            UseRefMatchedPeaksOnly = parameter.AlignmentBaseParam.UseRefMatchedPeaksOnly;
 
             if (parameter is MsdialGcmsParameter gcms) {
                 IndexType = gcms.AlignmentIndexType;

--- a/src/MSDIAL5/MsdialGuiApp/View/Setting/AlignmentParameterSettingView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Setting/AlignmentParameterSettingView.xaml
@@ -280,6 +280,15 @@
                               VerticalContentAlignment="Center"
                               Height="24"/>
                 </ui:LabeledContent>
+
+                <ui:LabeledContent PrependLabel="Do alignment for ref.matched peaks only:">
+                    <CheckBox IsChecked="{Binding Path=UseRefMatchedPeaksOnly.Value}"
+                              IsEnabled="{Binding IsReadOnly, Mode=OneTime, Converter={StaticResource NegativeConverter}}"
+                              HorizontalAlignment="Left"
+                              ToolTip="Alignment is performed for peaks annotated. "
+                              VerticalContentAlignment="Center"
+                              Height="24"/>
+                </ui:LabeledContent>
             </StackPanel>
         </Expander>
     </Grid>

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/AlignmentParameterSettingViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/AlignmentParameterSettingViewModel.cs
@@ -57,6 +57,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
             IsKeepSuggestedMetaboliteFeatures = Model.ToReactivePropertySlimAsSynchronized(m => m.IsKeepSuggestedMetaboliteFeatures).AddTo(Disposables);
             IsKeepRemovableFeaturesAndAssignedTagForChecking = Model.ToReactivePropertySlimAsSynchronized(m => m.IsKeepRemovableFeaturesAndAssignedTagForChecking).AddTo(Disposables);
             IsForceInsertForGapFilling = Model.ToReactivePropertySlimAsSynchronized(m => m.IsForceInsertForGapFilling).AddTo(Disposables);
+            UseRefMatchedPeaksOnly = model.ToReactivePropertySlimAsSynchronized(m => m.UseRefMatchedPeaksOnly).AddTo(Disposables);
             ShouldRunAlignment = Model.ToReactivePropertySlimAsSynchronized(m => m.ShouldRunAlignment).AddTo(Disposables);
 
             IsEnabled = isEnabled.ToReadOnlyReactivePropertySlim().AddTo(Disposables);
@@ -87,6 +88,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
                 IsKeepSuggestedMetaboliteFeatures.ToUnit(),
                 IsKeepRemovableFeaturesAndAssignedTagForChecking.ToUnit(),
                 IsForceInsertForGapFilling.ToUnit(),
+                UseRefMatchedPeaksOnly.ToUnit(),
             }.Merge();
 
             decide = new Subject<Unit>().AddTo(Disposables);
@@ -140,6 +142,8 @@ namespace CompMs.App.Msdial.ViewModel.Setting
         public ReactivePropertySlim<bool> IsKeepRemovableFeaturesAndAssignedTagForChecking { get; }
 
         public ReactivePropertySlim<bool> IsForceInsertForGapFilling { get; }
+
+        public ReactivePropertySlim<bool> UseRefMatchedPeaksOnly { get; }
 
         public ReactivePropertySlim<bool> ShouldRunAlignment { get; }
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/GcmsAlignmentParameterSettingViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/GcmsAlignmentParameterSettingViewModel.cs
@@ -58,6 +58,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
             IsKeepRefMatchedMetaboliteFeatures = model.ToReactivePropertySlimAsSynchronized(m => m.IsKeepRefMatchedMetaboliteFeatures).AddTo(Disposables);
             IsKeepRemovableFeaturesAndAssignedTagForChecking = model.ToReactivePropertySlimAsSynchronized(m => m.IsKeepRemovableFeaturesAndAssignedTagForChecking).AddTo(Disposables);
             IsForceInsertForGapFilling = model.ToReactivePropertySlimAsSynchronized(m => m.IsForceInsertForGapFilling).AddTo(Disposables);
+            UseRefMatchedPeaksOnly = model.ToReactivePropertySlimAsSynchronized(m => m.UseRefMatchedPeaksOnly).AddTo(Disposables);
             ShouldRunAlignment = model.ToReactivePropertySlimAsSynchronized(m => m.ShouldRunAlignment).AddTo(Disposables);
 
             IndexType = model.ToReactivePropertySlimAsSynchronized(m => m.IndexType).AddTo(Disposables);
@@ -103,6 +104,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
                 IsKeepRefMatchedMetaboliteFeatures.ToUnit(),
                 IsKeepRemovableFeaturesAndAssignedTagForChecking.ToUnit(),
                 IsForceInsertForGapFilling.ToUnit(),
+                UseRefMatchedPeaksOnly.ToUnit(),
             }.Merge();
 
             _decide = new Subject<Unit>().AddTo(Disposables);
@@ -155,6 +157,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
         public ReactivePropertySlim<bool> IsKeepRefMatchedMetaboliteFeatures { get; }
         public ReactivePropertySlim<bool> IsKeepRemovableFeaturesAndAssignedTagForChecking { get; }
         public ReactivePropertySlim<bool> IsForceInsertForGapFilling { get; }
+        public ReactivePropertySlim<bool> UseRefMatchedPeaksOnly { get; }
         public ReactivePropertySlim<bool> IsIdentificationOnlyPerformedForAlignmentFile { get; }
         public ReactivePropertySlim<bool> IsRepresentativeQuantMassBasedOnBasePeakMz { get; }
 

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsAlignmentProcessFactory.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsAlignmentProcessFactory.cs
@@ -39,10 +39,6 @@ public class LcmsAlignmentProcessFactory : AlignmentProcessFactory
     }
 
     public override IPeakJoiner CreatePeakJoiner() {
-        return new LcmsPeakJoiner(
-            LcmsParameter.RetentionTimeAlignmentTolerance, LcmsParameter.RetentionTimeAlignmentFactor,
-            LcmsParameter.Ms1AlignmentTolerance, LcmsParameter.Ms1AlignmentFactor,
-            Progress
-        );
+        return new LcmsPeakJoiner(LcmsParameter.AlignmentBaseParam, new LcmsDataAccessor(LcmsParameter), _evaluator, Progress);
     }
 }

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/LcmsDataAccessor.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/LcmsDataAccessor.cs
@@ -9,42 +9,46 @@ using CompMs.MsdialLcmsApi.Parameter;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace CompMs.MsdialLcMsApi.Algorithm
+namespace CompMs.MsdialLcMsApi.Algorithm;
+
+class LcmsDataAccessor : DataAccessor, IFeatureAccessor<ChromatogramPeakFeature>
 {
-    class LcmsDataAccessor : DataAccessor
-    {
 
-        static readonly IComparer<IMSScanProperty> Comparer = CompositeComparer.Build(MassComparer.Comparer, ChromXsComparer.RTComparer);
+    static readonly IComparer<IMSScanProperty> Comparer = CompositeComparer.Build(MassComparer.Comparer, ChromXsComparer.RTComparer);
 
-        private readonly MsdialLcmsParameter lcmsParameter;
+    private readonly MsdialLcmsParameter lcmsParameter;
 
-        public LcmsDataAccessor(MsdialLcmsParameter lcmsParameter) {
-            this.lcmsParameter = lcmsParameter;
+    public LcmsDataAccessor(MsdialLcmsParameter lcmsParameter) {
+        this.lcmsParameter = lcmsParameter;
+    }
+
+    public override ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
+        var detected = spot.AlignedPeakProperties.Where(x => x.MasterPeakID >= 0);
+        var timeMin = detected.Min(x => x.ChromXsTop.RT.Value);
+        var timeMax = detected.Max(x => x.ChromXsTop.RT.Value);
+        var peakWidth = detected.Average(x => x.PeakWidth(ChromXType.RT));
+        var tLeftRt = timeMin - peakWidth * 1.5F;
+        var tRightRt = timeMax + peakWidth * 1.5F;
+        if (tRightRt - tLeftRt > 5 && lcmsParameter.RetentionTimeAlignmentTolerance <= 2.5) {
+            tLeftRt = spot.TimesCenter.Value - 2.5;
+            tRightRt = spot.TimesCenter.Value + 2.5;
         }
+        
+        var chromatogramRange = new ChromatogramRange(tLeftRt, tRightRt, ChromXType.RT, ChromXUnit.Min);
+        var peaklist = ms1Spectra.GetMs1ExtractedChromatogram(peak.Mass, ms1MassTolerance, chromatogramRange);
+        return new ChromatogramPeakInfo(
+            peak.FileID, peaklist.ChromatogramSmoothing(this.lcmsParameter.SmoothingMethod, this.lcmsParameter.SmoothingLevel).AsPeakArray(),
+            (float)peak.ChromXsTop.RT.Value, (float)peak.ChromXsLeft.RT.Value, (float)peak.ChromXsRight.RT.Value);
+    }
 
-        public override ChromatogramPeakInfo AccumulateChromatogram(AlignmentChromPeakFeature peak, AlignmentSpotProperty spot, Ms1Spectra ms1Spectra, IReadOnlyList<RawSpectrum> spectrum, float ms1MassTolerance) {
-            var detected = spot.AlignedPeakProperties.Where(x => x.MasterPeakID >= 0);
-            var timeMin = detected.Min(x => x.ChromXsTop.RT.Value);
-            var timeMax = detected.Max(x => x.ChromXsTop.RT.Value);
-            var peakWidth = detected.Average(x => x.PeakWidth(ChromXType.RT));
-            var tLeftRt = timeMin - peakWidth * 1.5F;
-            var tRightRt = timeMax + peakWidth * 1.5F;
-            if (tRightRt - tLeftRt > 5 && lcmsParameter.RetentionTimeAlignmentTolerance <= 2.5) {
-                tLeftRt = spot.TimesCenter.Value - 2.5;
-                tRightRt = spot.TimesCenter.Value + 2.5;
-            }
-            
-            var chromatogramRange = new ChromatogramRange(tLeftRt, tRightRt, ChromXType.RT, ChromXUnit.Min);
-            var peaklist = ms1Spectra.GetMs1ExtractedChromatogram(peak.Mass, ms1MassTolerance, chromatogramRange);
-            return new ChromatogramPeakInfo(
-                peak.FileID, peaklist.ChromatogramSmoothing(this.lcmsParameter.SmoothingMethod, this.lcmsParameter.SmoothingLevel).AsPeakArray(),
-                (float)peak.ChromXsTop.RT.Value, (float)peak.ChromXsLeft.RT.Value, (float)peak.ChromXsRight.RT.Value);
-        }
+    List<ChromatogramPeakFeature> IFeatureAccessor<ChromatogramPeakFeature>.GetMSScanProperties(AnalysisFileBean analysisFile) {
+        var chromatogram = MsdialPeakSerializer.LoadChromatogramPeakFeatures(analysisFile.PeakAreaBeanInformationFilePath);
+        chromatogram.Sort(Comparer);
+        return chromatogram;
+    }
 
-        public override List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile) {
-            var chromatogram = MsdialPeakSerializer.LoadChromatogramPeakFeatures(analysisFile.PeakAreaBeanInformationFilePath);
-            chromatogram.Sort(Comparer);
-            return new List<IMSScanProperty>(chromatogram);
-        }
+    public override List<IMSScanProperty> GetMSScanProperties(AnalysisFileBean analysisFile) {
+        var chromatogram = ((IFeatureAccessor<ChromatogramPeakFeature>)this).GetMSScanProperties(analysisFile);
+        return new List<IMSScanProperty>(chromatogram);
     }
 }

--- a/tests/MSDIAL5/MsdialLcMsApiTests/MsdialLcMsApiTests.csproj
+++ b/tests/MSDIAL5/MsdialLcMsApiTests/MsdialLcMsApiTests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
 
     <Configurations>Debug;Release;Debug vendor unsupported;Release vendor unsupported</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### PR Classification  
Refactoring, new feature, and test enhancements to improve modularity, maintainability, and alignment functionality.  

#### PR Summary  
This PR introduces the `UseRefMatchedPeaksOnly` feature, refactors alignment logic to use modern C# practices, and enhances test coverage with updated data structures.  
- **`IPeakJoiner`, `GcmsPeakJoiner`, and `LcmsPeakJoiner`**: Refactored to use `IFeatureAccessor` for modularity and added support for `UseRefMatchedPeaksOnly`.  
- **`GcmsDataAccessor` and `LcmsDataAccessor`**: Implemented `IFeatureAccessor` and updated methods for better abstraction and readability.  
- **UI and ViewModel**: Added a checkbox and property binding for `UseRefMatchedPeaksOnly` in alignment settings.  
- **Tests**: Updated `LcmsPeakJoinerTests` to use `ChromatogramPeakFeature`, introduced `StubAccessor` and `FakeEvaluator`, and added a new test for `UseRefMatchedPeaksOnly`.  
- **General Improvements**: Replaced redundant list initializations, improved null handling, and removed unused code.  
