### PR TITLE
Added ItemSelectBehavior Helper for Selecting Specific Elements from Lists

### DIFF
--- a/src/Common/ChartDrawing/Behavior/ItemSelectBehavior.cs
+++ b/src/Common/ChartDrawing/Behavior/ItemSelectBehavior.cs
@@ -1,7 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Media;
 
 namespace CompMs.Graphics.Behavior;
 
@@ -14,54 +13,47 @@ public static class ItemSelectBehavior
             typeof(ItemSelectBehavior),
             new FrameworkPropertyMetadata(
                 null,
-                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnSelectedItemChanged)
         );
 
     public static object GetSelectedItem(DependencyObject d) => d.GetValue(SelectedItemProperty);
 
     public static void SetSelectedItem(DependencyObject d, object value) => d.SetValue(SelectedItemProperty, value);
 
+    private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        if (d is UIElement ui) {
+            ui.RemoveHandler(ButtonBase.ClickEvent, OnClickHandler);
+            ui.AddHandler(ButtonBase.ClickEvent, OnClickHandler);
+        }
+        if (d is ContextMenu cm) {
+            cm.RemoveHandler(MenuItem.ClickEvent, OnClickHandler);
+            cm.AddHandler(MenuItem.ClickEvent, OnClickHandler);
+        }
+        if (d is MenuItem mi) {
+            mi.RemoveHandler(MenuItem.ClickEvent, OnClickHandler);
+            mi.AddHandler(MenuItem.ClickEvent, OnClickHandler);
+        }
+    }
+
+    private static readonly RoutedEventHandler OnClickHandler = OnClick;
+
+    private static void OnClick(object sender, RoutedEventArgs e) {
+        if (e.OriginalSource is DependencyObject src && sender is DependencyObject d) {
+            var value = GetItem(src);
+            d.SetCurrentValue(SelectedItemProperty, value);
+        }
+    }
+
     public static readonly DependencyProperty ItemProperty =
         DependencyProperty.RegisterAttached(
             "Item",
             typeof(object),
             typeof(ItemSelectBehavior),
-            new PropertyMetadata(null, OnItemChanged)
+            new PropertyMetadata(null)
         );
 
     public static object GetItem(DependencyObject d) => d.GetValue(ItemProperty);
 
     public static void SetItem(DependencyObject d, object value) => d.SetValue(ItemProperty, value);
-
-    private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
-        if (d is ButtonBase btn) {
-            WeakEventManager<ButtonBase, RoutedEventArgs>.RemoveHandler(btn, nameof(ButtonBase.Click), OnClick);
-            WeakEventManager<ButtonBase, RoutedEventArgs>.AddHandler(btn, nameof(ButtonBase.Click), OnClick);
-        }
-        if (d is MenuItem menu) {
-            WeakEventManager<MenuItem, RoutedEventArgs>.RemoveHandler(menu, nameof(MenuItem.Click), OnClick);
-            WeakEventManager<MenuItem, RoutedEventArgs>.AddHandler(menu, nameof(MenuItem.Click), OnClick);
-        }
-    }
-
-    private static void OnClick(object sender, RoutedEventArgs e) {
-        if (sender is DependencyObject d) {
-            var parent = FindAncestorWithProperty(d, SelectedItemProperty);
-            if (parent is not null) {
-                var value = GetItem(d);
-                parent.SetCurrentValue(SelectedItemProperty, value);
-            }
-        }
-    }
-
-    private static DependencyObject? FindAncestorWithProperty(DependencyObject child, DependencyProperty property) {
-        var parent = VisualTreeHelper.GetParent(child);
-        while (parent is not null) {
-            if (parent.ReadLocalValue(property) != DependencyProperty.UnsetValue) {
-                return parent;
-            }
-            parent = VisualTreeHelper.GetParent(parent);
-        }
-        return null;
-    }
 }

