### PR TITLE
Fix typo in XAML: "Exp. vs.Rep." to "Exp. vs. Ref."

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsMainView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsMainView.xaml
@@ -411,7 +411,7 @@
                                 <ContentPresenter Content="{Binding}"/>
                                 <DataTemplate.Resources>
                                     <DataTemplate DataType="{x:Type vmchart:RawDecSpectrumsViewModel}">
-                                        <TextBlock Text="Exp. vs.Rep." VerticalAlignment="Stretch"/>
+                                        <TextBlock Text="Exp. vs. Ref." VerticalAlignment="Stretch"/>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type vmchart:Ms2ChromatogramsViewModel}">
                                         <TextBlock Text="MS2 Chrom." VerticalAlignment="Stretch"/>

--- a/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsMainView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsMainView.xaml
@@ -232,7 +232,7 @@
                         <DataTemplate>
                             <DataTemplate.Resources>
                                 <DataTemplate DataType="{x:Type chartvm:RawDecSpectrumsViewModel}">
-                                    <TextBlock Text="Exp. vs.Rep."
+                                    <TextBlock Text="Exp. vs. Ref."
                                                VerticalAlignment="Stretch"/>
                                 </DataTemplate>
                                 <DataTemplate DataType="{x:Type chartvm:EiChromatogramsViewModel}">

--- a/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsMainView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsMainView.xaml
@@ -421,7 +421,7 @@
                                 <ContentPresenter Content="{Binding}"/>
                                 <DataTemplate.Resources>
                                     <DataTemplate DataType="{x:Type vmchart:RawDecSpectrumsViewModel}">
-                                        <TextBlock Text="Exp. vs.Rep." VerticalAlignment="Stretch"/>
+                                        <TextBlock Text="Exp. vs. Ref." VerticalAlignment="Stretch"/>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type vmchart:Ms2ChromatogramsViewModel}">
                                         <TextBlock Text="MS2 Chrom." VerticalAlignment="Stretch"/>

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsMainView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsMainView.xaml
@@ -394,7 +394,7 @@
                             <DataTemplate>
                                 <DataTemplate.Resources>
                                     <DataTemplate DataType="{x:Type vmchart:RawDecSpectrumsViewModel}">
-                                        <TextBlock Text="Exp. vs.Rep."
+                                        <TextBlock Text="Exp. vs. Ref."
                                                    VerticalAlignment="Stretch"/>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type vmchart:Ms2ChromatogramsViewModel}">

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsMainView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsMainView.xaml
@@ -424,7 +424,7 @@
                             <DataTemplate>
                                 <DataTemplate.Resources>
                                     <DataTemplate DataType="{x:Type vmchart:RawDecSpectrumsViewModel}">
-                                        <TextBlock Text="Exp. vs.Rep."
+                                        <TextBlock Text="Exp. vs. Ref."
                                                    VerticalAlignment="Stretch"/>
                                     </DataTemplate>
                                     <DataTemplate DataType="{x:Type vmchart:Ms2ChromatogramsViewModel}">


### PR DESCRIPTION
Fix typo in XAML: "Exp. vs.Rep." to "Exp. vs. Ref."

Corrected text in `TextBlock` elements within `DataTemplate`
for `RawDecSpectrumsViewModel` across multiple XAML files
(`DimsMainView.xaml`, `GcmsMainView.xaml`, `ImmsMainView.xaml`,
`LcimmsMainView.xaml`, and `LcmsMainView.xaml`). Ensures
consistency and resolves a typographical error in displayed text.