### PR TITLE
Added Support for Multiple Intensity Axis Titles in MS/MS Spectrum View

### DIFF
--- a/src/Common/ChartDrawing/Base/AxisTitles.cs
+++ b/src/Common/ChartDrawing/Base/AxisTitles.cs
@@ -1,0 +1,68 @@
+﻿using CompMs.CommonMVVM;
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace CompMs.Graphics.Base;
+
+[TypeConverter(typeof(AxisTitlesTypeConverter))]
+public sealed class AxisTitles : BindableBase
+{
+    public static readonly AxisTitles Empty = new AxisTitles { Titles = [] };
+
+    public string[] Titles {
+        get => _titles;
+        set => SetProperty(ref _titles, value);
+    }
+    private string[] _titles = [];
+
+    public override string ToString() {
+        return string.Join(";", _titles);
+    }
+}
+
+public sealed class AxisTitlesTypeConverter : TypeConverter {
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) {
+        if (sourceType == typeof(string)) {
+            return true;
+        }
+        if (typeof(System.Collections.Generic.IEnumerable<string>).IsAssignableFrom(sourceType)) {
+            return true;
+        }
+        return base.CanConvertFrom(context, sourceType);
+    }
+
+    public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) {
+        if (destinationType == typeof(string)) {
+            return true;
+        }
+        if (destinationType.IsAssignableFrom(typeof(string[]))) {
+            return true;
+        }
+        return base.CanConvertTo(context, destinationType);
+    }
+
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
+        if (value is string title) {
+            return new AxisTitles { Titles = [title] };
+        }
+        if (value is string[] titles) {
+            return new AxisTitles { Titles = titles };
+        }
+        if (value is System.Collections.Generic.IList<string> titles_) {
+            return new AxisTitles { Titles = [.. titles_] };
+        }
+        return base.ConvertFrom(context, culture, value);
+    }
+
+    public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) {
+        if (destinationType == typeof(string)) {
+            return value.ToString();
+        }
+        if (destinationType == typeof(string[]) || destinationType.IsAssignableFrom(typeof(string[]))) {
+            return ((AxisTitles)value).Titles;
+        }
+        return base.ConvertTo(context, culture, value, destinationType);
+    }
+}
+

--- a/src/Common/ChartDrawing/Base/AxisValue.cs
+++ b/src/Common/ChartDrawing/Base/AxisValue.cs
@@ -29,7 +29,7 @@ namespace CompMs.Graphics.Core.Base
         public static bool operator <=(AxisValue lhs, AxisValue rhs) => lhs.CompareTo(rhs) <= 0;
         public static bool operator >=(AxisValue lhs, AxisValue rhs) => lhs.CompareTo(rhs) >= 0;
 
