### PR TITLE
Adjust min chain length in EadLipidAnnotator to 8

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/Annotation/EadLipidAnnotator.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Annotation/EadLipidAnnotator.cs
@@ -25,7 +25,7 @@ namespace CompMs.MsdialCore.Algorithm.Annotation
         private readonly LipidDescription _description;
 
         public EadLipidAnnotator(EadLipidDatabase db, string id, int priority, MsRefSearchParameterBase parameter) {
-            _lipidGenerator = new DGTSLipidGeneratorDecorator(new LipidGenerator(new TotalChainVariationGenerator(chainGenerator: new Omega3nChainGenerator(), minLength: 12)));
+            _lipidGenerator = new DGTSLipidGeneratorDecorator(new LipidGenerator(new TotalChainVariationGenerator(chainGenerator: new Omega3nChainGenerator(), minLength: 8)));
             _description = LipidDescription.Class | LipidDescription.Chain | LipidDescription.SnPosition | LipidDescription.DoubleBondPosition;
 
             Id = id ?? throw new ArgumentNullException(nameof(id));


### PR DESCRIPTION
Changed the minimum chain length parameter for the TotalChainVariationGenerator within the EadLipidAnnotator constructor from 12 to 8. This allows shorter lipid chains to be considered in the lipid generation process.