--- a/src/Common/ChartDrawing/Behavior/ItemSelectBehavior.cs
+++ b/src/Common/ChartDrawing/Behavior/ItemSelectBehavior.cs
@@ -1,0 +1,70 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+
+namespace CompMs.Graphics.Behavior;
+
+public static class ItemSelectBehavior
+{
+    public static readonly DependencyProperty SelectedItemProperty =
+        DependencyProperty.RegisterAttached(
+            "SelectedItem",
+            typeof(object),
+            typeof(ItemSelectBehavior),
+            new FrameworkPropertyMetadata(
+                _defaultSelectedItem,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnSelectedItemChanged)
+        );
+
+    private static readonly object _defaultSelectedItem = new();
+
+    public static object GetSelectedItem(DependencyObject d) => d.GetValue(SelectedItemProperty);
+
+    public static void SetSelectedItem(DependencyObject d, object value) => d.SetValue(SelectedItemProperty, value);
+
+    private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        SetParentDependencyObject(d, d);
+    }
+
+    private static readonly DependencyProperty ParentDependencyObjectProperty =
+        DependencyProperty.RegisterAttached(
+            "ParentDependencyObject",
+            typeof(DependencyObject),
+            typeof(ItemSelectBehavior),
+            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.Inherits)
+        );
+
+    private static DependencyObject GetParentDependencyObject(DependencyObject d) => (DependencyObject)d.GetValue(ParentDependencyObjectProperty);
+    private static void SetParentDependencyObject(DependencyObject d, DependencyObject value) => d.SetValue(ParentDependencyObjectProperty, value);
+
+    public static readonly DependencyProperty ItemProperty =
+        DependencyProperty.RegisterAttached(
+            "Item",
+            typeof(object),
+            typeof(ItemSelectBehavior),
+            new PropertyMetadata(null, OnItemChanged)
+        );
+
+    public static object GetItem(DependencyObject d) => d.GetValue(ItemProperty);
+
+    public static void SetItem(DependencyObject d, object value) => d.SetValue(ItemProperty, value);
+
+    private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+        if (d is ButtonBase btn) {
+            btn.Click -= OnClick;
+            btn.Click += OnClick;
+        }
+        if (d is MenuItem menu) {
+            menu.Click -= OnClick;
+            menu.Click += OnClick;
+        }
+    }
+
+    private static void OnClick(object sender, RoutedEventArgs e) {
+        if (sender is DependencyObject d) {
+            var parent = GetParentDependencyObject(d);
+            parent.SetCurrentValue(SelectedItemProperty, GetItem(d));
+        }
+    }
+}