-        public int CompareTo(AxisValue other) {
+        public readonly int CompareTo(AxisValue other) {
             if (double.IsNaN(other.Value)) {
                 return 1;
             }
@@ -45,19 +45,19 @@ namespace CompMs.Graphics.Core.Base
             return 0;
         }
 
-        public override bool Equals(object obj) {
+        public override readonly bool Equals(object obj) {
             return (obj is AxisValue other) && other.Value == Value;
         }
 
-        public override string ToString() {
+        public override readonly string ToString() {
             return Value.ToString();
         }
 
-        public override int GetHashCode() {
+        public override readonly int GetHashCode() {
             return Value.GetHashCode();
         }
 
-        public bool IsNaN() {
+        public readonly bool IsNaN() {
             return double.IsNaN(Value);
         }
     }

--- a/src/Common/ChartDrawing/Chart/LineSpectrumControlSlim.cs
+++ b/src/Common/ChartDrawing/Chart/LineSpectrumControlSlim.cs
@@ -428,6 +428,7 @@ namespace CompMs.Graphics.Chart
 
                 var lo = SearchCollection.LowerBound(tree.Value, new LineSpectrumControlSlimItem(hr.Minimum, 0d, null), (a, b) => a.X.Value.CompareTo(b.X.Value));
                 var hi = SearchCollection.UpperBound(tree.Value, new LineSpectrumControlSlimItem(hr.Maximum, 0d, null), (a, b) => a.X.Value.CompareTo(b.X.Value));
+                drawingContext.DrawRectangle(Brushes.Transparent, null, new Rect(0d, 0d, actualWidth, actualHeight));
                 for (int i = lo; i < hi; i++) {
                     var item = tree.Value[i];
                     var x = haxis.TranslateToRenderPoint(item.X, flippedX, actualWidth);
@@ -439,7 +440,7 @@ namespace CompMs.Graphics.Chart
             UpdateSelectedPoint();
         }
 
-        private static readonly double radius = 3d;
+        private static readonly double radius = 4d;
 
         private bool CursorOnLine(AxisValue x, AxisValue y, LineSpectrumControlSlimItem item, double cutoff) {
             return (item.Y >= y && y > yBase || yBase > y && y >= item.Y)
@@ -493,9 +494,15 @@ namespace CompMs.Graphics.Chart
                     .Where(item => CursorOnLine(x, y, item, dx))
                     .DefaultIfEmpty()
                     .Argmin(item => Math.Abs(x - item?.X ?? 0d));
-                if (spot != null && FocusedItem != spot.Item) {
-                    FocusedItem = spot.Item;
+                if (spot is not null) {
                     FocusedPoint = pt;
+                    if (FocusedItem != spot.Item) {
+                        FocusedItem = spot.Item;
+                    }
+                }
+                else {
+                    FocusedItem = null;
+                    FocusedPoint = null;
                 }
             }
         }

--- a/src/Common/ChartDrawing/Chart/MultiChart.cs
+++ b/src/Common/ChartDrawing/Chart/MultiChart.cs
@@ -44,6 +44,8 @@ namespace CompMs.Graphics.Chart
             DefaultStyleKeyProperty.OverrideMetadata(typeof(MultiChart), new FrameworkPropertyMetadata(typeof(MultiChart)));
         }
 
+        private bool _isHorizontalTitleChanging = false, _isVerticalTitleChanging = false, _isHorizontalTitlesChanging = false, _isVerticalTitlesChanging = false;
+
         public MultiChart()
         {
             SetValue(RenderAreaControlStateProperty, new RenderAreaControlState());
@@ -110,21 +112,81 @@ namespace CompMs.Graphics.Chart
         public static readonly DependencyProperty HorizontalTitleProperty =
             DependencyProperty.Register(
                 nameof(HorizontalTitle), typeof(string), typeof(MultiChart),
-                new PropertyMetadata(string.Empty));
+                new PropertyMetadata(
+                    string.Empty,
+                    OnHorizontalTitleChanged));
 
         public string HorizontalTitle {
             get => (string)GetValue(HorizontalTitleProperty);
             set => SetValue(HorizontalTitleProperty, value);
         }
 
+        private static void OnHorizontalTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is MultiChart chart && !chart._isHorizontalTitlesChanging) {
+                chart._isHorizontalTitleChanging = true;
+                chart.SetCurrentValue(HorizontalTitlesProperty, new AxisTitles() { Titles = [(string)e.NewValue] });
+                chart._isHorizontalTitleChanging = false;
+            }
+        }
+
+        public static readonly DependencyProperty HorizontalTitlesProperty =
+            DependencyProperty.Register(
+                nameof(HorizontalTitles), typeof(AxisTitles), typeof(MultiChart),
+                new PropertyMetadata(
+                    AxisTitles.Empty,
+                    OnHorizontalTitlesChanged));
+
+        public AxisTitles HorizontalTitles {
+            get => (AxisTitles)GetValue(HorizontalTitlesProperty);
+            set => SetValue(HorizontalTitlesProperty, value);
+        }
+
+        private static void OnHorizontalTitlesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is MultiChart chart && !chart._isHorizontalTitleChanging) {
+                chart._isHorizontalTitlesChanging = true;
+                chart.SetCurrentValue(HorizontalTitleProperty, ((AxisTitles?)e.NewValue)?.ToString() ?? string.Empty);
+                chart._isHorizontalTitlesChanging = false;
+            }
+        }
+
         public static readonly DependencyProperty VerticalTitleProperty =
             DependencyProperty.Register(
                 nameof(VerticalTitle), typeof(string), typeof(MultiChart),
-                new PropertyMetadata(string.Empty));
+                new PropertyMetadata(
+                    string.Empty,
+                    OnVerticalTitleChanged));
 
         public string VerticalTitle {
             get => (string)GetValue(VerticalTitleProperty);
             set => SetValue(VerticalTitleProperty, value);
+        }
+
+        private static void OnVerticalTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is MultiChart chart && !chart._isVerticalTitlesChanging) {
+                chart._isVerticalTitleChanging = true;
+                chart.SetCurrentValue(VerticalTitlesProperty, new AxisTitles() { Titles = [(string)e.NewValue] });
+                chart._isVerticalTitleChanging = false;
+            }
+        }
+
+        public static readonly DependencyProperty VerticalTitlesProperty =
+            DependencyProperty.Register(
+                nameof(VerticalTitles), typeof(AxisTitles), typeof(MultiChart),
+                new PropertyMetadata(
+                    AxisTitles.Empty,
+                    OnVerticalTitlesChanged));
+
+        public AxisTitles VerticalTitles {
+            get => (AxisTitles)GetValue(VerticalTitlesProperty);
+            set => SetValue(VerticalTitlesProperty, value);
+        }
+
+        private static void OnVerticalTitlesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is MultiChart chart && !chart._isVerticalTitleChanging) {
+                chart._isVerticalTitlesChanging = true;
+                chart.SetCurrentValue(VerticalTitleProperty, ((AxisTitles?)e.NewValue)?.ToString() ?? string.Empty);
+                chart._isVerticalTitlesChanging = false;
+            }
         }
 
         public static readonly DependencyProperty RenderAreaControlStateProperty =

