### PR TITLE
Fix console CSV metadata and vendor folder inputs

### DIFF
--- a/src/MSDIAL5/MsdialCore/Export/MztabFormatExport.cs
+++ b/src/MSDIAL5/MsdialCore/Export/MztabFormatExport.cs
@@ -979,7 +979,7 @@ namespace CompMs.MsdialCore.Export
             AlignmentSpotProperty spot
         )
         {
-            return new List<string>() { ValueOrNull(spot.Ontology.ToString()) };
+            return new List<string>() { ValueOrNull(spot.Ontology) };
         }
         private static IReadOnlyDictionary<int, string> SetStandardDic(
         IReadOnlyList<AlignmentSpotProperty> spots
@@ -1339,7 +1339,7 @@ namespace CompMs.MsdialCore.Export
         }
 
         static string UnknownIfEmpty(string value) => string.IsNullOrEmpty(value) ? "Unknown" : value;
-        static string ValueOrNull(string value) => string.IsNullOrEmpty(value) ? "null" : value;
+        static string ValueOrNull(string? value) => string.IsNullOrEmpty(value) ? "null" : value;
 
 
         public class Database

--- a/src/MSDIAL5/MsdialGcMsApi/Export/GcmsAnalysisMetadataAccessor.cs
+++ b/src/MSDIAL5/MsdialGcMsApi/Export/GcmsAnalysisMetadataAccessor.cs
@@ -41,6 +41,7 @@ namespace CompMs.MsdialGcMsApi.Export
                 "Simple dot product",
                 "Weighted dot product",
                 "Reverse dot product",
+                "Matched peaks count",
                 "Fragment presence %",
                 "Total score",
                 "Spectrum"
@@ -69,6 +70,7 @@ namespace CompMs.MsdialGcMsApi.Export
                 ["Simple dot product"] = NegativeIfNull(matchResult?.SimpleDotProduct, "F2"),
                 ["Weighted dot product"] = NegativeIfNull(matchResult?.WeightedDotProduct, "F2"),
                 ["Reverse dot product"] = NegativeIfNull(matchResult?.ReverseDotProduct, "F2"),
+                ["Matched peaks count"] = NegativeIfNull(matchResult?.MatchedPeaksCount, "F0"),
                 ["Fragment presence %"] = NegativeIfNull(matchResult?.MatchedPeaksPercentage, "F2"),
                 ["Total score"] = NegativeIfNull(matchResult?.TotalScore, "F2"),
                 ["Spectrum"] = EncodeSpectrum(scan),

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/AnalysisFilesParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/AnalysisFilesParser.cs
@@ -132,7 +132,7 @@ namespace CompMs.App.MsdialConsole.Parser
                 //var afFilepath = Path.GetFullPath(Path.Combine(line[0], Path.GetDirectoryName(Path.GetFullPath(filepath))));
                 var afFilepath = Path.GetFullPath(line[0]);
                 Debug.WriteLine("afFilepath: {0}", afFilepath, "");
-                if (System.IO.File.Exists(afFilepath) == false)
+                if (!System.IO.File.Exists(afFilepath) && !System.IO.Directory.Exists(afFilepath))
                 {
                     throw new FileNotFoundException("File not found: " + afFilepath);
                 }
@@ -208,12 +208,13 @@ namespace CompMs.App.MsdialConsole.Parser
 
         public static List<AnalysisFileBean> ReadFolderContents(string folderpath)
         {
-            var filepathes = Directory.GetFiles(folderpath, "*.*", SearchOption.TopDirectoryOnly);
             var importableFiles = new List<string>();
 
-            foreach (var file in filepathes) {
-                if (DataAccess.IsDataFormatSupported(file)) {
-                    importableFiles.Add(file);
+            foreach (var path in Directory.EnumerateFileSystemEntries(folderpath, "*", SearchOption.TopDirectoryOnly)) {
+                var extension = Path.GetExtension(path).ToLowerInvariant();
+                var isVendorDirectory = Directory.Exists(path) && (extension == ".raw" || extension == ".d");
+                if (isVendorDirectory || DataAccess.IsDataFormatSupported(path)) {
+                    importableFiles.Add(path);
                 }
             }
 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -149,6 +149,7 @@ namespace CompMs.App.MsdialConsole.Parser
                         param.RetentionType = (RetentionType)Enum.Parse(typeof(RetentionType), value, true);
                     return true;
                 case "ri compound":
+                case "ri compound type":
                     if (value == "fames" || value == "alkanes")
                         param.RiCompoundType = (RiCompoundType)Enum.Parse(typeof(RiCompoundType), value, true);
                     return true;
@@ -357,8 +358,8 @@ namespace CompMs.App.MsdialConsole.Parser
 
                 //Peak detection param
                 case "smoothing method":
-                    if (valueLower == "simplemovingaverage" || valueLower == "linearweightedmovingaverage" || valueLower == "savitzkygolayfilter" || valueLower == "binomialfilter")
-                        param.SmoothingMethod = (SmoothingMethod)Enum.Parse(typeof(SmoothingMethod), valueLower, true);
+                    if (Enum.TryParse(value, true, out SmoothingMethod smoothingMethod))
+                        param.SmoothingMethod = smoothingMethod;
                     return true;
                 case "smoothing level": if (int.TryParse(valueLower, out int smoothlevel)) param.SmoothingLevel = smoothlevel; return true;
                 case "average peak width": if (int.TryParse(valueLower, out int avepeakwidth)) param.AveragePeakWidth = avepeakwidth; return true;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -76,6 +76,18 @@ namespace CompMs.App.MsdialConsole.Parser
             return ReadMspAnnotatorSettingsTable(settingsFilePath, param);
         }
 
+        public static List<TextAnnotatorSetting> ReadTextAnnotatorSettings(string filepath, ParameterBase param) {
+            var settingsFilePath = ReadTextAnnotatorSettingsFilePath(filepath);
+            if (settingsFilePath.IsEmptyOrNull()) {
+                return new List<TextAnnotatorSetting>();
+            }
+            if (!Path.IsPathRooted(settingsFilePath)) {
+                var baseDirectory = Path.GetDirectoryName(filepath) ?? string.Empty;
+                settingsFilePath = Path.Combine(baseDirectory, settingsFilePath);
+            }
+            return ReadTextAnnotatorSettingsTable(settingsFilePath, param);
+        }
+
         private static string ReadMspAnnotatorSettingsFilePath(string filepath) {
             using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
                 while (sr.Peek() > -1) {
@@ -87,6 +99,25 @@ namespace CompMs.App.MsdialConsole.Parser
                         case "msp annotator settings file path":
                         case "msp annotation settings file path":
                         case "msp search settings file path":
+                            return value;
+                    }
+                }
+            }
+            return string.Empty;
+        }
+
+        private static string ReadTextAnnotatorSettingsFilePath(string filepath) {
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    readFieldValues(sr.ReadLine(), out string method, out string value, out bool isReadable);
+                    if (!isReadable) {
+                        continue;
+                    }
+                    switch (method.ToLower()) {
+                        case "text annotator settings file path":
+                        case "text library annotator settings file path":
+                        case "text db annotator settings file path":
+                        case "text annotation settings file path":
                             return value;
                     }
                 }
