### PR TITLE
Add SpectrumLabel and label selection to UI

### DIFF
--- a/src/MSDIAL5/SpectrumViewer/Model/DisplayScan.cs
+++ b/src/MSDIAL5/SpectrumViewer/Model/DisplayScan.cs
@@ -4,6 +4,7 @@ using CompMs.Common.Interfaces;
 using CompMs.CommonMVVM;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CompMs.App.SpectrumViewer.Model
 {
@@ -35,6 +36,7 @@ namespace CompMs.App.SpectrumViewer.Model
         public ChromXs ChromXs { get => Scan.ChromXs; set => Scan.ChromXs = value; }
         public IonMode IonMode { get => Scan.IonMode; set => Scan.IonMode = value; }
         public double PrecursorMz { get => Scan.PrecursorMz; set => Scan.PrecursorMz = value; }
+        public object[] SpectrumLabel => Scan.Spectrum.Select(p => new { p.Mass, p.Intensity, NeutralLoss = p.Mass - Scan.PrecursorMz }).ToArray();
 
         public void AddPeak(double mass, double intensity, string comment = null) {
             Scan.AddPeak(mass, intensity, comment);

--- a/src/MSDIAL5/SpectrumViewer/View/ViewTemplates.xaml
+++ b/src/MSDIAL5/SpectrumViewer/View/ViewTemplates.xaml
@@ -370,12 +370,13 @@
                                                         </ToolTip>
                                                     </chart:LineSpectrumControlSlim.ToolTip>
                                                 </chart:LineSpectrumControlSlim>
-                                                <chart:Annotator ItemsSource="{Binding Spectrum}"
+                                                <chart:Annotator ItemsSource="{Binding Path=SpectrumLabel}"
                                                                  HorizontalPropertyName="Mass"
                                                                  VerticalPropertyName="Intensity"
                                                                  Overlap="Direct, Horizontal"
                                                                  OrderingPropertyName="Intensity"
-                                                                 LabelPropertyName="Mass"
+                                                                 LabelPropertyName="{Binding Path=DataContext.LabelProperty.Value, FallbackValue=Mass,
+                                                                                             RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                                  Format="N4"
                                                                  TopN="10"
                                                                  Brush="{Binding Path=(ItemsControl.AlternationIndex),
@@ -438,12 +439,13 @@
                                                         </ToolTip>
                                                     </chart:LineSpectrumControlSlim.ToolTip>
                                                 </chart:LineSpectrumControlSlim>
-                                                <chart:Annotator ItemsSource="{Binding Spectrum}"
+                                                <chart:Annotator ItemsSource="{Binding Path=SpectrumLabel}"
                                                                  HorizontalPropertyName="Mass"
                                                                  VerticalPropertyName="Intensity"
                                                                  Overlap="Direct, Horizontal"
                                                                  OrderingPropertyName="Intensity"
-                                                                 LabelPropertyName="Mass"
+                                                                 LabelPropertyName="{Binding Path=DataContext.LabelProperty.Value, FallbackValue=Mass,
+                                                                                             RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                                  Format="N4"
                                                                  TopN="10"
                                                                  Brush="{Binding Path=(ItemsControl.AlternationIndex),
@@ -853,6 +855,14 @@
                 <StackPanel Orientation="Horizontal" Margin="8,0">
                     <TextBlock Text="Lower label:" Margin="0,0,4,0" Foreground="White" VerticalAlignment="Center"/>
                     <CheckBox IsChecked="{Binding LowerSpectrumsViewModel.IsLabelVisible.Value}" VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="8,0">
+                    <TextBlock Text="Label type:" Margin="0,0,4,0" Foreground="White" VerticalAlignment="Center"/>
+                    <ComboBox SelectedValuePath="Tag" SelectedIndex="0"
+                              SelectedValue="{Binding Path=LabelProperty.Value, Mode=OneWayToSource}">
+                        <ComboBoxItem Content="m/z" Tag="Mass"/>
+                        <ComboBoxItem Content="NL" Tag="NeutralLoss"/>
+                    </ComboBox>
                 </StackPanel>
             </StackPanel>
             <ContentControl Style="{StaticResource ViewChartStyle}"

--- a/src/MSDIAL5/SpectrumViewer/ViewModel/SplitSpectrumsViewModel.cs
+++ b/src/MSDIAL5/SpectrumViewer/ViewModel/SplitSpectrumsViewModel.cs
@@ -104,6 +104,8 @@ namespace CompMs.App.SpectrumViewer.ViewModel
             RemoveScanCommand = new ReactiveCommand()
                 .WithSubscribe(model.RemoveScan)
                 .AddTo(Disposables);
+
+            LabelProperty = new ReactiveProperty<string>(string.Empty).AddTo(Disposables);
         }
 
         public SplitSpectrumsModel Model { get; }
@@ -131,5 +133,7 @@ namespace CompMs.App.SpectrumViewer.ViewModel
         public ReactiveCommand ShiftScanCommand { get; }
 
         public ReactiveCommand RemoveScanCommand { get; }
+
+        public ReactiveProperty<string> LabelProperty { get; }
     }
 }


### PR DESCRIPTION
Add SpectrumLabel and label selection to UI

- Updated DisplayScan to include SpectrumLabel for detailed peak information.
- Changed ViewTemplates to bind chart:Annotator to SpectrumLabel.
- Added ComboBox for selecting label type (m/z or NL) in the UI.
- Introduced LabelProperty in SplitSpectrumsViewModel for binding.