--- a/src/Common/ChartDrawing/Chart/SimpleChartControl.cs
+++ b/src/Common/ChartDrawing/Chart/SimpleChartControl.cs
@@ -44,6 +44,8 @@ namespace CompMs.Graphics.Chart
             DefaultStyleKeyProperty.OverrideMetadata(typeof(SimpleChartControl), new FrameworkPropertyMetadata(typeof(SimpleChartControl)));
         }
 
+        private bool _isHorizontalTitleChanging = false, _isVerticalTitleChanging = false, _isHorizontalTitlesChanging = false, _isVerticalTitlesChanging = false;
+
         public SimpleChartControl()
         {
             SetValue(RenderAreaControlStateProperty, new RenderAreaControlState());
@@ -110,21 +112,81 @@ namespace CompMs.Graphics.Chart
         public static readonly DependencyProperty HorizontalTitleProperty =
             DependencyProperty.Register(
                 nameof(HorizontalTitle), typeof(string), typeof(SimpleChartControl),
-                new PropertyMetadata(string.Empty));
+                new PropertyMetadata(
+                    string.Empty,
+                    OnHorizontalTitleChanged));
 
         public string HorizontalTitle {
             get => (string)GetValue(HorizontalTitleProperty);
             set => SetValue(HorizontalTitleProperty, value);
         }
 
+        private static void OnHorizontalTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is SimpleChartControl chart && !chart._isHorizontalTitlesChanging) {
+                chart._isHorizontalTitleChanging = true;
+                chart.SetCurrentValue(HorizontalTitlesProperty, new AxisTitles() { Titles = [(string)e.NewValue] });
+                chart._isHorizontalTitleChanging = false;
+            }
+        }
+
+        public static readonly DependencyProperty HorizontalTitlesProperty =
+            DependencyProperty.Register(
+                nameof(HorizontalTitles), typeof(AxisTitles), typeof(SimpleChartControl),
+                new PropertyMetadata(
+                    AxisTitles.Empty,
+                    OnHorizontalTitlesChanged));
+
+        public AxisTitles HorizontalTitles {
+            get => (AxisTitles)GetValue(HorizontalTitlesProperty);
+            set => SetValue(HorizontalTitlesProperty, value);
+        }
+
+        private static void OnHorizontalTitlesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is SimpleChartControl chart && !chart._isHorizontalTitleChanging) {
+                chart._isHorizontalTitlesChanging = true;
+                chart.SetCurrentValue(HorizontalTitleProperty, ((AxisTitles?)e.NewValue)?.ToString() ?? string.Empty);
+                chart._isHorizontalTitlesChanging = false;
+            }
+        }
+
         public static readonly DependencyProperty VerticalTitleProperty =
             DependencyProperty.Register(
                 nameof(VerticalTitle), typeof(string), typeof(SimpleChartControl),
-                new PropertyMetadata(string.Empty));
+                new PropertyMetadata(
+                    string.Empty,
+                    OnVerticalTitleChanged));
 
         public string VerticalTitle {
             get => (string)GetValue(VerticalTitleProperty);
             set => SetValue(VerticalTitleProperty, value);
+        }
+
+        private static void OnVerticalTitleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is SimpleChartControl chart && !chart._isVerticalTitlesChanging) {
+                chart._isVerticalTitleChanging = true;
+                chart.SetCurrentValue(VerticalTitlesProperty, new AxisTitles() { Titles = [(string)e.NewValue] });
+                chart._isVerticalTitleChanging = false;
+            }
+        }
+
+        public static readonly DependencyProperty VerticalTitlesProperty =
+            DependencyProperty.Register(
+                nameof(VerticalTitles), typeof(AxisTitles), typeof(SimpleChartControl),
+                new PropertyMetadata(
+                    AxisTitles.Empty,
+                    OnVerticalTitlesChanged));
+
+        public AxisTitles VerticalTitles {
+            get => (AxisTitles)GetValue(VerticalTitlesProperty);
+            set => SetValue(VerticalTitlesProperty, value);
+        }
+
+        private static void OnVerticalTitlesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is SimpleChartControl chart && !chart._isVerticalTitleChanging) {
+                chart._isVerticalTitlesChanging = true;
+                chart.SetCurrentValue(VerticalTitleProperty, ((AxisTitles)e.NewValue).ToString());
+                chart._isVerticalTitlesChanging = false;
+            }
         }
 
         public static readonly DependencyProperty RenderAreaControlStateProperty =

