### PR TITLE
Handle null or empty exp_spectrum in calculations

### DIFF
--- a/src/Common/CommonStandard/Lipidomics/EieioMsCharacterizationUtility.cs
+++ b/src/Common/CommonStandard/Lipidomics/EieioMsCharacterizationUtility.cs
@@ -420,7 +420,7 @@ namespace CompMs.Common.Lipidomics
             var adduct = reference.AdductType;
 
             var result = new LipidMsCharacterizationResult();
-            var minimumPeakIntensity = exp_spectrum.Min(n => n.Intensity);
+            var minimumPeakIntensity = exp_spectrum?.DefaultIfEmpty().Min(n => n?.Intensity) ?? 0d;
             var minimumPeakIntensityFactor = 2.0;
 
             var matchedpeaks = MsScanMatching.GetMachedSpectralPeaks(exp_spectrum, ref_spectrum, tolerance, mzBegin, mzEnd);


### PR DESCRIPTION
Handle null or empty exp_spectrum in calculations

Updated the calculation of minimumPeakIntensity to safely handle cases where exp_spectrum may be null or empty. Utilized the null-conditional operator and DefaultIfEmpty() to ensure a default value of 0 is returned, preventing potential exceptions.