--- a/src/Common/ChartDrawing/Converter/AreEqualsConverter.cs
+++ b/src/Common/ChartDrawing/Converter/AreEqualsConverter.cs
@@ -7,6 +7,8 @@ namespace CompMs.Graphics.Converter
 {
     public class AreEqualsConverter : IMultiValueConverter
     {
+        public static readonly AreEqualsConverter Default = new AreEqualsConverter();
+
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values.Length < 2) return false;

--- a/src/MSDIAL5/MsdialGuiApp/View/Chart/AlignmentMs2SpectrumView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Chart/AlignmentMs2SpectrumView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              xmlns:chart="clr-namespace:CompMs.Graphics.Chart;assembly=ChartDrawing"
+             xmlns:behavior="clr-namespace:CompMs.Graphics.Behavior;assembly=ChartDrawing"
              xmlns:components="clr-namespace:CompMs.Common.Components;assembly=Common"
              xmlns:common="clr-namespace:CompMs.CommonMVVM;assembly=CommonMVVM"
              xmlns:core="clr-namespace:CompMs.Graphics.Core.Base;assembly=ChartDrawing"
@@ -32,6 +33,43 @@
                           Style="{StaticResource VerticalConcatChart}">
             <chart:MultiChart.ContextMenu>
                 <ContextMenu>
+                    <MenuItem Header="Change axis type of upper spectrum into.."
+                              ItemsSource="{Binding Path=UpperVerticalAxisItemCollection}"
+                              DisplayMemberPath="Label"
+                              behavior:ItemSelectBehavior.SelectedItem="{Binding UpperVerticalAxisItem.Value}">
+                        <MenuItem.ItemContainerStyle>
+                            <Style TargetType="{x:Type MenuItem}">
+                                <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                                <Setter Property="IsChecked">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource AreEquals}" Mode="OneWay">
+                                            <Binding Path="."/>
+                                            <Binding Path="DataContext.UpperVerticalAxisItem.Value" RelativeSource="{RelativeSource AncestorType=MenuItem}"/>
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </MenuItem.ItemContainerStyle>
+                    </MenuItem>
+                    <MenuItem Header="Change axis type of lower spectrum into.."
+                              ItemsSource="{Binding Path=LowerVerticalAxisItemCollection}"
+                              DisplayMemberPath="Label"
+                              behavior:ItemSelectBehavior.SelectedItem="{Binding LowerVerticalAxisItem.Value}">
+                        <MenuItem.ItemContainerStyle>
+                            <Style TargetType="{x:Type MenuItem}">
+                                <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                                <Setter Property="IsChecked">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource AreEquals}" Mode="OneWay">
+                                            <Binding Path="."/>
+                                            <Binding Path="DataContext.LowerVerticalAxisItem.Value" RelativeSource="{RelativeSource AncestorType=MenuItem}"/>
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </MenuItem.ItemContainerStyle>
+                    </MenuItem>
+                    <Separator/>
                     <MenuItem Header="Show all spectrum peak"
                               Command="{Binding PlacementTarget.DataContext.SwitchAllSpectrumCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue={x:Static common:NeverCommand.Instance}}"/>
                     <MenuItem Header="Show matched spectrum peak"

--- a/src/MSDIAL5/MsdialGuiApp/View/Chart/MsSpectrumView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Chart/MsSpectrumView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              xmlns:chart="clr-namespace:CompMs.Graphics.Chart;assembly=ChartDrawing"
+             xmlns:behavior="clr-namespace:CompMs.Graphics.Behavior;assembly=ChartDrawing"
              xmlns:components="clr-namespace:CompMs.Common.Components;assembly=Common"
              xmlns:common="clr-namespace:CompMs.CommonMVVM;assembly=CommonMVVM"
              xmlns:core="clr-namespace:CompMs.Graphics.Core.Base;assembly=ChartDrawing"
@@ -32,6 +33,43 @@
                           Style="{StaticResource VerticalConcatChart}">
             <chart:MultiChart.ContextMenu>
                 <ContextMenu>
+                    <MenuItem Header="Change axis type of upper spectrum into.."
+                              ItemsSource="{Binding Path=UpperVerticalAxisItemCollection}"
+                              DisplayMemberPath="Label"
+                              behavior:ItemSelectBehavior.SelectedItem="{Binding UpperVerticalAxisItem.Value}">
+                        <MenuItem.ItemContainerStyle>
+                            <Style TargetType="{x:Type MenuItem}">
+                                <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                                <Setter Property="IsChecked">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource AreEquals}" Mode="OneWay">
+                                            <Binding Path="."/>
+                                            <Binding Path="DataContext.UpperVerticalAxisItem.Value" RelativeSource="{RelativeSource AncestorType=MenuItem}"/>
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </MenuItem.ItemContainerStyle>
+                    </MenuItem>
+                    <MenuItem Header="Change axis type of lower spectrum into.."
+                              ItemsSource="{Binding Path=LowerVerticalAxisItemCollection}"
+                              DisplayMemberPath="Label"
+                              behavior:ItemSelectBehavior.SelectedItem="{Binding LowerVerticalAxisItem.Value}">
+                        <MenuItem.ItemContainerStyle>
+                            <Style TargetType="{x:Type MenuItem}">
+                                <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                                <Setter Property="IsChecked">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource AreEquals}" Mode="OneWay">
+                                            <Binding Path="."/>
+                                            <Binding Path="DataContext.LowerVerticalAxisItem.Value" RelativeSource="{RelativeSource AncestorType=MenuItem}"/>
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </MenuItem.ItemContainerStyle>
+                    </MenuItem>
+                    <Separator/>
                     <MenuItem Header="Show all spectrum peak"
                               Command="{Binding PlacementTarget.DataContext.SwitchAllSpectrumCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue={x:Static common:NeverCommand.Instance}}"/>
                     <MenuItem Header="Show matched spectrum peak"