--- a/src/Common/CommonStandard/Extension/IEnumerableExtension.cs
+++ b/src/Common/CommonStandard/Extension/IEnumerableExtension.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CompMs.Common.Parser;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,6 +16,22 @@ namespace CompMs.Common.Extension {
 
         public static bool IsEmptyOrNull<T>(this IEnumerable<T>? collection) {
             return collection == null || !collection.Any();
+        }
+
+        public static bool AreAllEqual<T>(this IEnumerable<T> collection) {
+            using var enumerator = collection.GetEnumerator();
+            if (!enumerator.MoveNext()) {
+                return true;
+            }
+
+            var first = enumerator.Current;
+            var comparer = EqualityComparer<T>.Default;
+            while (enumerator.MoveNext()) {
+                if (!comparer.Equals(first, enumerator.Current)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         public static IEnumerable<T> Return<T>(T value) {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/AlignmentMs2SpectrumModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/AlignmentMs2SpectrumModel.cs
@@ -116,9 +116,9 @@ namespace CompMs.App.Msdial.Model.Chart
         public SingleSpectrumModel LowerSpectrumModel { get; }
 
         public IObservable<IAxisManager<double>> HorizontalAxis { get; }
-        public ReactivePropertySlim<AxisItemModel<double>> LowerVerticalAxisItem { get; }
+        public ReactivePropertySlim<AxisItemModel<double>?> LowerVerticalAxisItem { get; }
         public ObservableCollection<AxisItemModel<double>> LowerVerticalAxisItemCollection { get; }
-        public ReactivePropertySlim<AxisItemModel<double>> UpperVerticalAxisItem { get; }
+        public ReactivePropertySlim<AxisItemModel<double>?> UpperVerticalAxisItem { get; }
         public ObservableCollection<AxisItemModel<double>> UpperVerticalAxisItemCollection { get; }
         public ReadOnlyObservableCollection<AnalysisFileBeanModel> Files => _spectraManager.Files;
         public ReactiveProperty<AnalysisFileBeanModel?> SelectedFile => _spectraManager.SelectedFile;

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/AxisItemSelector.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/AxisItemSelector.cs
@@ -11,25 +11,25 @@ namespace CompMs.App.Msdial.Model.Chart
 {
     public sealed class AxisItemSelector<T> : DisposableModelBase
     {
-        private BehaviorSubject<AxisItemModel<T>> _selectedItemSubject;
+        private BehaviorSubject<AxisItemModel<T>?> _selectedItemSubject;
 
         public AxisItemSelector(params AxisItemModel<T>[] axisItems) {
             if (axisItems.Length == 0) {
                 throw new ArgumentException($"Argument '{nameof(axisItems)}' should have at least one item.");
             }
             AxisItems = new ObservableCollection<AxisItemModel<T>>(axisItems);
-            _selectedItemSubject = new BehaviorSubject<AxisItemModel<T>>(null!).AddTo(Disposables);
+            _selectedItemSubject = new BehaviorSubject<AxisItemModel<T>?>(null).AddTo(Disposables);
             _selectedAxisItem = axisItems.First();
             _selectedItemSubject.OnNext(_selectedAxisItem);
         }
 
         public ObservableCollection<AxisItemModel<T>> AxisItems { get; }
 
-        public AxisItemModel<T> SelectedAxisItem {
+        public AxisItemModel<T>? SelectedAxisItem {
             get => _selectedAxisItem;
             set => SetProperty(ref _selectedAxisItem, value);
         }
-        private AxisItemModel<T> _selectedAxisItem;
+        private AxisItemModel<T>? _selectedAxisItem;
 
         protected override void OnPropertyChanged(PropertyChangedEventArgs args) {
             base.OnPropertyChanged(args);
@@ -38,8 +38,12 @@ namespace CompMs.App.Msdial.Model.Chart
             }
         }
 
-        public IObservable<AxisItemModel<T>> GetAxisItemAsObservable() {
-            return _selectedItemSubject.AsObservable();
+        public IObservable<AxisItemModel<T>?> GetAxisItemAsObservable() {
+            return _selectedItemSubject.Where(v => v is not null);
+        }
+
+        public void Select(AxisItemModel<T> item) {
+            SelectedAxisItem = item;
         }
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/CheckChromatogramsModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/CheckChromatogramsModel.cs
@@ -146,7 +146,7 @@ internal sealed class CheckChromatogramsModel : BindableBase
         _advancedProcessParameter.DiplayEicSettingValues.AddRange(_displaySettingValueCandidates.Where(n => n.Mass > 0 && n.MassTolerance > 0));
         var displayEICs = _advancedProcessParameter.DiplayEicSettingValues;
         Chromatograms = LoadChromatogramsUsecase.Load(displayEICs);
-        if (Chromatograms.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> axis) {
+        if (Chromatograms.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> axis) {
             axis.ChartMargin = new ConstantMargin(0, 60);
         }
         AccumulatedMs1SpectrumModel = new AccumulatedMs1SpectrumModel(_accumulateSpectra, _scanCompoundSearchUsecase, LoadChromatogramsUsecase, File, _broker);

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/ChromatogramsModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/ChromatogramsModel.cs
@@ -65,7 +65,7 @@ public sealed class ChromatogramsModel : DisposableModelBase {
     public string VerticalProperty { get; }
 
     public ChromatogramsModel Merge(ChromatogramsModel other) {
-        return new ChromatogramsModel($"{Name} and {other.Name}", new ObservableCollection<DisplayChromatogram>(DisplayChromatograms.Concat(other.DisplayChromatograms)), $"{GraphTitle} and {other.GraphTitle}", ChromAxisItemSelector.SelectedAxisItem.GraphLabel, AbundanceAxisItemSelector.SelectedAxisItem.GraphLabel);
+        return new ChromatogramsModel($"{Name} and {other.Name}", new ObservableCollection<DisplayChromatogram>(DisplayChromatograms.Concat(other.DisplayChromatograms)), $"{GraphTitle} and {other.GraphTitle}", ChromAxisItemSelector.SelectedAxisItem?.GraphLabel ?? string.Empty, AbundanceAxisItemSelector.SelectedAxisItem?.GraphLabel ?? string.Empty);
     }
 
     public async Task ExportAsync(Stream stream, string separator) {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/ObservableMsSpectrum.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/ObservableMsSpectrum.cs
@@ -81,11 +81,13 @@ namespace CompMs.App.Msdial.Model.Chart
 
         public AxisPropertySelectors<double> CreateAxisPropertySelectors2(PropertySelector<SpectrumPeak, double> propertySelector, string graphLabel) {
             var rangeProperty = GetRange(propertySelector.Selector).Publish();
+            var absoluteAxis = rangeProperty.ToReactiveContinuousAxisManager(new ConstantMargin(0, 30), 0d, 0d, LabelType.Standard).AddTo(Disposables);
             var continuousAxis = rangeProperty.ToReactiveContinuousAxisManager(new ConstantMargin(0, 30), 0d, 0d, LabelType.Percent).AddTo(Disposables);
             var logAxis = rangeProperty.ToReactiveLogScaleAxisManager(new ConstantMargin(0, 30), 1d, 1d, labelType: LabelType.Percent).AddTo(Disposables);
             var sqrtAxis = rangeProperty.ToReactiveSqrtAxisManager(new ConstantMargin(0, 30), 0, 0, labelType: LabelType.Percent).AddTo(Disposables);
             var axisSelector = new AxisItemSelector<double>(
                     new AxisItemModel<double>("Relative", continuousAxis, $"Relative {graphLabel}"),
+                    new AxisItemModel<double>("Absolute", absoluteAxis, $"Absolute {graphLabel}"),
                     new AxisItemModel<double>("Log10", logAxis, $"Relative {graphLabel} (log10)"),
                     new AxisItemModel<double>("Sqrt", sqrtAxis, $"Relative {graphLabel} (^1/2)")).AddTo(Disposables);
             Disposables.Add(rangeProperty.Connect());

--- a/src/MSDIAL5/MsdialGuiApp/Model/Chart/RangeSelectableChromatogramModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Chart/RangeSelectableChromatogramModel.cs
@@ -87,7 +87,10 @@ namespace CompMs.App.Msdial.Model.Chart
         }
 
         public (double, double) ConvertToRt(RangeSelection range) {
-            var axis = ChromatogramModel.ChromAxisItemSelector.SelectedAxisItem.AxisManager;
+            var axis = ChromatogramModel.ChromAxisItemSelector.SelectedAxisItem?.AxisManager;
+            if (axis is null) {
+                return (0d, 1d);
+            }
             return range.ConvertBy(axis);
         }
     }

--- a/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedExtractedMs2SpectrumModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedExtractedMs2SpectrumModel.cs
@@ -176,7 +176,7 @@ internal sealed class AccumulatedExtractedMs2SpectrumModel : DisposableModelBase
 
         var range = MzRange.FromRange(0d, double.MaxValue);
         ProductIonChromatogram = _loadingChromatograms.LoadMS2Eic(Chromatogram.MzRange, range);
-        if (ProductIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ProductIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -186,11 +186,14 @@ internal sealed class AccumulatedExtractedMs2SpectrumModel : DisposableModelBase
             return;
         }
 
-        var axis = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem.AxisManager;
+        var axis = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem?.AxisManager;
+        if (axis is null) {
+            return;
+        }
         var (start, end) = new RangeSelection(SelectedRange).ConvertBy(axis);
         var range = MzRange.FromRange(start, end);
         ProductIonChromatogram = _loadingChromatograms.LoadMS2Eic(Chromatogram.MzRange, range);
-        if (ProductIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ProductIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -201,8 +204,8 @@ internal sealed class AccumulatedExtractedMs2SpectrumModel : DisposableModelBase
     }
 
     public void AddPeak() {
-        if (ProductIonRange is not null && ProductIonChromatogram is not null) {
-            var range = new RangeSelection(ProductIonRange).ConvertBy(ProductIonChromatogram.ChromAxisItemSelector.SelectedAxisItem.AxisManager);
+        if (ProductIonRange is not null && ProductIonChromatogram is not null && ProductIonChromatogram.ChromAxisItemSelector.SelectedAxisItem is { } axisItem) {
+            var range = new RangeSelection(ProductIonRange).ConvertBy(axisItem.AxisManager);
             ProductIonChromatogram?.AddPeak(range.Item1, range.Item2);
             ProductIonRange = null;
         }

--- a/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedMs1SpectrumModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedMs1SpectrumModel.cs
@@ -163,7 +163,7 @@ internal sealed class AccumulatedMs1SpectrumModel : DisposableModelBase
 
     public void CalculateTotalIonChromatogram() {
         ExtractedIonChromatogram = _loadingChromatograms.LoadTic();
-        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -172,11 +172,14 @@ internal sealed class AccumulatedMs1SpectrumModel : DisposableModelBase
         if (PlotComparedSpectrum is null || SelectedRange is null) {
             return;
         }
-        var axis = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem.AxisManager;
+        var axis = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem?.AxisManager;
+        if (axis is null) {
+            return;
+        }
         var (start, end) = new RangeSelection(SelectedRange).ConvertBy(axis);
         var range = MzRange.FromRange(start, end);
         ExtractedIonChromatogram = _loadingChromatograms.LoadEic(range);
-        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -187,8 +190,8 @@ internal sealed class AccumulatedMs1SpectrumModel : DisposableModelBase
     }
 
     public void AddPeak() {
-        if (ExtractIonRange is not null && ExtractedIonChromatogram is not null) {
-            var range = new RangeSelection(ExtractIonRange).ConvertBy(ExtractedIonChromatogram.ChromAxisItemSelector.SelectedAxisItem.AxisManager);
+        if (ExtractIonRange is not null && ExtractedIonChromatogram is not null && ExtractedIonChromatogram.ChromAxisItemSelector.SelectedAxisItem is { } axisItem) {
+            var range = new RangeSelection(ExtractIonRange).ConvertBy(axisItem.AxisManager);
             ExtractedIonChromatogram?.AddPeak(range.Item1, range.Item2);
             ExtractIonRange = null;
         }

--- a/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedMs2SpectrumModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedMs2SpectrumModel.cs
@@ -163,7 +163,7 @@ internal sealed class AccumulatedMs2SpectrumModel : DisposableModelBase
 
     public void CalculateTotalIonChromatogram() {
         ExtractedIonChromatogram = _loadingChromatograms.LoadMS2Tic();
-        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -172,11 +172,16 @@ internal sealed class AccumulatedMs2SpectrumModel : DisposableModelBase
         if (PlotComparedSpectrum is null || SelectedRange is null) {
             return;
         }
-        var axis = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem.AxisManager;
+
+        AxisItemModel<double>? axisItem = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem;
+        if (axisItem is null) {
+            return;
+        }
+        var axis = axisItem.AxisManager;
         var (start, end) = new RangeSelection(SelectedRange).ConvertBy(axis);
         var range = MzRange.FromRange(start, end);
         ExtractedIonChromatogram = _loadingChromatograms.LoadMS2Eic(range);
-        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -187,8 +192,8 @@ internal sealed class AccumulatedMs2SpectrumModel : DisposableModelBase
     }
 
     public void AddPeak() {
-        if (ExtractIonRange is not null && ExtractedIonChromatogram is not null) {
-            var range = new RangeSelection(ExtractIonRange).ConvertBy(ExtractedIonChromatogram.ChromAxisItemSelector.SelectedAxisItem.AxisManager);
+        if (ExtractIonRange is not null && ExtractedIonChromatogram is not null && ExtractedIonChromatogram.ChromAxisItemSelector.SelectedAxisItem is { } axisItem) {
+            var range = new RangeSelection(ExtractIonRange).ConvertBy(axisItem.AxisManager);
             ExtractedIonChromatogram?.AddPeak(range.Item1, range.Item2);
             ExtractIonRange = null;
         }

--- a/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedSpecificExperimentMS2SpectrumModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/MsResult/AccumulatedSpecificExperimentMS2SpectrumModel.cs
@@ -166,7 +166,7 @@ internal sealed class AccumulatedSpecificExperimentMS2SpectrumModel : Disposable
             return;
         }
         ExtractedIonChromatogram = _loadingChromatograms.LoadMS2Tic(_chromatogram.Chromatogram.ExperimentID);
-        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -176,10 +176,13 @@ internal sealed class AccumulatedSpecificExperimentMS2SpectrumModel : Disposable
             return;
         }
 
-        var axis = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem.AxisManager;
-        var (start, end) = new RangeSelection(SelectedRange).ConvertBy(axis);
+        AxisItemModel<double>? axisItem = PlotComparedSpectrum.MsSpectrumModel.UpperSpectrumModel.HorizontalPropertySelectors.AxisItemSelector.SelectedAxisItem;
+        if (axisItem is null) {
+            return;
+        }
+        var (start, end) = new RangeSelection(SelectedRange).ConvertBy(axisItem.AxisManager);
         ExtractedIonChromatogram = _loadingChromatograms.LoadMS2Eic(_chromatogram.Chromatogram.ExperimentID, MzRange.FromRange(start, end));
-        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager is BaseAxisManager<double> chromAxis) {
+        if (ExtractedIonChromatogram.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager is BaseAxisManager<double> chromAxis) {
             chromAxis.ChartMargin = new ConstantMargin(0, 60);
         }
     }
@@ -190,8 +193,8 @@ internal sealed class AccumulatedSpecificExperimentMS2SpectrumModel : Disposable
     }
 
     public void AddPeak() {
-        if (ExtractIonRange is not null && ExtractedIonChromatogram is not null) {
-            var range = new RangeSelection(ExtractIonRange).ConvertBy(ExtractedIonChromatogram.ChromAxisItemSelector.SelectedAxisItem.AxisManager);
+        if (ExtractIonRange is not null && ExtractedIonChromatogram is not null && ExtractedIonChromatogram.ChromAxisItemSelector.SelectedAxisItem is { } axisItem) {
+            var range = new RangeSelection(ExtractIonRange).ConvertBy(axisItem.AxisManager);
             ExtractedIonChromatogram?.AddPeak(range.Item1, range.Item2);
             ExtractIonRange = null;
         }

--- a/src/MSDIAL5/MsdialGuiApp/View/Chart/MsSpectrumView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Chart/MsSpectrumView.xaml
@@ -28,7 +28,7 @@
         <chart:MultiChart HorizontalAxis="{Binding HorizontalAxis.Value}"
                           GraphTitle="{Binding GraphTitle.Value}"
                           HorizontalTitle="{Binding HorizontalTitle.Value}"
-                          VerticalTitle="{Binding VerticalTitle.Value}"
+                          VerticalTitles="{Binding Path=VerticalTitles.Value}"
                           Style="{StaticResource VerticalConcatChart}">
             <chart:MultiChart.ContextMenu>
                 <ContextMenu>

--- a/src/MSDIAL5/MsdialGuiApp/View/Chart/RawPurifiedView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Chart/RawPurifiedView.xaml
@@ -97,7 +97,7 @@
                                Style="{StaticResource AxisTitle}"
                                IsHitTestVisible="False"
                                Grid.Row="3" Grid.Column="2"/>
-                    <TextBlock Text="{Binding Labels.VerticalTitle}"
+                    <TextBlock Text="{Binding Path=SelectedVerticalAxisItem.Value.GraphLabel}"
                                Style="{StaticResource AxisTitle}"
                                IsHitTestVisible="False"
                                Grid.Row="1" Grid.Column="0">
@@ -151,7 +151,7 @@
                                                  LabelSize="17"
                                                  Margin="1.5,0,0,0"
                                                  Grid.Column="2" Grid.Row="1" Grid.RowSpan="2"/>
-                    <TextBlock Text="{Binding Labels.HorizontalTitle}"
+                    <TextBlock Text="{Binding Path=SelectedVerticalAxisItem.Value.GraphLabel}"
                                Style="{StaticResource FormalItalicAxisTitle}"
                                Grid.Row="2" Grid.Column="2"/>
                     <TextBlock Text="{Binding Labels.VerticalTitle}"

--- a/src/MSDIAL5/MsdialGuiApp/View/ChartStyles.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/ChartStyles.xaml
@@ -442,15 +442,27 @@
                                    Style="{StaticResource AxisTitle}"
                                    IsHitTestVisible="False"
                                    Grid.Row="3" Grid.Column="1" />
-                        <TextBlock Name="VerticalTitle"
-                                   Text="{TemplateBinding VerticalTitle}"
-                                   Style="{StaticResource AxisTitle}"
-                                   IsHitTestVisible="False"
-                                   Grid.Row="1" Grid.Column="0">
-                            <TextBlock.LayoutTransform>
-                                <RotateTransform Angle="-90" CenterX="0.5" CenterY="0.5"/>
-                            </TextBlock.LayoutTransform>
-                        </TextBlock>
+                        <ItemsControl DataContext="{Binding Path=VerticalTitles, RelativeSource={RelativeSource TemplatedParent}}"
+                                      ItemsSource="{Binding Path=Titles}"
+                                      IsHitTestVisible="False"
+                                      Grid.Row="1" Grid.Column="0">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Columns="1"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Name="VerticalTitle"
+                                               Text="{Binding}"
+                                               Style="{StaticResource AxisTitle}">
+                                        <TextBlock.LayoutTransform>
+                                            <RotateTransform Angle="-90" CenterX="0.5" CenterY="0.5"/>
+                                        </TextBlock.LayoutTransform>
+                                    </TextBlock>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Chart/ChromatogramsViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Chart/ChromatogramsViewModel.cs
@@ -30,13 +30,13 @@ namespace CompMs.App.Msdial.ViewModel.Chart
         public AxisItemSelector<double> HorizontalSelector => _model.ChromAxisItemSelector;
         public AxisItemSelector<double> VerticalSelector => _model.AbundanceAxisItemSelector;
 
-        public IAxisManager<double> HorizontalAxis => _model.ChromAxisItemSelector.SelectedAxisItem.AxisManager;
-        public IAxisManager<double> VerticalAxis => _model.AbundanceAxisItemSelector.SelectedAxisItem.AxisManager;
+        public IAxisManager<double>? HorizontalAxis => _model.ChromAxisItemSelector.SelectedAxisItem?.AxisManager;
+        public IAxisManager<double>? VerticalAxis => _model.AbundanceAxisItemSelector.SelectedAxisItem?.AxisManager;
 
         public string GraphTitle => _model.GraphTitle;
 
-        public string HorizontalTitle => _model.ChromAxisItemSelector.SelectedAxisItem.GraphLabel;
-        public string VerticalTitle => _model.AbundanceAxisItemSelector.SelectedAxisItem.GraphLabel;
+        public string HorizontalTitle => _model.ChromAxisItemSelector.SelectedAxisItem?.GraphLabel ?? string.Empty;
+        public string VerticalTitle => _model.AbundanceAxisItemSelector.SelectedAxisItem?.GraphLabel ?? string.Empty;
 
         public string HorizontalProperty => _model.HorizontalProperty;
         public string VerticalProperty => _model.VerticalProperty;

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Chart/MsSpectrumViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Chart/MsSpectrumViewModel.cs
@@ -1,11 +1,13 @@
 ﻿using CompMs.App.Msdial.Model.Chart;
 using CompMs.App.Msdial.ViewModel.Service;
 using CompMs.CommonMVVM;
+using CompMs.Graphics.Base;
 using CompMs.Graphics.Core.Base;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Notifiers;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Reactive.Linq;
@@ -60,16 +62,18 @@ namespace CompMs.App.Msdial.ViewModel.Chart
         public SingleSpectrumViewModel LowerSpectrumViewModel { get; }
 
         public ReadOnlyReactivePropertySlim<IAxisManager<double>?> HorizontalAxis { get; }
-        public ReactivePropertySlim<AxisItemModel<double>> UpperVerticalAxisItem => _model.UpperVerticalAxisItem;
+        public ReactivePropertySlim<AxisItemModel<double>?> UpperVerticalAxisItem => _model.UpperVerticalAxisItem;
         public ReadOnlyObservableCollection<AxisItemModel<double>> UpperVerticalAxisItemCollection { get; }
-        public ReactivePropertySlim<AxisItemModel<double>> LowerVerticalAxisItem => _model.LowerVerticalAxisItem;
+        public ReactivePropertySlim<AxisItemModel<double>?> LowerVerticalAxisItem => _model.LowerVerticalAxisItem;
         public ReadOnlyObservableCollection<AxisItemModel<double>> LowerVerticalAxisItemCollection { get; }
 
         public ReadOnlyReactivePropertySlim<string?> GraphTitle { get; }
 
         public ReadOnlyReactivePropertySlim<string?> HorizontalTitle { get; }
 
+        [Obsolete("Use VerticalTitles instead.")]
         public ReadOnlyReactivePropertySlim<string?> VerticalTitle { get; }
+        public ReadOnlyReactivePropertySlim<AxisTitles> VerticalTitles => _model.VerticalTitles;
 
         public ReactiveCommand SwitchAllSpectrumCommand { get; }
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Chart/SingleSpectrumViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Chart/SingleSpectrumViewModel.cs
@@ -8,6 +8,7 @@ using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Notifiers;
 using System;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -37,6 +38,8 @@ namespace CompMs.App.Msdial.ViewModel.Chart
         public GraphLabels Labels => _model.Labels;
         public string HorizontalProperty => _model.HorizontalProperty;
         public ReadOnlyReactivePropertySlim<IAxisManager?> VerticalAxis { get; }
+        public AxisItemSelector<double> VerticalAxisItemSelector => _model.VerticalPropertySelectors.AxisItemSelector;
+        public ObservableCollection<AxisItemModel<double>> VerticalAxisItems => _model.VerticalAxisItemSelector.AxisItems;
         public ReadOnlyReactivePropertySlim<AxisItemModel<double>?> SelectedVerticalAxisItem { get; }
         public string VerticalProperty => _model.VerticalProperty;
         public ReadOnlyReactivePropertySlim<IBrushMapper> Brush { get; }


### PR DESCRIPTION
#### PR Classification  
New feature, code cleanup, and null safety improvements.  

#### PR Summary  
This PR introduces support for multiple axis titles, enhances null safety, and refactors axis-related logic for better performance and usability.  
- **`AxisTitles.cs`**: Added `AxisTitles` class and `AxisTitlesTypeConverter` to support multiple axis titles.  
- **`MsSpectrumModel.cs`**: Introduced `VerticalTitles` property, marked `VerticalTitle` as obsolete, and improved nullability handling.  
- **XAML Updates**: Updated bindings and replaced vertical title implementation with `ItemsControl` for multiple titles.  
- **Null Safety Enhancements**: Added null checks and null-conditional operators across multiple files to prevent null reference exceptions.  
- **General Refactoring**: Improved axis item handling in `SingleSpectrumViewModel` and refactored peak detection logic in spectrum models.  
