### PR TITLE
Fix: Incorrect standard deviation calculation in lowess cross-validation

### DIFF
--- a/src/Common/CommonStandard/Mathematics/Mathematics/SmootherMathematics.cs
+++ b/src/Common/CommonStandard/Mathematics/Mathematics/SmootherMathematics.cs
@@ -232,13 +232,14 @@ namespace CompMs.Common.Mathematics.Basic {
                     var fittedValue = 0.0;
                     var aveQcValue = BasicMathematics.Mean(yTrain);
 
+                    var localDevi = 0d;
                     for (int j = 0; j < xTest.Length; j++)
                     {
                         fittedValue = SmootherMathematics.Splint(xTrain, yLoessPreArray, ySplineDeviArray, xTest[j]);
                         if (fittedValue <= 0) fittedValue = aveQcValue;
-                        devi += Math.Pow(fittedValue - yTest[j], 2);
+                        localDevi += Math.Pow(fittedValue - yTest[j], 2);
                     }
-                    devi = devi / (double)xTest.Length;
+                    devi += localDevi / (double)xTest.Length;
                     counter++;
                 }
 


### PR DESCRIPTION
Fix: Incorrect standard deviation calculation in lowess cross-validation

`devi` was averaged in every outer loop iteration; now it’s accumulated
via `localDevi` to compute the correct cross-validation deviation.