### PR TITLE
Added RelativeAmplitudeCutoff Parameter for Spectrum Filtering in Deconvolution

### DIFF
--- a/src/MSDIAL5/MsdialCore/MSDec/MSDecHandler.cs
+++ b/src/MSDIAL5/MsdialCore/MSDec/MSDecHandler.cs
@@ -473,7 +473,7 @@ namespace CompMs.MsdialCore.MSDec {
             }
             if (spectrum.Count > 0) {
                 var maxIntensity = spectrum.Max(n => n.Intensity);
-                spectrum = spectrum.Where(n => n.Intensity > param.AmplitudeCutoff).ToList();
+                spectrum = spectrum.Where(n => n.Intensity > param.ChromDecBaseParam.AmplitudeCutoff).ToList();
                 return spectrum;
             }
 
@@ -589,13 +589,13 @@ namespace CompMs.MsdialCore.MSDec {
            MsDecBin[] msdecBins, int chromScanOfPeakTop, ParameterBase param) {
             var rdamScan = msdecBins[chromScanOfPeakTop].RdamScanNumber;
             var massBin = param.CentroidMs1Tolerance; if (param.AccuracyType == AccuracyType.IsNominal) massBin = 0.5F;
-            var focusedMs1Spectrum = DataAccess.GetCentroidMassSpectra(spectrumList, param.MSDataType, rdamScan, param.AmplitudeCutoff, param.MassRangeBegin, param.MassRangeEnd);
+            var focusedMs1Spectrum = DataAccess.GetCentroidMassSpectra(spectrumList, param.MSDataType, rdamScan, param.ChromDecBaseParam.AmplitudeCutoff, param.MassRangeBegin, param.MassRangeEnd);
             focusedMs1Spectrum = ExcludeMasses(focusedMs1Spectrum, param.ExcludedMassList);
             if (focusedMs1Spectrum.Count == 0) return new List<List<ChromatogramPeak>>();
 
             var rdamScanList = modelChromVector.RdamScanList;
             var peaksList = new List<List<ChromatogramPeak>>();
-            foreach (var spec in focusedMs1Spectrum.Where(n => n.Intensity >= param.AmplitudeCutoff).OrderByDescending(n => n.Intensity)) {
+            foreach (var spec in focusedMs1Spectrum.Where(n => n.Intensity >= param.ChromDecBaseParam.AmplitudeCutoff).OrderByDescending(n => n.Intensity)) {
                 var peaks = getTrimedAndSmoothedPeaklist(spectrumList, modelChromVector.ChromScanList[0], modelChromVector.ChromScanList[modelChromVector.ChromScanList.Count - 1], param.SmoothingLevel, msdecBins, (float)spec.Mass, param);
                 var baselineCorrectedPeaks = getBaselineCorrectedPeaklist(peaks, modelChromVector.TargetScanTopInModelChromVector);
 
@@ -1004,7 +1004,7 @@ namespace CompMs.MsdialCore.MSDec {
                 var baselineCorrectedPeaks = getBaselineCorrectedPeaklist(peaks, modelChromVector.TargetScanTopInModelChromVector);
                 var peaktopInt = baselineCorrectedPeaks[modelChromVector.TargetScanTopInModelChromVector].Intensity;
 
-                if (peaktopInt <= param.AmplitudeCutoff) continue;
+                if (peaktopInt <= param.ChromDecBaseParam.AmplitudeCutoff) continue;
 
                 peaksList.Add(baselineCorrectedPeaks);
             }
@@ -1019,7 +1019,7 @@ namespace CompMs.MsdialCore.MSDec {
                 var baselineCorrectedPeaks = getBaselineCorrectedPeaklist(peaks, modelChromVector.TargetScanTopInModelChromVector);
                 var peaktopInt = baselineCorrectedPeaks[modelChromVector.TargetScanTopInModelChromVector].Intensity;
 
-                if (peaktopInt <= param.AmplitudeCutoff) continue;
+                if (peaktopInt <= param.ChromDecBaseParam.AmplitudeCutoff) continue;
 
                 peaksList.Add(baselineCorrectedPeaks);
             }

--- a/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
+++ b/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
@@ -605,7 +605,7 @@ namespace CompMs.MsdialCore.Parameter
             pStrings.Add("\r\n");
             pStrings.Add("# Deconvolution");
             pStrings.Add(String.Join(": ", new string[] { "Sigma window value", SigmaWindowValue.ToString() }));
-            pStrings.Add(String.Join(": ", new string[] { "Amplitude cut off", AmplitudeCutoff.ToString() }));
+            pStrings.Add(String.Join(": ", new string[] { "Amplitude cut off", ChromDecBaseParam.AmplitudeCutoff.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Keep isotope range", KeptIsotopeRange.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Exclude after precursor", RemoveAfterPrecursor.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Keep original precursor isotopes", KeepOriginalPrecursorIsotopes.ToString() }));

--- a/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
+++ b/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
@@ -606,6 +606,7 @@ namespace CompMs.MsdialCore.Parameter
             pStrings.Add("# Deconvolution");
             pStrings.Add(String.Join(": ", new string[] { "Sigma window value", SigmaWindowValue.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Amplitude cut off", ChromDecBaseParam.AmplitudeCutoff.ToString() }));
+            pStrings.Add(String.Join(": ", new string[] { "Relative amplitude cut off", ChromDecBaseParam.RelativeAmplitudeCutoff.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Keep isotope range", KeptIsotopeRange.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Exclude after precursor", RemoveAfterPrecursor.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Keep original precursor isotopes", KeepOriginalPrecursorIsotopes.ToString() }));
@@ -1223,6 +1224,8 @@ namespace CompMs.MsdialCore.Parameter
         public AccuracyType AccuracyType { get; set; } = AccuracyType.IsAccurate;
         [Key(8)]
         public double TargetCE { get; set; } = 0; // used for AIF deconvolution. Zero means that min CE is used for MS1 
+        [Key(9)]
+        public float RelativeAmplitudeCutoff { get; set; } = 0;
     }
 
     [MessagePackObject]

--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -914,7 +914,9 @@ namespace CompMs.MsdialCore.Utility {
                 spectra.Add(new SpectrumPeak() { Mass = massSpectra[i].Mz, Intensity = massSpectra[i].Intensity });
             }
 
-            if (param.MS2DataType == MSDataType.Centroid) return spectra.Where(n => n.Intensity > param.ChromDecBaseParam.AmplitudeCutoff).ToList();
+            var amplitudeTop = spectra.DefaultIfEmpty().Max(p => p?.Intensity ?? 0d);
+            var cutoff = Math.Max(amplitudeTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff, param.ChromDecBaseParam.AmplitudeCutoff);
+            if (param.MS2DataType == MSDataType.Centroid) return spectra.Where(n => n.Intensity > cutoff).ToList();
             if (spectra.Count == 0) return new List<SpectrumPeak>();
             if (type == ExportspectraType.profile) return spectra;
 

--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -914,7 +914,7 @@ namespace CompMs.MsdialCore.Utility {
                 spectra.Add(new SpectrumPeak() { Mass = massSpectra[i].Mz, Intensity = massSpectra[i].Intensity });
             }
 
-            if (param.MS2DataType == MSDataType.Centroid) return spectra.Where(n => n.Intensity > param.AmplitudeCutoff).ToList();
+            if (param.MS2DataType == MSDataType.Centroid) return spectra.Where(n => n.Intensity > param.ChromDecBaseParam.AmplitudeCutoff).ToList();
             if (spectra.Count == 0) return new List<SpectrumPeak>();
             if (type == ExportspectraType.profile) return spectra;
 

--- a/src/MSDIAL5/MsdialDimsCore/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialDimsCore/Algorithm/Ms2Dec.cs
@@ -37,12 +37,16 @@ public sealed class Ms2Dec
         var targetSpecID = DataAccess.GetTargetCEIndexForMS2RawSpectrum(chromPeakFeature, targetCE);
 
         if (targetSpecID < 0) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
-        var cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType, param.ChromDecBaseParam.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
+        var spectrum = provider.LoadMsSpectrumFromIndex(targetSpecID);
+        var amplitudeTop = spectrum.Spectrum.DefaultIfEmpty().Max(p => p.Intensity);
+        var amplitudeThreshold = Math.Max((float)amplitudeTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff, param.ChromDecBaseParam.AmplitudeCutoff);
+        var cSpectrum = DataAccess.GetCentroidMassSpectra(spectrum, param.MS2DataType, amplitudeThreshold, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
         if (cSpectrum.IsEmptyOrNull()) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
 
         var curatedSpectra = new List<SpectrumPeak>();
-        var precursorMz = chromPeakFeature.Mass;
-        var threshold = Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, 0.1); // TODO: remove magic number
+        var precursorMz = chromPeakFeature.PeakFeature.Mass;
+        amplitudeTop = cSpectrum.DefaultIfEmpty().Max(p => p?.Intensity) ?? 0;
+        var threshold = Math.Max(Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, amplitudeTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff), 0.1); // TODO: remove magic number
 
         foreach (var peak in cSpectrum.Where(n => n.Intensity > threshold)) { //preparing MS/MS chromatograms -> peaklistList
             if (param.RemoveAfterPrecursor && precursorMz + param.KeptIsotopeRange < peak.Mass) continue;

--- a/src/MSDIAL5/MsdialDimsCore/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialDimsCore/Algorithm/Ms2Dec.cs
@@ -37,12 +37,12 @@ public sealed class Ms2Dec
         var targetSpecID = DataAccess.GetTargetCEIndexForMS2RawSpectrum(chromPeakFeature, targetCE);
 
         if (targetSpecID < 0) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
-        var cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType, param.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
+        var cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType, param.ChromDecBaseParam.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
         if (cSpectrum.IsEmptyOrNull()) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
 
         var curatedSpectra = new List<SpectrumPeak>();
         var precursorMz = chromPeakFeature.Mass;
-        var threshold = Math.Max(param.AmplitudeCutoff, 0.1); // TODO: remove magic number
+        var threshold = Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, 0.1); // TODO: remove magic number
 
         foreach (var peak in cSpectrum.Where(n => n.Intensity > threshold)) { //preparing MS/MS chromatograms -> peaklistList
             if (param.RemoveAfterPrecursor && precursorMz + param.KeptIsotopeRange < peak.Mass) continue;

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/DeconvolutionSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/DeconvolutionSettingModel.cs
@@ -13,6 +13,7 @@ namespace CompMs.App.Msdial.Model.Setting
             IsReadOnly = (process & ProcessOption.PeakSpotting) == 0;
             SigmaWindowValue = parameter.SigmaWindowValue;
             AmplitudeCutoff = parameter.AmplitudeCutoff;
+            RelativeAmplitudeCutoff = parameter.RelativeAmplitudeCutoff;
             RemoveAfterPrecursor = parameter.RemoveAfterPrecursor;
             KeptIsotopeRange = parameter.KeptIsotopeRange;
             KeepOriginalPrecurosrIsotopes = parameter.KeepOriginalPrecursorIsotopes;
@@ -31,6 +32,12 @@ namespace CompMs.App.Msdial.Model.Setting
             set => SetProperty(ref _amplitudeCufoff, value);
         }
         private float _amplitudeCufoff;
+
+        public float RelativeAmplitudeCutoff {
+            get => _relativeAmplitudeCufoff;
+            set => SetProperty(ref _relativeAmplitudeCufoff, value);
+        }
+        private float _relativeAmplitudeCufoff;
 
         public bool RemoveAfterPrecursor {
             get => _removeAfterPrecurosr;
@@ -56,6 +63,7 @@ namespace CompMs.App.Msdial.Model.Setting
             }
             _parameter.SigmaWindowValue = SigmaWindowValue;
             _parameter.AmplitudeCutoff = AmplitudeCutoff;
+            _parameter.RelativeAmplitudeCutoff = RelativeAmplitudeCutoff;
             _parameter.RemoveAfterPrecursor = RemoveAfterPrecursor;
             _parameter.KeptIsotopeRange = KeptIsotopeRange;
             _parameter.KeepOriginalPrecursorIsotopes = KeepOriginalPrecurosrIsotopes;
@@ -67,6 +75,7 @@ namespace CompMs.App.Msdial.Model.Setting
             }
             SigmaWindowValue = parameter.SigmaWindowValue;
             AmplitudeCutoff = parameter.AmplitudeCutoff;
+            RelativeAmplitudeCutoff = parameter.RelativeAmplitudeCutoff;
             RemoveAfterPrecursor = parameter.RemoveAfterPrecursor;
             KeptIsotopeRange = parameter.KeptIsotopeRange;
             KeepOriginalPrecurosrIsotopes = parameter.KeepOriginalPrecursorIsotopes;

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/DeconvolutionSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/DeconvolutionSettingModel.cs
@@ -34,10 +34,10 @@ namespace CompMs.App.Msdial.Model.Setting
         private float _amplitudeCufoff;
 
         public float RelativeAmplitudeCutoff {
-            get => _relativeAmplitudeCufoff;
-            set => SetProperty(ref _relativeAmplitudeCufoff, value);
+            get => _relativeAmplitudeCutoff;
+            set => SetProperty(ref _relativeAmplitudeCutoff, value);
         }
-        private float _relativeAmplitudeCufoff;
+        private float _relativeAmplitudeCutoff;
 
         public bool RemoveAfterPrecursor {
             get => _removeAfterPrecurosr;

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/MethodSettingModelFactory.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/MethodSettingModelFactory.cs
@@ -158,7 +158,7 @@ namespace CompMs.App.Msdial.Model.Setting
             else if (parameter.TargetOmics == TargetOmics.Proteomics) {
                 parameter.MaxChargeNumber = 6;
                 parameter.MinimumAmplitude = 100000;
-                parameter.AmplitudeCutoff = 1000;
+                parameter.ChromDecBaseParam.AmplitudeCutoff = 1000;
             }
             return model;
         }

--- a/src/MSDIAL5/MsdialGuiApp/View/Setting/DeconvolutionSettingView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Setting/DeconvolutionSettingView.xaml
@@ -44,6 +44,13 @@
                     <TextBox Text="{Binding AmplitudeCutoff.Value}"
                              IsReadOnly="{Binding IsReadOnly, Mode=OneTime}"/>
                 </ui:LabeledContent>
+                <ui:LabeledContent PrependLabel="MS/MS relative abundance cut off:"
+                                   AppendLabel="%"
+                                   ToolTip="Recommend: 0-100"
+                                   Style="{StaticResource AlignedContent}">
+                    <TextBox Text="{Binding RelativeAmplitudeCutoff.Value}"
+                             IsReadOnly="{Binding IsReadOnly, Mode=OneTime}"/>
+                </ui:LabeledContent>
             </StackPanel>
         </GroupBox>
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/DataObj/ParameterBaseVM.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/DataObj/ParameterBaseVM.cs
@@ -774,6 +774,15 @@ namespace CompMs.App.Msdial.ViewModel.DataObj
             }
         }
 
+        public float RelativeAmplitudeCutoff {
+            get => innerModel.ChromDecBaseParam.RelativeAmplitudeCutoff;
+            set {
+                if (innerModel.ChromDecBaseParam.RelativeAmplitudeCutoff == value) return;
+                innerModel.ChromDecBaseParam.RelativeAmplitudeCutoff = value;
+                OnPropertyChanged(nameof(RelativeAmplitudeCutoff));
+            }
+        }
+
         public float AveragePeakWidth {
             get => innerModel.AveragePeakWidth;
             set {

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/DataObj/ParameterBaseVM.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/DataObj/ParameterBaseVM.cs
@@ -766,10 +766,10 @@ namespace CompMs.App.Msdial.ViewModel.DataObj
         }
 
         public float AmplitudeCutoff {
-            get => innerModel.AmplitudeCutoff;
+            get => innerModel.ChromDecBaseParam.AmplitudeCutoff;
             set {
-                if (innerModel.AmplitudeCutoff == value) return;
-                innerModel.AmplitudeCutoff = value;
+                if (innerModel.ChromDecBaseParam.AmplitudeCutoff == value) return;
+                innerModel.ChromDecBaseParam.AmplitudeCutoff = value;
                 OnPropertyChanged(nameof(AmplitudeCutoff));
             }
         }

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DeconvolutionSettingViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DeconvolutionSettingViewModel.cs
@@ -32,6 +32,13 @@ namespace CompMs.App.Msdial.ViewModel.Setting
                 ignoreValidationErrorValue: true
             ).SetValidateAttribute(() => AmplitudeCutoff).AddTo(Disposables);
 
+            RelativeAmplitudeCutoff = model.ToReactivePropertyAsSynchronized(
+                m => m.RelativeAmplitudeCutoff,
+                m => Math.Min(m * 100f, 100f).ToString(),
+                vm => float.Parse(vm) / 100f,
+                ignoreValidationErrorValue: true
+            ).SetValidateAttribute(() => RelativeAmplitudeCutoff).AddTo(Disposables);
+
             RemoveAfterPrecursor = model.ToReactivePropertySlimAsSynchronized(m => m.RemoveAfterPrecursor).AddTo(Disposables);
 
             KeptIsotopeRange = model.ToReactivePropertyAsSynchronized(
@@ -49,6 +56,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
             {
                 SigmaWindowValue.ObserveHasErrors,
                 AmplitudeCutoff.ObserveHasErrors,
+                RelativeAmplitudeCutoff.ObserveHasErrors,
                 KeptIsotopeRange.ObserveHasErrors,
             }.CombineLatestValuesAreAnyTrue()
             .ToReadOnlyReactivePropertySlim()
@@ -58,6 +66,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
             {
                 SigmaWindowValue.ToUnit(),
                 AmplitudeCutoff.ToUnit(),
+                RelativeAmplitudeCutoff.ToUnit(),
                 RemoveAfterPrecursor.ToUnit(),
                 KeptIsotopeRange.ToUnit(),
                 KeepOriginalPrecurosrIsotopes.ToUnit(),
@@ -86,6 +95,10 @@ namespace CompMs.App.Msdial.ViewModel.Setting
         [Required(ErrorMessage = "Amplitude cut off value is required.")]
         [RegularExpression(@"\d*\.?\d+", ErrorMessage = "Invalid character entered.")]
         public ReactiveProperty<string> AmplitudeCutoff { get; }
+
+        [Required(ErrorMessage = "Relative amplitude cut off value is required.")]
+        [RegularExpression(@"100(\.0+)?|([1-9]?\d)?(\.\d+)?", ErrorMessage = "Invalid value entered.")]
+        public ReactiveProperty<string> RelativeAmplitudeCutoff { get; }
 
         public ReactivePropertySlim<bool> RemoveAfterPrecursor { get; }
 

--- a/src/MSDIAL5/MsdialImmsCore/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialImmsCore/Algorithm/Ms2Dec.cs
@@ -119,15 +119,17 @@ public sealed class Ms2Dec
     }
 
     private static List<SpectrumPeak> GetCuratedSpectrum(RawSpectrum ms2Spectrum, double precursorMz, MsdialImmsParameter parameter) {
-
         //first, the MS/MS spectrum at the scan point of peak top is stored.
+        var amplitudeTop = ms2Spectrum.Spectrum.DefaultIfEmpty().Max(p => p.Intensity);
+        var amplitudeThreshold = Math.Max((float)amplitudeTop * parameter.ChromDecBaseParam.RelativeAmplitudeCutoff, parameter.ChromDecBaseParam.AmplitudeCutoff);
         var cSpectrum = DataAccess.GetCentroidMassSpectra(
-            ms2Spectrum, parameter.MS2DataType, parameter.ChromDecBaseParam.AmplitudeCutoff,
+            ms2Spectrum, parameter.MS2DataType, amplitudeThreshold,
             parameter.Ms2MassRangeBegin, parameter.Ms2MassRangeEnd);
         if (cSpectrum.IsEmptyOrNull())
-            return new List<SpectrumPeak>();
+            return [];
 
-        var threshold = Math.Max(parameter.ChromDecBaseParam.AmplitudeCutoff, 0.1);
+        amplitudeTop = cSpectrum.DefaultIfEmpty().Max(p => p?.Intensity) ?? 0d;
+        var threshold = Math.Max(Math.Max(amplitudeTop * parameter.ChromDecBaseParam.RelativeAmplitudeCutoff, parameter.ChromDecBaseParam.AmplitudeCutoff), 0.1);
         var curatedSpectra = cSpectrum.Where(n => n.Intensity > threshold);
 
         if (parameter.RemoveAfterPrecursor)

--- a/src/MSDIAL5/MsdialImmsCore/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialImmsCore/Algorithm/Ms2Dec.cs
@@ -122,12 +122,12 @@ public sealed class Ms2Dec
 
         //first, the MS/MS spectrum at the scan point of peak top is stored.
         var cSpectrum = DataAccess.GetCentroidMassSpectra(
-            ms2Spectrum, parameter.MS2DataType, parameter.AmplitudeCutoff,
+            ms2Spectrum, parameter.MS2DataType, parameter.ChromDecBaseParam.AmplitudeCutoff,
             parameter.Ms2MassRangeBegin, parameter.Ms2MassRangeEnd);
         if (cSpectrum.IsEmptyOrNull())
             return new List<SpectrumPeak>();
 
-        var threshold = Math.Max(parameter.AmplitudeCutoff, 0.1);
+        var threshold = Math.Max(parameter.ChromDecBaseParam.AmplitudeCutoff, 0.1);
         var curatedSpectra = cSpectrum.Where(n => n.Intensity > threshold);
 
         if (parameter.RemoveAfterPrecursor)

--- a/src/MSDIAL5/MsdialLcImMsApi/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialLcImMsApi/Algorithm/Ms2Dec.cs
@@ -51,17 +51,21 @@ public sealed class Ms2Dec {
         }
         else {
             if (targetSpecID < 0) {
-                cSpectrum = new List<SpectrumPeak>();
+                cSpectrum = [];
             }
             else {
-                cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType, param.ChromDecBaseParam.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
+                var spectrum = provider.LoadMsSpectrumFromIndex(targetSpecID);
+                var intensityTop = spectrum.Spectrum.DefaultIfEmpty().Max(p => p.Intensity);
+                var intensityThreshold = Math.Max((float)intensityTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff, param.ChromDecBaseParam.AmplitudeCutoff);
+                cSpectrum = DataAccess.GetCentroidMassSpectra(spectrum, param.MS2DataType, intensityThreshold, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
             }
         }
         if (cSpectrum.IsEmptyOrNull()) return MSDecObjectHandler.GetDefaultMSDecResult(dtChromPeak);
 
-        var precursorMz = rtChromPeak.Mass;
+        var precursorMz = rtChromPeak.PeakFeature.Mass;
         var curatedSpectra = new List<SpectrumPeak>(); // used for normalization of MS/MS intensities
-        var threshold = Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, 0.1);
+        var amplitudeTop = cSpectrum.DefaultIfEmpty().Max(p => p?.Intensity) ?? 0d;
+        var threshold = Math.Max(Math.Max(amplitudeTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff, param.ChromDecBaseParam.AmplitudeCutoff), 0.1);
         foreach (var peak in cSpectrum.Where(n => n.Intensity > threshold)) { //preparing MS/MS chromatograms -> peaklistList
             if (param.RemoveAfterPrecursor && precursorMz + param.KeptIsotopeRange < peak.Mass) continue;
             curatedSpectra.Add(peak);

--- a/src/MSDIAL5/MsdialLcImMsApi/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialLcImMsApi/Algorithm/Ms2Dec.cs
@@ -54,14 +54,14 @@ public sealed class Ms2Dec {
                 cSpectrum = new List<SpectrumPeak>();
             }
             else {
-                cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType, param.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
+                cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType, param.ChromDecBaseParam.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
             }
         }
         if (cSpectrum.IsEmptyOrNull()) return MSDecObjectHandler.GetDefaultMSDecResult(dtChromPeak);
 
         var precursorMz = rtChromPeak.Mass;
         var curatedSpectra = new List<SpectrumPeak>(); // used for normalization of MS/MS intensities
-        var threshold = Math.Max(param.AmplitudeCutoff, 0.1);
+        var threshold = Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, 0.1);
         foreach (var peak in cSpectrum.Where(n => n.Intensity > threshold)) { //preparing MS/MS chromatograms -> peaklistList
             if (param.RemoveAfterPrecursor && precursorMz + param.KeptIsotopeRange < peak.Mass) continue;
             curatedSpectra.Add(peak);

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Ms2Dec.cs
@@ -77,12 +77,12 @@ namespace CompMs.MsdialLcMsApi.Algorithm {
             //first, the MS/MS spectrum at the scan point of peak top is stored.
             if (targetSpecID < 0) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
             var cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType,
-                param.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
+                param.ChromDecBaseParam.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
             if (cSpectrum.IsEmptyOrNull()) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
 
             var curatedSpectra = new List<SpectrumPeak>(); // used for normalization of MS/MS intensities
             var precursorMz = chromPeakFeature.Mass;
-            var threshold = Math.Max(param.AmplitudeCutoff, 0.1);
+            var threshold = Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, 0.1);
 
             foreach (var peak in cSpectrum.Where(n => n.Intensity > threshold)) { //preparing MS/MS chromatograms -> peaklistList
                 if (param.RemoveAfterPrecursor && precursorMz + param.KeptIsotopeRange < peak.Mass) continue;

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Ms2Dec.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Ms2Dec.cs
@@ -76,13 +76,17 @@ namespace CompMs.MsdialLcMsApi.Algorithm {
 
             //first, the MS/MS spectrum at the scan point of peak top is stored.
             if (targetSpecID < 0) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
-            var cSpectrum = DataAccess.GetCentroidMassSpectra(provider.LoadMsSpectrumFromIndex(targetSpecID), param.MS2DataType,
-                param.ChromDecBaseParam.AmplitudeCutoff, param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
+            RawSpectrum spectrum = provider.LoadMsSpectrumFromIndex(targetSpecID);
+            var intensityTop = spectrum.Spectrum.DefaultIfEmpty().Max(p => p.Intensity);
+            var cSpectrum = DataAccess.GetCentroidMassSpectra(spectrum, param.MS2DataType,
+                Math.Max((float)intensityTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff, param.ChromDecBaseParam.AmplitudeCutoff),
+                param.Ms2MassRangeBegin, param.Ms2MassRangeEnd);
             if (cSpectrum.IsEmptyOrNull()) return MSDecObjectHandler.GetDefaultMSDecResult(chromPeakFeature);
 
             var curatedSpectra = new List<SpectrumPeak>(); // used for normalization of MS/MS intensities
-            var precursorMz = chromPeakFeature.Mass;
-            var threshold = Math.Max(param.ChromDecBaseParam.AmplitudeCutoff, 0.1);
+            var precursorMz = chromPeakFeature.PeakFeature.Mass;
+            var amplitudeTop = cSpectrum.DefaultIfEmpty().Max(p => p?.Intensity) ?? 0d;
+            var threshold = Math.Max(Math.Max(amplitudeTop * param.ChromDecBaseParam.RelativeAmplitudeCutoff, param.ChromDecBaseParam.AmplitudeCutoff), 0.1);
 
             foreach (var peak in cSpectrum.Where(n => n.Intensity > threshold)) { //preparing MS/MS chromatograms -> peaklistList
                 if (param.RemoveAfterPrecursor && precursorMz + param.KeptIsotopeRange < peak.Mass) continue;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -383,7 +383,7 @@ namespace CompMs.App.MsdialConsole.Parser
 
                 //Deconvolution
                 case "sigma window valueLower": if (float.TryParse(valueLower, out float sigmaWindow)) param.SigmaWindowValue = sigmaWindow; return true;
-                case "amplitude cut off": if (float.TryParse(valueLower, out float ms2ampthreshold)) param.AmplitudeCutoff = ms2ampthreshold; return true;
+                case "amplitude cut off": if (float.TryParse(valueLower, out float ms2ampthreshold)) param.ChromDecBaseParam.AmplitudeCutoff = ms2ampthreshold; return true;
                 case "keep isotope range": if (float.TryParse(valueLower, out float keepisotoperange)) param.KeptIsotopeRange = keepisotoperange; return true;
                 case "exclude after precursor": if (valueLower == "false") param.RemoveAfterPrecursor = false; return true;
                 case "keep original precursor isotopes": if (valueLower == "false") param.KeepOriginalPrecursorIsotopes = false; return true;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -384,6 +384,7 @@ namespace CompMs.App.MsdialConsole.Parser
                 //Deconvolution
                 case "sigma window valueLower": if (float.TryParse(valueLower, out float sigmaWindow)) param.SigmaWindowValue = sigmaWindow; return true;
                 case "amplitude cut off": if (float.TryParse(valueLower, out float ms2ampthreshold)) param.ChromDecBaseParam.AmplitudeCutoff = ms2ampthreshold; return true;
+                case "relative amplitude cut off": if (float.TryParse(valueLower, out float ms2relativeampthreshold)) param.ChromDecBaseParam.RelativeAmplitudeCutoff = ms2relativeampthreshold; return true;
                 case "keep isotope range": if (float.TryParse(valueLower, out float keepisotoperange)) param.KeptIsotopeRange = keepisotoperange; return true;
                 case "exclude after precursor": if (valueLower == "false") param.RemoveAfterPrecursor = false; return true;
                 case "keep original precursor isotopes": if (valueLower == "false") param.KeepOriginalPrecursorIsotopes = false; return true;


### PR DESCRIPTION
#### PR Classification  
New feature  

#### PR Summary  
Introduces a `RelativeAmplitudeCutoff` parameter for flexible spectrum filtering based on relative intensity thresholds, complementing the existing absolute threshold. Updates span core logic, UI, ViewModel, and configuration parsing for seamless integration.  
- **`MSDecHandler.cs`**: Updated spectrum filtering logic to use both relative and absolute amplitude cutoffs.  
- **`ParameterBase.cs`**: Added `RelativeAmplitudeCutoff` property with default value and updated `ToString` method.  
- **`DeconvolutionSettingView.xaml`**: Added UI input for `RelativeAmplitudeCutoff` with validation and tooltips.  
- **`ConfigParser.cs`**: Enabled parsing of `RelativeAmplitudeCutoff` from configuration files.  
- **`Ms2Dec.cs`**: Enhanced MS/MS spectrum handling to incorporate the new parameter in intensity threshold calculations.  
