### PR TITLE
Added ExecuteChromDeconvolution Option to Control Chromatogram-Based Deconvolution

### DIFF
--- a/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
+++ b/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
@@ -1226,6 +1226,8 @@ namespace CompMs.MsdialCore.Parameter
         public double TargetCE { get; set; } = 0; // used for AIF deconvolution. Zero means that min CE is used for MS1 
         [Key(9)]
         public float RelativeAmplitudeCutoff { get; set; } = 0;
+        [Key(10)]
+        public bool ExecuteChromDeconvolution { get; set; } = true;
     }
 
     [MessagePackObject]

--- a/src/MSDIAL5/MsdialGuiApp/Model/Setting/DeconvolutionSettingModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Setting/DeconvolutionSettingModel.cs
@@ -17,6 +17,7 @@ namespace CompMs.App.Msdial.Model.Setting
             RemoveAfterPrecursor = parameter.RemoveAfterPrecursor;
             KeptIsotopeRange = parameter.KeptIsotopeRange;
             KeepOriginalPrecurosrIsotopes = parameter.KeepOriginalPrecursorIsotopes;
+            ExecuteChromDeconvolution = parameter.ExecuteChromDeconvolution;
         }
 
         public bool IsReadOnly { get; }
@@ -57,6 +58,12 @@ namespace CompMs.App.Msdial.Model.Setting
         }
         private bool _keepOriginalPrecurosrIsotopes;
 
+        public bool ExecuteChromDeconvolution {
+            get => _executeChromDeconvolution;
+            set => SetProperty(ref _executeChromDeconvolution, value);
+        }
+        private bool _executeChromDeconvolution;
+
         public void Commit() {
             if (IsReadOnly) {
                 return;
@@ -67,6 +74,7 @@ namespace CompMs.App.Msdial.Model.Setting
             _parameter.RemoveAfterPrecursor = RemoveAfterPrecursor;
             _parameter.KeptIsotopeRange = KeptIsotopeRange;
             _parameter.KeepOriginalPrecursorIsotopes = KeepOriginalPrecurosrIsotopes;
+            _parameter.ExecuteChromDeconvolution = ExecuteChromDeconvolution;
         }
 
         public void LoadParameter(ChromDecBaseParameter parameter) {
@@ -79,6 +87,7 @@ namespace CompMs.App.Msdial.Model.Setting
             RemoveAfterPrecursor = parameter.RemoveAfterPrecursor;
             KeptIsotopeRange = parameter.KeptIsotopeRange;
             KeepOriginalPrecurosrIsotopes = parameter.KeepOriginalPrecursorIsotopes;
+            ExecuteChromDeconvolution = parameter.ExecuteChromDeconvolution;
         }
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/View/Setting/DeconvolutionSettingView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Setting/DeconvolutionSettingView.xaml
@@ -81,6 +81,17 @@
                               IsEnabled="{Binding IsReadOnly, Mode=OneTime, Converter={StaticResource NegativeConverter}}"
                               ToolTip="If you want to keep the original precursor's isotopic ions, please check."/>
                 </ui:LabeledContent>
+
+                <ui:LabeledContent PrependLabel="Run RT deconvolution:"
+                                   Style="{StaticResource AlignedContent}">
+                    <CheckBox IsChecked="{Binding Path=ExecuteChromDeconvolution.Value}"
+                              IsEnabled="{Binding IsReadOnly, Mode=OneTime, Converter={StaticResource NegativeConverter}}" />
+                    <ui:LabeledContent.ToolTip>
+                        <TextBlock>
+                            If unchecked, chromatogram based deconvolution will not be executed.
+                        </TextBlock>
+                    </ui:LabeledContent.ToolTip>
+                </ui:LabeledContent>
             </StackPanel>
         </Expander>
     </Grid>

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DeconvolutionSettingViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Setting/DeconvolutionSettingViewModel.cs
@@ -50,6 +50,8 @@ namespace CompMs.App.Msdial.ViewModel.Setting
 
             KeepOriginalPrecurosrIsotopes = model.ToReactivePropertySlimAsSynchronized(m => m.KeepOriginalPrecurosrIsotopes).AddTo(Disposables);
 
+            ExecuteChromDeconvolution = model.ToReactivePropertySlimAsSynchronized(m => m.ExecuteChromDeconvolution).AddTo(Disposables);
+
             IsEnabled = isEnabled.ToReadOnlyReactivePropertySlim().AddTo(Disposables);
 
             ObserveHasErrors = new[]
@@ -70,6 +72,7 @@ namespace CompMs.App.Msdial.ViewModel.Setting
                 RemoveAfterPrecursor.ToUnit(),
                 KeptIsotopeRange.ToUnit(),
                 KeepOriginalPrecurosrIsotopes.ToUnit(),
+                ExecuteChromDeconvolution.ToUnit(),
             }.Merge();
 
             decide = new Subject<Unit>().AddTo(Disposables);
@@ -108,6 +111,8 @@ namespace CompMs.App.Msdial.ViewModel.Setting
         public ReactiveProperty<string> KeptIsotopeRange { get; }
 
         public ReactivePropertySlim<bool> KeepOriginalPrecurosrIsotopes { get; }
+
+        public ReactivePropertySlim<bool> ExecuteChromDeconvolution { get; }
 
         public ReadOnlyReactivePropertySlim<bool> IsEnabled { get; }
 


### PR DESCRIPTION
#### PR Classification
New feature to enhance chromatogram deconvolution functionality.

#### PR Summary
This pull request introduces a new boolean property `ExecuteChromDeconvolution` to control the execution of chromatogram-based deconvolution. It includes updates to the model, view model, and UI to support this feature.
- `ParameterBase.cs`: Added `ExecuteChromDeconvolution` property with a default value of `true`.
- `DeconvolutionSettingModel.cs`: Integrated `ExecuteChromDeconvolution` into the model and updated the `Commit` method to save its state.
- `DeconvolutionSettingView.xaml`: Added a checkbox in the UI for users to enable or disable `ExecuteChromDeconvolution`.
- `DeconvolutionSettingViewModel.cs`: Created a reactive property for `ExecuteChromDeconvolution` to synchronize with the model and included it in error observation logic.