@@ -152,6 +183,68 @@ namespace CompMs.App.MsdialConsole.Parser
                 var searchParameter = new MsRefSearchParameterBase(param.MspSearchParam);
                 ApplyMspSearchParameter(searchParameter, fields, headers);
                 settings.Add(new MspAnnotatorSetting(annotatorId, mspFilePath, priority, searchParameter));
+            }
+            return settings;
+        }
+
+        private static List<TextAnnotatorSetting> ReadTextAnnotatorSettingsTable(string filepath, ParameterBase param) {
+            if (!File.Exists(filepath)) {
+                Console.WriteLine($"Text annotator settings file was not found: {filepath}");
+                return new List<TextAnnotatorSetting>();
+            }
+
+            var rows = new List<string>();
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    var line = sr.ReadLine()?.TrimEnd('\r', '\n');
+                    if (!line.IsEmptyOrNull() && !line.TrimStart().StartsWith("#")) {
+                        rows.Add(line);
+                    }
+                }
+            }
+            if (rows.Count == 0) {
+                return new List<TextAnnotatorSetting>();
+            }
+
+            var headers = rows[0].Split('\t').Select(NormalizeHeader).ToArray();
+            var pathIndex = FindColumn(headers, "textdbfilepath", "textlibraryfilepath", "textfilepath", "filepath", "path");
+            if (pathIndex < 0) {
+                Console.WriteLine("Text annotator settings TSV requires a 'text_db_file_path' column.");
+                return new List<TextAnnotatorSetting>();
+            }
+
+            var settings = new List<TextAnnotatorSetting>();
+            var usedAnnotatorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var baseDirectory = Path.GetDirectoryName(filepath) ?? string.Empty;
+            for (var i = 1; i < rows.Count; i++) {
+                var fields = rows[i].Split('\t');
+                var textDbFilePath = GetField(fields, pathIndex);
+                if (textDbFilePath.IsEmptyOrNull()) {
+                    continue;
+                }
+                if (!Path.IsPathRooted(textDbFilePath)) {
+                    textDbFilePath = Path.Combine(baseDirectory, textDbFilePath);
+                }
+
+                var settingIndex = settings.Count + 1;
+                var annotatorId = GetField(fields, headers, "annotatorid", "id", "name");
+                if (annotatorId.IsEmptyOrNull()) {
+                    annotatorId = $"TextDB_{settingIndex}";
+                }
+                if (!usedAnnotatorIds.Add(annotatorId)) {
+                    Console.WriteLine($"Duplicated Text annotator_id was skipped: {annotatorId}");
+                    continue;
+                }
+
+                var priority = settingIndex;
+                var priorityText = GetField(fields, headers, "priority");
+                if (!priorityText.IsEmptyOrNull() && int.TryParse(priorityText, out var parsedPriority)) {
+                    priority = parsedPriority;
+                }
+
+                var searchParameter = new MsRefSearchParameterBase(param.TextDbSearchParam);
+                ApplyMspSearchParameter(searchParameter, fields, headers);
+                settings.Add(new TextAnnotatorSetting(annotatorId, textDbFilePath, priority, searchParameter));
             }
             return settings;
         }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -11,9 +11,11 @@ using CompMs.MsdialLcImMsApi.Parameter;
 using CompMs.MsdialLcmsApi.Parameter;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.IO;
 using CompMs.Common.Query;
+using CompMs.Common.Parameter;
 using System.Linq;
 
 namespace CompMs.App.MsdialConsole.Parser
@@ -60,6 +62,177 @@ namespace CompMs.App.MsdialConsole.Parser
                 }
             }
             return param;