--- a/src/MSDIAL5/MsdialGuiApp/View/Chart/RawPurifiedView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Chart/RawPurifiedView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:chart="clr-namespace:CompMs.Graphics.Chart;assembly=ChartDrawing"
              xmlns:core="clr-namespace:CompMs.Graphics.Core.Base;assembly=ChartDrawing"
              xmlns:vm="clr-namespace:CompMs.App.Msdial.ViewModel.Chart"
@@ -177,6 +178,25 @@
             <io:SaveImageAsCommand x:Key="SaveFormattedChartCommand" Formatter="{StaticResource FormattedChartFormatter}" Format="Emf"/>
             <io:CopyImageAsCommand x:Key="CopyFormattedChartCommand" Formatter="{StaticResource FormattedChartFormatter}" Format="Emf"/>
             <ContextMenu x:Key="ChartContextMenu" d:DataContext="{d:DesignInstance Type={x:Type vm:SingleSpectrumViewModel}}">
+                <MenuItem Header="Change axis type into.."
+                          ItemsSource="{Binding Path=VerticalAxisItemSelector.AxisItems}"
+                          DisplayMemberPath="Label"
+                          behavior:ItemSelectBehavior.SelectedItem="{Binding VerticalAxisItemSelector.SelectedAxisItem}">
+                    <MenuItem.ItemContainerStyle>
+                        <Style TargetType="{x:Type MenuItem}">
+                            <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                            <Setter Property="IsChecked">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{StaticResource AreEquals}" Mode="OneWay">
+                                        <Binding Path="."/>
+                                        <Binding Path="DataContext.VerticalAxisItemSelector.SelectedAxisItem" RelativeSource="{RelativeSource AncestorType=MenuItem}"/>
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </MenuItem.ItemContainerStyle>
+                </MenuItem>
+                <Separator/>
                 <MenuItem Header="Save spectra table as.."
                           Command="{Binding SaveCommand, FallbackValue={x:Static mvvm:NeverCommand.Instance}}"/>
                 <MenuItem Header="Save image as...">

