### PR TITLE
Restrict MSDIAL Artifact Publishing Jobs to Push Events Only

### DIFF
--- a/.github/workflows/dotnet_test.yml
+++ b/.github/workflows/dotnet_test.yml
@@ -37,6 +37,7 @@ jobs:
 
   publish-msdial5:
     needs: test
+    if: github.event_name == 'push'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +63,7 @@ jobs:
 
   publish-msdial5-console:
     needs: test
+    if: github.event_name == 'push'
     runs-on: ${{ matrix.triple.os }}
     strategy:
       matrix:
@@ -97,6 +99,7 @@ jobs:
 
   publish-msdial4:
     needs: test
+    if: github.event_name == 'push'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -122,6 +125,7 @@ jobs:
 
   publish-msdial4-console:
     needs: test
+    if: github.event_name == 'push'
     runs-on: ${{ matrix.pair.os }}
     strategy:
       matrix:

--- a/src/MSDIAL5/MsdialGuiApp/App.xaml.cs
+++ b/src/MSDIAL5/MsdialGuiApp/App.xaml.cs
@@ -24,6 +24,9 @@ namespace CompMs.App.Msdial
         }
 
         private void LogUnhandledException(Exception exception, string source) {
+            while (exception is AggregateException agg) {
+                exception = agg.InnerException;
+            }
             // Log the exception
             string message = $"Unhandled exception ({source})";
             try


### PR DESCRIPTION
Added four publishing jobs for MSDIAL4 and MSDIAL5 artifacts to the dotnet_test.yml file. Configured these jobs—publish-msdial5, publish-msdial5-console, publish-msdial4, and publish-msdial4-console—to run only on push events, ensuring they do not execute during pull requests.