+        }
+
+        public static List<MspAnnotatorSetting> ReadMspAnnotatorSettings(string filepath, ParameterBase param) {
+            var settingsFilePath = ReadMspAnnotatorSettingsFilePath(filepath);
+            if (settingsFilePath.IsEmptyOrNull()) {
+                return new List<MspAnnotatorSetting>();
+            }
+            if (!Path.IsPathRooted(settingsFilePath)) {
+                var baseDirectory = Path.GetDirectoryName(filepath) ?? string.Empty;
+                settingsFilePath = Path.Combine(baseDirectory, settingsFilePath);
+            }
+            return ReadMspAnnotatorSettingsTable(settingsFilePath, param);
+        }
+
+        private static string ReadMspAnnotatorSettingsFilePath(string filepath) {
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    readFieldValues(sr.ReadLine(), out string method, out string value, out bool isReadable);
+                    if (!isReadable) {
+                        continue;
+                    }
+                    switch (method.ToLower()) {
+                        case "msp annotator settings file path":
+                        case "msp annotation settings file path":
+                        case "msp search settings file path":
+                            return value;
+                    }
+                }
+            }
+            return string.Empty;
+        }
+
+        private static List<MspAnnotatorSetting> ReadMspAnnotatorSettingsTable(string filepath, ParameterBase param) {
+            if (!File.Exists(filepath)) {
+                Console.WriteLine($"MSP annotator settings file was not found: {filepath}");
+                return new List<MspAnnotatorSetting>();
+            }
+
+            var rows = new List<string>();
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    var line = sr.ReadLine()?.TrimEnd('\r', '\n');
+                    if (!line.IsEmptyOrNull() && !line.TrimStart().StartsWith("#")) {
+                        rows.Add(line);
+                    }
+                }
+            }
+            if (rows.Count == 0) {
+                return new List<MspAnnotatorSetting>();
+            }
+
+            var headers = rows[0].Split('\t').Select(NormalizeHeader).ToArray();
+            var pathIndex = FindColumn(headers, "mspfilepath", "mspfile", "filepath", "path");
+            if (pathIndex < 0) {
+                Console.WriteLine("MSP annotator settings TSV requires a 'msp_file_path' column.");
+                return new List<MspAnnotatorSetting>();
+            }
+
+            var settings = new List<MspAnnotatorSetting>();
+            var usedAnnotatorIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var baseDirectory = Path.GetDirectoryName(filepath) ?? string.Empty;
+            for (var i = 1; i < rows.Count; i++) {
+                var fields = rows[i].Split('\t');
+                var mspFilePath = GetField(fields, pathIndex);
+                if (mspFilePath.IsEmptyOrNull()) {
+                    continue;
+                }
+                if (!Path.IsPathRooted(mspFilePath)) {
+                    mspFilePath = Path.Combine(baseDirectory, mspFilePath);
+                }
+
+                var settingIndex = settings.Count + 1;
+                var annotatorId = GetField(fields, headers, "annotatorid", "id", "name");
+                if (annotatorId.IsEmptyOrNull()) {
+                    annotatorId = $"MspDB_{settingIndex}";
+                }
+                if (!usedAnnotatorIds.Add(annotatorId)) {
+                    Console.WriteLine($"Duplicated MSP annotator_id was skipped: {annotatorId}");
+                    continue;
+                }
+
+                var priority = settingIndex;
+                var priorityText = GetField(fields, headers, "priority");
+                if (!priorityText.IsEmptyOrNull() && int.TryParse(priorityText, out var parsedPriority)) {
+                    priority = parsedPriority;
+                }
+
+                var searchParameter = new MsRefSearchParameterBase(param.MspSearchParam);
+                ApplyMspSearchParameter(searchParameter, fields, headers);
+                settings.Add(new MspAnnotatorSetting(annotatorId, mspFilePath, priority, searchParameter));
+            }
+            return settings;
+        }
+
+        private static void ApplyMspSearchParameter(MsRefSearchParameterBase parameter, string[] fields, string[] headers) {
+            SetFloat(fields, headers, value => parameter.MassRangeBegin = value, "massrangebegin", "massbegin");
+            SetFloat(fields, headers, value => parameter.MassRangeEnd = value, "massrangeend", "massend");
+            SetFloat(fields, headers, value => parameter.RtTolerance = value, "rttolerance", "retentiontimetolerance");
+            SetFloat(fields, headers, value => parameter.RiTolerance = value, "ritolerance", "retentionindextolerance");
+            SetFloat(fields, headers, value => parameter.CcsTolerance = value, "ccstolerance");
+            SetFloat(fields, headers, value => parameter.Ms1Tolerance = value, "ms1tolerance", "accuratems1tolerance");
+            SetFloat(fields, headers, value => parameter.Ms2Tolerance = value, "ms2tolerance");
+            SetFloat(fields, headers, value => parameter.RelativeAmpCutoff = value, "relativeamplitudecutoff", "relativeampcutoff");
+            SetFloat(fields, headers, value => parameter.AbsoluteAmpCutoff = value, "absoluteamplitudecutoff", "absoluteampcutoff");
+            SetFloat(fields, headers, value => parameter.WeightedDotProductCutOff = value, "weighteddotproductcutoff");
+            SetFloat(fields, headers, value => parameter.SimpleDotProductCutOff = value, "simpledotproductcutoff");
+            SetFloat(fields, headers, value => parameter.ReverseDotProductCutOff = value, "reversedotproductcutoff");
+            SetFloat(fields, headers, value => parameter.MatchedPeaksPercentageCutOff = value, "matchedpeakspercentagecutoff", "matchedpeakpercentagecutoff");
+            SetFloat(fields, headers, value => parameter.MinimumSpectrumMatch = value, "minimumspectrummatch", "minimumpeakmatch");
+            SetFloat(fields, headers, value => parameter.TotalScoreCutoff = value, "totalscorecutoff");
+            SetBool(fields, headers, value => parameter.IsUseTimeForAnnotationScoring = value, "useretentioninformationforscoring", "useretentiontimeforscoring", "usertscoring", "usertimescoring");
+            SetBool(fields, headers, value => parameter.IsUseTimeForAnnotationFiltering = value, "useretentioninformationforfiltering", "useretentiontimeforfiltering", "usertfiltering", "usetimefiltering");
+            SetBool(fields, headers, value => parameter.IsUseCcsForAnnotationScoring = value, "useccsforscoring", "useccsscoring");
+            SetBool(fields, headers, value => parameter.IsUseCcsForAnnotationFiltering = value, "useccsforfiltering", "useccsfiltering");
+        }
+
+        private static string NormalizeHeader(string text) {
+            return new string((text ?? string.Empty)
+                .Trim()
+                .Trim('"')
+                .ToLowerInvariant()
+                .Where(char.IsLetterOrDigit)
+                .ToArray());
+        }
+
+        private static int FindColumn(string[] headers, params string[] aliases) {
+            foreach (var alias in aliases.Select(NormalizeHeader)) {
+                for (var i = 0; i < headers.Length; i++) {
+                    if (headers[i] == alias) {
+                        return i;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        private static string GetField(string[] fields, int index) {
+            return index >= 0 && index < fields.Length
+                ? fields[index].Trim().Trim('"')
+                : string.Empty;
+        }
+
+        private static string GetField(string[] fields, string[] headers, params string[] aliases) {
+            return GetField(fields, FindColumn(headers, aliases));
+        }
+
+        private static void SetFloat(string[] fields, string[] headers, Action<float> setter, params string[] aliases) {
+            var value = GetField(fields, headers, aliases);
+            if (value.IsEmptyOrNull()) {
+                return;
+            }
+            if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+                || float.TryParse(value, out parsed)) {
+                setter(parsed);
+            }
+        }
+
+        private static void SetBool(string[] fields, string[] headers, Action<bool> setter, params string[] aliases) {
+            var value = GetField(fields, headers, aliases);
+            if (value.IsEmptyOrNull()) {
+                return;
+            }
+            if (bool.TryParse(value, out var parsed)) {
+                setter(parsed);
+            }
+            else if (value == "1") {
+                setter(true);
+            }
+            else if (value == "0") {
+                setter(false);
+            }
         }
 
         public static MolecularSpectrumNetworkingBaseParameter ReadForMoleculerNetworkingParameter(string filepath) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/MspAnnotatorSetting.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/MspAnnotatorSetting.cs
@@ -1,0 +1,18 @@
+using CompMs.Common.Parameter;
+
+namespace CompMs.App.MsdialConsole.Parser;
+
+public sealed class MspAnnotatorSetting
+{
+    public MspAnnotatorSetting(string annotatorId, string mspFilePath, int priority, MsRefSearchParameterBase searchParameter) {
+        AnnotatorId = annotatorId;
+        MspFilePath = mspFilePath;
+        Priority = priority;
+        SearchParameter = searchParameter;
+    }
+
+    public string AnnotatorId { get; }
+    public string MspFilePath { get; }
+    public int Priority { get; }
+    public MsRefSearchParameterBase SearchParameter { get; }
+}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/TextAnnotatorSetting.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/TextAnnotatorSetting.cs
@@ -1,0 +1,18 @@
+using CompMs.Common.Parameter;
+
+namespace CompMs.App.MsdialConsole.Parser;
+
+public sealed class TextAnnotatorSetting
+{
+    public TextAnnotatorSetting(string annotatorId, string textDbFilePath, int priority, MsRefSearchParameterBase searchParameter) {
+        AnnotatorId = annotatorId;
+        TextDbFilePath = textDbFilePath;
+        Priority = priority;
+        SearchParameter = searchParameter;
+    }
+
+    public string AnnotatorId { get; }
+    public string TextDbFilePath { get; }
+    public int Priority { get; }
+    public MsRefSearchParameterBase SearchParameter { get; }
+}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/CommonProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/CommonProcess.cs
@@ -18,6 +18,17 @@ using System.Text;
 
 namespace CompMs.App.MsdialConsole.Process
 {
+    public sealed class MspDataBaseAnnotatorSetting
+    {
+        public MspDataBaseAnnotatorSetting(MoleculeDataBase dataBase, List<MspAnnotatorSetting> annotatorSettings) {
+            DataBase = dataBase;
+            AnnotatorSettings = annotatorSettings;
+        }
+
+        public MoleculeDataBase DataBase { get; }
+        public List<MspAnnotatorSetting> AnnotatorSettings { get; }
+    }
+
     public static class CommonProcess {
 
         public static bool SetProjectProperty(ParameterBase param, string input, out List<AnalysisFileBean> analysisFiles, out AlignmentFileBean alignmentFile) {
@@ -120,6 +131,93 @@ namespace CompMs.App.MsdialConsole.Process
                 }
                 compoundsInTargetMode.Add(new MoleculeMsReference() { Name = "Target", PrecursorMz = targetMz, MassTolerance = param.MassSliceWidth });
             }
+        }
+
+        public static void ParseLibraries(ParameterBase param, float targetMz, IReadOnlyList<MspAnnotatorSetting> mspAnnotatorSettings,
+            out IupacDatabase iupacDB, out List<MspDataBaseAnnotatorSetting> mspDBs, out MoleculeDataBase? txtDB,
+            out List<MoleculeMsReference> isotopeTextDB, out List<MoleculeMsReference> compoundsInTargetMode,
+            out MoleculeDataBase? lbmDB) {
+
+            mspDBs = new List<MspDataBaseAnnotatorSetting>();
+            txtDB = null;
+            lbmDB = null;
+            iupacDB = IupacResourceParser.GetIUPACDatabase();
+            isotopeTextDB = new List<MoleculeMsReference>();
+            compoundsInTargetMode = new List<MoleculeMsReference>();
+
+            var effectiveMspSettings = mspAnnotatorSettings?
+                .Where(setting => !setting.MspFilePath.IsEmptyOrNull())
+                .ToList() ?? new List<MspAnnotatorSetting>();
+            if (effectiveMspSettings.Count == 0 && ErrorHandler.IsFileExist(param.MspFilePath)) {
+                effectiveMspSettings.Add(new MspAnnotatorSetting(param.MspFilePath, param.MspFilePath, 1, param.MspSearchParam));
+            }
+
+            var mspFileGroups = effectiveMspSettings
+                .GroupBy(setting => Path.GetFullPath(setting.MspFilePath), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            for (var i = 0; i < mspFileGroups.Count; i++) {
+                var group = mspFileGroups[i];
+                var mspFilePath = group.Key;
+                if (!ErrorHandler.IsFileExist(mspFilePath)) {
+                    Console.WriteLine($"MSP file was not found: {mspFilePath}");
+                    continue;
+                }
+
+                var mspList = LibraryHandler.ReadMsLibrary(mspFilePath, param, out var mspError);
+                var dbId = mspFileGroups.Count == 1 && effectiveMspSettings.Count == 1 && effectiveMspSettings[0].AnnotatorId == param.MspFilePath
+                    ? "MspDB"
+                    : GetSafeMspDataBaseId(mspFilePath, i + 1);
+                var mspDB = new MoleculeDataBase(mspList, dbId, DataBaseSource.Msp, SourceType.MspDB, mspFilePath);
+                if (mspError != string.Empty) {
+                    Console.WriteLine(mspError);
+                }
+                mspDBs.Add(new MspDataBaseAnnotatorSetting(mspDB, group.ToList()));
+            }
+
+            if (ErrorHandler.IsFileExist(param.LbmFilePath)) {
+                var lbmList = LibraryHandler.ReadMsLibrary(param.LbmFilePath, param, out var lbmError);
+                lbmDB = new MoleculeDataBase(lbmList, "LbmDB", DataBaseSource.Lbm, SourceType.MspDB, param.LbmFilePath);
+                if (lbmError != string.Empty) {
+                    Console.WriteLine(lbmError);
+                }
+            }
+
+            if (ErrorHandler.IsFileExist(param.TextDBFilePath)) {
+                var txtList = LibraryHandler.ReadMsLibrary(param.TextDBFilePath, param, out var txtError);
+                txtDB = new MoleculeDataBase(txtList, "TextDB", DataBaseSource.Text, SourceType.TextDB, param.TextDBFilePath);
+                if (txtError != string.Empty) {
+                    Console.WriteLine(txtError);
+                }
+            }
+
+            if (ErrorHandler.IsFileExist(param.IsotopeTextDBFilePath)) {
+                isotopeTextDB = TextLibraryParser.TextLibraryReader(param.IsotopeTextDBFilePath, out string errorInIsitopeTextDB);
+                if (errorInIsitopeTextDB != string.Empty) Console.WriteLine(errorInIsitopeTextDB);
+            }
+
+            if (ErrorHandler.IsFileExist(param.CompoundListInTargetModePath)) {
+                compoundsInTargetMode = TextLibraryParser.CompoundListInTargetModeReader(param.CompoundListInTargetModePath, out string errorInTargetModeLib);
+                if (errorInTargetModeLib != string.Empty) Console.WriteLine(errorInTargetModeLib);
+            }
+
+            if (targetMz > 0) {
+                if (compoundsInTargetMode.IsEmptyOrNull()) {
+                    compoundsInTargetMode = new List<MoleculeMsReference>();
+                }
+                compoundsInTargetMode.Add(new MoleculeMsReference() { Name = "Target", PrecursorMz = targetMz, MassTolerance = param.MassSliceWidth });
+            }
+        }
+
+        private static string GetSafeMspDataBaseId(string mspFilePath, int index) {
+            var name = Path.GetFileNameWithoutExtension(mspFilePath);
+            var safeName = new string(name.Select(c => char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '_').ToArray());
+            if (safeName.Length > 64) {
+                safeName = safeName.Substring(0, 64);
+            }
+            if (safeName.IsEmptyOrNull()) {
+                safeName = "library";
+            }
+            return $"MspDB_{index}_{safeName}";
         }
 
         public static void SetLipidQueries(ParameterBase param) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/CommonProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/CommonProcess.cs
@@ -29,6 +29,17 @@ namespace CompMs.App.MsdialConsole.Process
         public List<MspAnnotatorSetting> AnnotatorSettings { get; }
     }
 
+    public sealed class TextDataBaseAnnotatorSetting
+    {
+        public TextDataBaseAnnotatorSetting(MoleculeDataBase dataBase, List<TextAnnotatorSetting> annotatorSettings) {
+            DataBase = dataBase;
+            AnnotatorSettings = annotatorSettings;
+        }
+
+        public MoleculeDataBase DataBase { get; }
+        public List<TextAnnotatorSetting> AnnotatorSettings { get; }
+    }
+
     public static class CommonProcess {
 
         public static bool SetProjectProperty(ParameterBase param, string input, out List<AnalysisFileBean> analysisFiles, out AlignmentFileBean alignmentFile) {
@@ -133,13 +144,13 @@ namespace CompMs.App.MsdialConsole.Process
             }
         }
 
-        public static void ParseLibraries(ParameterBase param, float targetMz, IReadOnlyList<MspAnnotatorSetting> mspAnnotatorSettings,
-            out IupacDatabase iupacDB, out List<MspDataBaseAnnotatorSetting> mspDBs, out MoleculeDataBase? txtDB,
+        public static void ParseLibraries(ParameterBase param, float targetMz, IReadOnlyList<MspAnnotatorSetting> mspAnnotatorSettings, IReadOnlyList<TextAnnotatorSetting> textAnnotatorSettings,
+            out IupacDatabase iupacDB, out List<MspDataBaseAnnotatorSetting> mspDBs, out List<TextDataBaseAnnotatorSetting> textDBs,
             out List<MoleculeMsReference> isotopeTextDB, out List<MoleculeMsReference> compoundsInTargetMode,
             out MoleculeDataBase? lbmDB) {
 
             mspDBs = new List<MspDataBaseAnnotatorSetting>();
-            txtDB = null;
+            textDBs = new List<TextDataBaseAnnotatorSetting>();
             lbmDB = null;
             iupacDB = IupacResourceParser.GetIUPACDatabase();
             isotopeTextDB = new List<MoleculeMsReference>();
@@ -166,7 +177,7 @@ namespace CompMs.App.MsdialConsole.Process
                 var mspList = LibraryHandler.ReadMsLibrary(mspFilePath, param, out var mspError);
                 var dbId = mspFileGroups.Count == 1 && effectiveMspSettings.Count == 1 && effectiveMspSettings[0].AnnotatorId == param.MspFilePath
                     ? "MspDB"
-                    : GetSafeMspDataBaseId(mspFilePath, i + 1);
+                    : GetSafeDataBaseId("MspDB", mspFilePath, i + 1);
                 var mspDB = new MoleculeDataBase(mspList, dbId, DataBaseSource.Msp, SourceType.MspDB, mspFilePath);
                 if (mspError != string.Empty) {
                     Console.WriteLine(mspError);
@@ -182,12 +193,33 @@ namespace CompMs.App.MsdialConsole.Process
                 }
             }
 
-            if (ErrorHandler.IsFileExist(param.TextDBFilePath)) {
-                var txtList = LibraryHandler.ReadMsLibrary(param.TextDBFilePath, param, out var txtError);
-                txtDB = new MoleculeDataBase(txtList, "TextDB", DataBaseSource.Text, SourceType.TextDB, param.TextDBFilePath);
+            var effectiveTextSettings = textAnnotatorSettings?
+                .Where(setting => !setting.TextDbFilePath.IsEmptyOrNull())
+                .ToList() ?? new List<TextAnnotatorSetting>();
+            if (effectiveTextSettings.Count == 0 && ErrorHandler.IsFileExist(param.TextDBFilePath)) {
+                effectiveTextSettings.Add(new TextAnnotatorSetting(param.TextDBFilePath, param.TextDBFilePath, 2, param.TextDbSearchParam));
+            }
+
+            var textFileGroups = effectiveTextSettings
+                .GroupBy(setting => Path.GetFullPath(setting.TextDbFilePath), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            for (var i = 0; i < textFileGroups.Count; i++) {
+                var group = textFileGroups[i];
+                var textDbFilePath = group.Key;
+                if (!ErrorHandler.IsFileExist(textDbFilePath)) {
+                    Console.WriteLine($"Text DB file was not found: {textDbFilePath}");
+                    continue;
+                }
+
+                var txtList = LibraryHandler.ReadMsLibrary(textDbFilePath, param, out var txtError);
+                var dbId = textFileGroups.Count == 1 && effectiveTextSettings.Count == 1 && effectiveTextSettings[0].AnnotatorId == param.TextDBFilePath
+                    ? "TextDB"
+                    : GetSafeDataBaseId("TextDB", textDbFilePath, i + 1);
+                var txtDB = new MoleculeDataBase(txtList, dbId, DataBaseSource.Text, SourceType.TextDB, textDbFilePath);
                 if (txtError != string.Empty) {
                     Console.WriteLine(txtError);
                 }
+                textDBs.Add(new TextDataBaseAnnotatorSetting(txtDB, group.ToList()));
             }
 
             if (ErrorHandler.IsFileExist(param.IsotopeTextDBFilePath)) {
@@ -208,8 +240,8 @@ namespace CompMs.App.MsdialConsole.Process
             }
         }
 
-        private static string GetSafeMspDataBaseId(string mspFilePath, int index) {
-            var name = Path.GetFileNameWithoutExtension(mspFilePath);
+        private static string GetSafeDataBaseId(string prefix, string filePath, int index) {
+            var name = Path.GetFileNameWithoutExtension(filePath);
             var safeName = new string(name.Select(c => char.IsLetterOrDigit(c) || c == '-' || c == '_' ? c : '_').ToArray());
             if (safeName.Length > 64) {
                 safeName = safeName.Substring(0, 64);
@@ -217,7 +249,7 @@ namespace CompMs.App.MsdialConsole.Process
             if (safeName.IsEmptyOrNull()) {
                 safeName = "library";
             }
-            return $"MspDB_{index}_{safeName}";
+            return $"{prefix}_{index}_{safeName}";
         }
 
         public static void SetLipidQueries(ParameterBase param) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/CommonProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/CommonProcess.cs
@@ -54,9 +54,10 @@ namespace CompMs.App.MsdialConsole.Process
             if (param.ProjectParam.AcquisitionType == AcquisitionType.None) {
                 param.ProjectParam.AcquisitionType = AcquisitionType.DDA;
             }
-            foreach (var analysisFile in analysisFiles) {
-                // ProjectBaseParameter.AcquisitionType is obsolete, but is used because it is not possible to set the AcquisitionType of individual files in the Console application.
-                analysisFile.AcquisitionType = param.ProjectParam.AcquisitionType;
+            if (!AnalysisFilesParser.isCsv(input)) {
+                foreach (var analysisFile in analysisFiles) {
+                    analysisFile.AcquisitionType = param.ProjectParam.AcquisitionType;
+                }
             }
 #pragma warning restore CS0618 // Type or member is obsolete
             if (param.GetType() == typeof(MsdialGcmsParameter)) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -39,8 +39,9 @@ public sealed class LcmsProcess
         }
 
         var mspAnnotatorSettings = ConfigParser.ReadMspAnnotatorSettings(methodFile, param);
-        CommonProcess.ParseLibraries(param, targetMz, mspAnnotatorSettings, out IupacDatabase iupacDB,
-            out var mspDBs, out var txtDB,
+        var textAnnotatorSettings = ConfigParser.ReadTextAnnotatorSettings(methodFile, param);
+        CommonProcess.ParseLibraries(param, targetMz, mspAnnotatorSettings, textAnnotatorSettings, out IupacDatabase iupacDB,
+            out var mspDBs, out var textDBs,
             out List<MoleculeMsReference> isotopeTextDB, out List<MoleculeMsReference> compoundsInTargetMode,
             out var lbmDB);
 
@@ -69,11 +70,15 @@ public sealed class LcmsProcess
                 new MetabolomicsAnnotatorParameterPair(lbmAnnotator.Save(), new AnnotationQueryFactory(lbmAnnotator, param.PeakPickBaseParam, param.LbmSearchParam, ignoreIsotopicPeak: true)),
             ]);
         }
-        if (txtDB is { Database.Count: > 0 }) {
-            var textannotator = new LcmsTextDBAnnotator(txtDB, param.TextDbSearchParam, param.TextDBFilePath, 2);
-            dbStorage.AddMoleculeDataBase(txtDB, [
-                new MetabolomicsAnnotatorParameterPair(textannotator.Save(), new AnnotationQueryFactory(textannotator, param.PeakPickBaseParam, param.TextDbSearchParam, ignoreIsotopicPeak: false)),
-            ]);
+        foreach (var textDB in textDBs.Where(db => db.DataBase is { Database.Count: > 0 })) {
+            var annotatorPairs = new List<IAnnotatorParameterPair<MoleculeDataBase>>();
+            foreach (var setting in textDB.AnnotatorSettings) {
+                var annotator = new LcmsTextDBAnnotator(textDB.DataBase, setting.SearchParameter, setting.AnnotatorId, setting.Priority);
+                annotatorPairs.Add(new MetabolomicsAnnotatorParameterPair(annotator.Save(), new AnnotationQueryFactory(annotator, param.PeakPickBaseParam, setting.SearchParameter, ignoreIsotopicPeak: false)));
+            }
+            if (annotatorPairs.Count > 0) {
+                dbStorage.AddMoleculeDataBase(textDB.DataBase, annotatorPairs);
+            }
         }
         container.DataBaseMapper = new DataBaseMapper();
         container.DataBases = dbStorage;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -38,8 +38,9 @@ public sealed class LcmsProcess
             return -1;
         }
 
-        CommonProcess.ParseLibraries(param, targetMz, out IupacDatabase iupacDB,
-            out var mspDB, out var txtDB, 
+        var mspAnnotatorSettings = ConfigParser.ReadMspAnnotatorSettings(methodFile, param);
+        CommonProcess.ParseLibraries(param, targetMz, mspAnnotatorSettings, out IupacDatabase iupacDB,
+            out var mspDBs, out var txtDB,
             out List<MoleculeMsReference> isotopeTextDB, out List<MoleculeMsReference> compoundsInTargetMode,
             out var lbmDB);
 
@@ -52,11 +53,15 @@ public sealed class LcmsProcess
         };
 
         var dbStorage = DataBaseStorage.CreateEmpty();
-        if (mspDB is { Database.Count: > 0 }) {
-            var annotator = new LcmsMspAnnotator(mspDB, param.MspSearchParam, param.TargetOmics, param.MspFilePath, 1);
-            dbStorage.AddMoleculeDataBase(mspDB, [
-                new MetabolomicsAnnotatorParameterPair(annotator.Save(), new AnnotationQueryFactory(annotator, param.PeakPickBaseParam, param.MspSearchParam, ignoreIsotopicPeak: true)),
-            ]);
+        foreach (var mspDB in mspDBs.Where(db => db.DataBase is { Database.Count: > 0 })) {
+            var annotatorPairs = new List<IAnnotatorParameterPair<MoleculeDataBase>>();
+            foreach (var setting in mspDB.AnnotatorSettings) {
+                var annotator = new LcmsMspAnnotator(mspDB.DataBase, setting.SearchParameter, param.TargetOmics, setting.AnnotatorId, setting.Priority);
+                annotatorPairs.Add(new MetabolomicsAnnotatorParameterPair(annotator.Save(), new AnnotationQueryFactory(annotator, param.PeakPickBaseParam, setting.SearchParameter, ignoreIsotopicPeak: true)));
+            }
+            if (annotatorPairs.Count > 0) {
+                dbStorage.AddMoleculeDataBase(mspDB.DataBase, annotatorPairs);
+            }
         }
         if (lbmDB is { Database.Count: > 0 }) {
             var lbmAnnotator = new LcmsMspAnnotator(lbmDB, param.LbmSearchParam, param.TargetOmics, param.LbmFilePath, 1);

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/MsdialCoreTestAppTests.csproj
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/MsdialCoreTestAppTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Configurations>Debug;Release;Debug vendor unsupported;Release vendor unsupported</Configurations>
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MsdialCoreTestApp\MsdialCoreTestApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/AnalysisFilesParserTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/AnalysisFilesParserTests.cs
@@ -1,0 +1,81 @@
+using CompMs.App.MsdialConsole.Parser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace MsdialCoreTestAppTests.Parser;
+
+[TestClass]
+public sealed class AnalysisFilesParserTests
+{
+    [TestMethod]
+    public void ReadCsvContents_AcceptsFolderTypeVendorData()
+    {
+        using var directory = new TemporaryDirectory();
+        var waters = directory.CreateDirectory("waters.raw");
+        var agilent = directory.CreateDirectory("agilent.d");
+        var csv = directory.CreateFile(
+            "analysis_files.csv",
+            $"""
+            file_path,file_name,file_type,class_id,acquisition_type,batch_order,analytical_order,factor
+            {waters},waters,Sample,Sample,DDA,1,1,1
+            {agilent},agilent,Sample,Sample,DDA,1,2,1
+            """);
+
+        var files = AnalysisFilesParser.ReadCsvContents(csv);
+
+        Assert.AreEqual(2, files.Count);
+        CollectionAssert.AreEqual(
+            new[] { waters, agilent },
+            files.Select(file => file.AnalysisFilePath).ToArray());
+    }
+
+    [TestMethod]
+    public void ReadFolderContents_IncludesFolderTypeVendorData()
+    {
+        using var directory = new TemporaryDirectory();
+        directory.CreateDirectory("waters.raw");
+        directory.CreateDirectory("agilent.d");
+        directory.CreateFile("sample.mzML");
+
+        var files = AnalysisFilesParser.ReadFolderContents(directory.Path);
+
+        CollectionAssert.AreEquivalent(
+            new[] { "waters.raw", "agilent.d", "sample.mzML" },
+            files.Select(file => Path.GetFileName(file.AnalysisFilePath)).ToArray());
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "MsdialCoreTestAppTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public string CreateDirectory(string name)
+        {
+            var path = System.IO.Path.Combine(Path, name);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public string CreateFile(string name, string content = "")
+        {
+            var path = System.IO.Path.Combine(Path, name);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/Process/CommonProcessTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/Process/CommonProcessTests.cs
@@ -1,0 +1,83 @@
+using CompMs.App.MsdialConsole.Process;
+using CompMs.Common.Enum;
+using CompMs.MsdialLcmsApi.Parameter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace MsdialCoreTestAppTests.Process;
+
+[TestClass]
+public sealed class CommonProcessTests
+{
+    [TestMethod]
+    public void SetProjectProperty_PreservesPerFileAcquisitionTypesForCsvInput()
+    {
+        using var directory = new TemporaryDirectory();
+        var dda = directory.CreateFile("dda.mzML");
+        var swath = directory.CreateFile("swath.mzML");
+        var csv = directory.CreateFile(
+            "analysis_files.csv",
+            $"""
+            file_path,file_name,file_type,class_id,acquisition_type,batch_order,analytical_order,factor
+            {dda},dda,Sample,DDA,DDA,1,1,1
+            {swath},swath,Sample,SWATH,SWATH,1,2,1
+            """);
+        var parameter = new MsdialLcmsParameter();
+#pragma warning disable CS0618
+        parameter.ProjectParam.AcquisitionType = AcquisitionType.AIF;
+#pragma warning restore CS0618
+
+        var result = CommonProcess.SetProjectProperty(parameter, csv, out var files, out _);
+
+        Assert.IsTrue(result);
+        CollectionAssert.AreEqual(
+            new[] { AcquisitionType.DDA, AcquisitionType.SWATH },
+            files.Select(file => file.AcquisitionType).ToArray());
+    }
+
+    [TestMethod]
+    public void SetProjectProperty_AppliesProjectAcquisitionTypeForFolderInput()
+    {
+        using var directory = new TemporaryDirectory();
+        directory.CreateFile("first.mzML");
+        directory.CreateFile("second.mzML");
+        var parameter = new MsdialLcmsParameter();
+#pragma warning disable CS0618
+        parameter.ProjectParam.AcquisitionType = AcquisitionType.AIF;
+#pragma warning restore CS0618
+
+        var result = CommonProcess.SetProjectProperty(parameter, directory.Path, out var files, out _);
+
+        Assert.IsTrue(result);
+        Assert.IsTrue(files.Count > 0);
+        Assert.IsTrue(files.All(file => file.AcquisitionType == AcquisitionType.AIF));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "MsdialCoreTestAppTests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public string CreateFile(string name, string content = "")
+        {
+            var path = System.IO.Path.Combine(Path, name);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve each CSV row's `acquisition_type` instead of replacing it with the project-wide value
- accept folder-type vendor data paths in Console CSV input
- include top-level Waters `.raw` and Agilent/Bruker `.d` directories when importing a folder
- add regression tests for mixed acquisition types and vendor directory inputs

## Verification
- `dotnet test tests/MSDIAL5/MsdialCoreTestAppTests/MsdialCoreTestAppTests.csproj -c Release -f net8.0 --no-restore`
- 4 tests passed
- smoke tested one Waters `.raw` folder and one Bruker `.d` folder through LCMS Console processing

## Agilent note
Agilent `.d` reached the vendor reader after this parser fix, but the current local build could not resolve `BaseDataAccess.dll`. The reader may also require Microsoft Visual C++ 2013 Redistributable Package x64 on Windows; that environment-specific issue is separate from this CSV/folder parser fix.