--- a/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml
+++ b/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml
@@ -1,0 +1,95 @@
+﻿<Page x:Class="ChartDrawingUiTest.Behavior.ItemSelectBehaviorTest"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:ChartDrawingUiTest.Behavior"
+      xmlns:behavior="clr-namespace:CompMs.Graphics.Behavior;assembly=ChartDrawing"
+      xmlns:converter="clr-namespace:CompMs.Graphics.Converter;assembly=ChartDrawing"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      d:DataContext="{d:DesignInstance Type={x:Type local:ItemSelectBehaviorTest}}"
+      Title="ItemSelectBehaviorTest">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+
+        <ComboBox ItemsSource="{Binding Path=Items}" SelectedItem="{Binding Path=SelectedItem, Mode=TwoWay}"/>
+
+        <ItemsControl ItemsSource="{Binding Path=Items}"
+                      behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}"
+                      Grid.Column="1" Grid.Row="1">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <RadioButton Content="{Binding}"
+                                 behavior:ItemSelectBehavior.Item="{Binding}">
+                        <RadioButton.IsChecked>
+                            <MultiBinding Converter="{x:Static converter:AreEqualsConverter.Default}" Mode="OneWay">
+                                <Binding Path="."/>
+                                <Binding Path="DataContext.SelectedItem" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                            </MultiBinding>
+                        </RadioButton.IsChecked>
+                    </RadioButton>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <Label Content="{Binding Path=SelectedItem, Mode=OneWay}" ContentStringFormat="{}{0} (Right click here)" Background="Pink" Grid.Row="0" Grid.Column="1">
+            <Label.ContextMenu>
+                <ContextMenu ItemsSource="{Binding Path=Items}"
+                             behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}">
+                    <ContextMenu.ItemContainerStyle>
+                        <Style TargetType="MenuItem">
+                            <Setter Property="IsChecked">
+                                <Setter.Value>
+                                    <MultiBinding Converter="{x:Static converter:AreEqualsConverter.Default}" Mode="OneWay">
+                                        <Binding Path="."/>
+                                        <Binding Path="DataContext.SelectedItem" RelativeSource="{RelativeSource AncestorType=ContextMenu}"/>
+                                    </MultiBinding>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                        </Style>
+                    </ContextMenu.ItemContainerStyle>
+                </ContextMenu>
+            </Label.ContextMenu>
+        </Label>
+
+        <ItemsControl ItemsSource="{Binding Path=Items}"
+                      behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}"
+                      Grid.Row="1" Grid.Column="0">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Left" Margin="8,0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Text" Value="x"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Value="true">
+                                            <DataTrigger.Binding>
+                                                <MultiBinding Converter="{x:Static converter:AreEqualsConverter.Default}" Mode="OneWay">
+                                                    <Binding Path="."/>
+                                                    <Binding Path="DataContext.SelectedItem" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                                </MultiBinding>
+                                            </DataTrigger.Binding>
+                                            <Setter Property="Text" Value="o"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <Button Content="{Binding}"
+                                behavior:ItemSelectBehavior.Item="{Binding}"/>
+                    </DockPanel>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Grid>
+</Page>

--- a/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml
+++ b/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml
@@ -40,26 +40,56 @@
             </ItemsControl.ItemTemplate>
         </ItemsControl>
 
-        <Label Content="{Binding Path=SelectedItem, Mode=OneWay}" ContentStringFormat="{}{0} (Right click here)" Background="Pink" Grid.Row="0" Grid.Column="1">
-            <Label.ContextMenu>
-                <ContextMenu ItemsSource="{Binding Path=Items}"
-                             behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}">
-                    <ContextMenu.ItemContainerStyle>
-                        <Style TargetType="MenuItem">
-                            <Setter Property="IsChecked">
-                                <Setter.Value>
-                                    <MultiBinding Converter="{x:Static converter:AreEqualsConverter.Default}" Mode="OneWay">
-                                        <Binding Path="."/>
-                                        <Binding Path="DataContext.SelectedItem" RelativeSource="{RelativeSource AncestorType=ContextMenu}"/>
-                                    </MultiBinding>
-                                </Setter.Value>
-                            </Setter>
-                            <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
-                        </Style>
-                    </ContextMenu.ItemContainerStyle>
-                </ContextMenu>
-            </Label.ContextMenu>
-        </Label>
+        <Grid Grid.Row="0" Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Label Content="{Binding Path=SelectedItem, Mode=OneWay}" ContentStringFormat="{}{0} (Right click here)" Background="Pink" Grid.Row="0">
+                <Label.ContextMenu>
+                    <ContextMenu ItemsSource="{Binding Path=Items}"
+                                 behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}">
+                        <ContextMenu.ItemContainerStyle>
+                            <Style TargetType="MenuItem">
+                                <Setter Property="IsChecked">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{x:Static converter:AreEqualsConverter.Default}" Mode="OneWay">
+                                            <Binding Path="."/>
+                                            <Binding Path="DataContext.SelectedItem" RelativeSource="{RelativeSource AncestorType=ContextMenu}"/>
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                                <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                            </Style>
+                        </ContextMenu.ItemContainerStyle>
+                    </ContextMenu>
+                </Label.ContextMenu>
+            </Label>
+
+            <Label Content="{Binding Path=SelectedItem, Mode=OneWay}" ContentStringFormat="{}{0} (Right click here)" Background="Pink" Grid.Row="1">
+                <Label.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Nested case"
+                                  ItemsSource="{Binding Path=Items}"
+                                  behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}">
+                            <MenuItem.ItemContainerStyle>
+                                <Style TargetType="MenuItem">
+                                    <Setter Property="IsChecked">
+                                        <Setter.Value>
+                                            <MultiBinding Converter="{x:Static converter:AreEqualsConverter.Default}" Mode="OneWay">
+                                                <Binding Path="."/>
+                                                <Binding Path="DataContext.SelectedItem" RelativeSource="{RelativeSource AncestorType=MenuItem}"/>
+                                            </MultiBinding>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <Setter Property="behavior:ItemSelectBehavior.Item" Value="{Binding}"/>
+                                </Style>
+                            </MenuItem.ItemContainerStyle>
+                        </MenuItem>
+                    </ContextMenu>
+                </Label.ContextMenu>
+            </Label>
+        </Grid>
 
         <ItemsControl ItemsSource="{Binding Path=Items}"
                       behavior:ItemSelectBehavior.SelectedItem="{Binding Path=SelectedItem}"

