### PR TITLE
Reduce project file asset churn

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/MsdialGuiApp.csproj
+++ b/src/MSDIAL5/MsdialGuiApp/MsdialGuiApp.csproj
@@ -172,41 +172,12 @@
         <Content Include="CytoscapeLocalBrowser\data\elements.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\data\style.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\MsdialCytoscapeViewer.html" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\iconHelp.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\iconLink.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_glass_75_d0e5f5_1x400.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_glass_85_dfeffc_1x400.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_glass_95_fef1ec_1x400.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_gloss-wave_55_5c9ccc_500x100.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_inset-hard_100_f5f8f9_1x100.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_inset-hard_100_fcfdfd_1x100.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_217bc0_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_2e83ff_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_469bdd_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_6da8d5_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_cd0a0a_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_d8e7f3_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_f9bd01_256x240.png" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="CytoscapeLocalBrowser\assembly\images\*.png" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\Chart.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\contextmenu.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\cytoscape.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\fakeLoader.css" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\fakeLoader.min.js" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\iconHelp.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\iconLink.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_glass_75_d0e5f5_1x400.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_glass_85_dfeffc_1x400.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_glass_95_fef1ec_1x400.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_gloss-wave_55_5c9ccc_500x100.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_inset-hard_100_f5f8f9_1x100.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-bg_inset-hard_100_fcfdfd_1x100.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_217bc0_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_2e83ff_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_469bdd_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_6da8d5_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_cd0a0a_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_d8e7f3_256x240.png" CopyToOutputDirectory="PreserveNewest" />
-        <Content Include="CytoscapeLocalBrowser\assembly\images\ui-icons_f9bd01_256x240.png" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\jquery-1.12.4.min.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\jquery-3.3.1.min.js" CopyToOutputDirectory="PreserveNewest" />
         <Content Include="CytoscapeLocalBrowser\assembly\jquery-3.4.1.min.js" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
This trims unnecessary evaluation work in the WPF app project by collapsing a long, duplicated asset list into wildcard includes. The change keeps the same runtime assets but makes the project file cheaper to maintain and faster to parse.

## What changed
- Replaced repeated Cytoscape image entries with a single wildcard include for the image folder
- Removed duplicate asset declarations in `MsdialGuiApp.csproj`

## Notes
- The wildcard only covers files that actually exist in the `images` folder, so there is no behavioral change for missing asset types
- No runtime code paths were changed