### PR TITLE
Add ignoreRtCorrection support in measurement loading

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/BaseDataProvider.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/BaseDataProvider.cs
@@ -49,8 +49,9 @@ namespace CompMs.MsdialCore.Algorithm
             });
         }
 
-        protected static async Task<RawMeasurement> LoadMeasurementAsync(AnalysisFileBean file, bool isProfile, bool isImagingMs, bool isGuiProcess, int retry, CancellationToken token) {
-            using (var access = new RawDataAccess(file.AnalysisFilePath, 0, isProfile, isImagingMs, isGuiProcess, file.RetentionTimeCorrectionBean.PredictedRt)) {
+        protected static async Task<RawMeasurement> LoadMeasurementAsync(AnalysisFileBean file, bool isProfile, bool isImagingMs, bool isGuiProcess, int retry, bool ignoreRtCorrection, CancellationToken token) {
+            List<double> correctedRts = ignoreRtCorrection ? null : file.RetentionTimeCorrectionBean.PredictedRt;
+            using (var access = new RawDataAccess(file.AnalysisFilePath, 0, isProfile, isImagingMs, isGuiProcess, correctedRts)) {
                 for (var i = 0; i < retry; i++) {
                     var rawObj = await Task.Run(() => access.GetMeasurement(), token).ConfigureAwait(false);
                     if (rawObj != null) {

--- a/src/MSDIAL5/MsdialCore/Algorithm/StandardDataProvider.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/StandardDataProvider.cs
@@ -15,14 +15,37 @@ namespace CompMs.MsdialCore.Algorithm
 
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardDataProvider"/> class.
+        /// This constructor loads raw measurement data asynchronously based on the provided parameters.
+        /// </summary>
+        /// <param name="file">The analysis file containing the raw measurement data.</param>
+        /// <param name="isImagingMs">Indicates whether the data is from imaging mass spectrometry.</param>
+        /// <param name="isGuiProcess">Indicates whether the process is running in a GUI context.</param>
+        /// <param name="retry">The number of retry attempts for loading the measurement data.</param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
         public StandardDataProvider(AnalysisFileBean file, bool isImagingMs, bool isGuiProcess, int retry, CancellationToken token = default)
-            : base(LoadMeasurementAsync(file, false, isImagingMs, isGuiProcess, retry, token)) {
+            : base(LoadMeasurementAsync(file, false, isImagingMs, isGuiProcess, retry, false, token)) {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardDataProvider"/> class.
+        /// This constructor loads raw measurement data asynchronously based on the provided parameters.
+        /// </summary>
+        /// <param name="file">The analysis file containing the raw measurement data.</param>
+        /// <param name="isImagingMs">Indicates whether the data is from imaging mass spectrometry.</param>
+        /// <param name="isGuiProcess">Indicates whether the process is running in a GUI context.</param>
+        /// <param name="retry">The number of retry attempts for loading the measurement data.</param>
+        /// <param name="ignoreRtCorrection">Specifies whether to ignore retention time correction during data loading.</param>
+        /// <param name="token">A cancellation token to observe while waiting for the task to complete.</param>
+        public StandardDataProvider(AnalysisFileBean file, bool isImagingMs, bool isGuiProcess, int retry, bool ignoreRtCorrection, CancellationToken token = default)
+            : base(LoadMeasurementAsync(file, false, isImagingMs, isGuiProcess, retry, ignoreRtCorrection, token)) {
 
         }
     }
 
-    public class StandardDataProviderFactory
-        : IDataProviderFactory<AnalysisFileBean>, IDataProviderFactory<RawMeasurement>
+    public class StandardDataProviderFactory : IDataProviderFactory<AnalysisFileBean>, IDataProviderFactory<RawMeasurement>
     {
         public StandardDataProviderFactory(int retry = 5, bool isGuiProcess = false) {
             this.retry = retry;
@@ -32,8 +55,13 @@ namespace CompMs.MsdialCore.Algorithm
         private readonly bool isGuiProcess;
         private readonly int retry = 5;
 
+        /// <summary>
+        /// Whether to ignore RT correction when reading raw spectra.
+        /// </summary>
+        public bool IgnoreRtCorrection { get; set; } = false;
+
         public IDataProvider Create(AnalysisFileBean file) {
-            return new StandardDataProvider(file, false, isGuiProcess, retry);
+            return new StandardDataProvider(file, false, isGuiProcess, retry, IgnoreRtCorrection);
         }
 
         public IDataProvider Create(RawMeasurement rawMeasurement) {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Core/RtCorrectionProcessModelLegacy.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Core/RtCorrectionProcessModelLegacy.cs
@@ -82,7 +82,7 @@ namespace CompMs.App.Msdial.Model.Core
                 MaxDegreeOfParallelism = param.NumThreads
             };
             System.Threading.Tasks.Parallel.ForEach(files, parallelOptions, f => {
-                StandardDataProviderFactory factory = new StandardDataProviderFactory();
+                StandardDataProviderFactory factory = new StandardDataProviderFactory() { IgnoreRtCorrection = true, };
                 var provider = factory.Create(f);
                 RetentionTimeCorrection.Execute(f, param, provider);
                 _bgWorker!.ReportProgress(1);


### PR DESCRIPTION
Add ignoreRtCorrection support in measurement loading

- Modified LoadMeasurementAsync to accept ignoreRtCorrection parameter.
- Added new constructor in StandardDataProvider for ignoreRtCorrection.
- Updated StandardDataProviderFactory to include IgnoreRtCorrection property.
- Set IgnoreRtCorrection to true in RtCorrectionProcessModelLegacy for parallel processing.
- Enhanced documentation for StandardDataProvider constructors.