--- a/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml.cs
+++ b/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using System.Windows.Controls;
+
+namespace ChartDrawingUiTest.Behavior;
+
+/// <summary>
+/// Interaction logic for ItemSelectBehaviorTest.xaml
+/// </summary>
+public partial class ItemSelectBehaviorTest : Page, INotifyPropertyChanged
+{
+    public ItemSelectBehaviorTest() {
+        InitializeComponent();
+
+        DataContext = this;
+    }
+
+    public string SelectedItem {
+        get => _selectedItem;
+        set {
+            _selectedItem = value;
+            PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedItem)));
+        }
+    }
+
+    private string? _selectedItem = "A";
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public string[] Items { get; } = ["A", "B", "C", "D", "E"];
+}

--- a/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml.cs
+++ b/tests/Common/ChartDrawingUiTest/Behavior/ItemSelectBehaviorTest.xaml.cs
@@ -18,7 +18,7 @@ public partial class ItemSelectBehaviorTest : Page, INotifyPropertyChanged
         get => _selectedItem;
         set {
             _selectedItem = value;
-            PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedItem)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedItem)));
         }
     }
 

--- a/tests/Common/ChartDrawingUiTest/MainWindow.xaml.cs
+++ b/tests/Common/ChartDrawingUiTest/MainWindow.xaml.cs
@@ -73,6 +73,7 @@ namespace ChartDrawingUiTest
                 typeof(DockItemsControl),
                 typeof(ReorderableItemsControlBehaviorTest),
                 typeof(MovableItemsControlBehaviorTest),
+                typeof(ItemSelectBehaviorTest),
             };
             pageType = pages.ToDictionary(type => type.Name);
             names = pageType.Keys.ToList();


### PR DESCRIPTION
#### PR Classification  
New feature: Introduced a behavior for item selection in WPF applications.  

#### PR Summary  
Added `ItemSelectBehavior` to standardize item selection handling and updated multiple views to support dynamic axis type selection via context menus.  
- **`ItemSelectBehavior.cs`**: Added a new behavior class with dependency properties and event handlers for selection tracking.  
- **`AreEqualsConverter.cs`**: Enhanced with a static instance for reuse in bindings.  
- **`AlignmentMs2SpectrumView.xaml`, `MsSpectrumView.xaml`, `RawPurifiedView.xaml`**: Integrated `ItemSelectBehavior` and `AreEqualsConverter` for axis type selection via context menus.  
- **`ItemSelectBehaviorTest.xaml` and `ItemSelectBehaviorTest.xaml.cs`**: Added a test page to demonstrate and validate the new behavior.  
- **`MainWindow.xaml.cs`**: Registered the test page in the navigation system.  
