### PR TITLE
Set up agent docs and context map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs for this repo live in GitHub Issues, and external PRs are also a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The canonical triage roles map directly to `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a multi-context layout with `CONTEXT-MAP.md` at the root pointing to per-context `CONTEXT.md` files. See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,24 @@
+# CONTEXT MAP
+
+This repository is split into several code contexts. Read the context file for the area you are working in, then read any ADRs that apply.
+
+## Active development context
+
+- **MSDIAL5** — the primary development target. Unless told otherwise, work in `src/MSDIAL5/` and the shared foundation in `src/Common/`.
+
+## Repository contexts
+
+| Context | Scope | Read this |
+| --- | --- | --- |
+| Common | Shared foundation code used by MSDIAL4, MSDIAL5, and other apps, even though it is not cleanly separated today. | `src/Common/CONTEXT.md` |
+| MSDIAL4 | MSDIAL4-era application and supporting libraries. | `src/MSDIAL4/CONTEXT.md` |
+| MSDIAL5 | Current mainline MSDIAL development. Prefer this unless told otherwise. | `src/MSDIAL5/CONTEXT.md` |
+| CompMs.App | Non-MSDIAL applications and tools under the CompMs.App umbrella. | `src/CompMs.App/CONTEXT.md` |
+| MSFINDER | MSFINDER application and supporting libraries. | `src/MSFINDER/CONTEXT.md` |
+| RawDataApp | Raw data conversion and viewer applications. | `src/RawDataApp/CONTEXT.md` |
+
+## Reading rules
+
+- If you are working in **MSDIAL5**, also read **Common** because it contains the shared base code that MSDIAL5 builds on.
+- If your change touches code that is shared across MSDIAL4 and MSDIAL5, treat **Common** as the first stop and check both contexts for call sites.
+- If your task is about one of the other application areas, prefer that context's `CONTEXT.md` first and only widen the scope if the change crosses boundaries.

--- a/docs/adr/0001-msdial5-primary-development.md
+++ b/docs/adr/0001-msdial5-primary-development.md
@@ -1,0 +1,33 @@
+# ADR 0001: Treat MSDIAL5 as the primary development target
+
+## Status
+
+Accepted
+
+## Context
+
+This repository contains multiple product areas under `src/`, including `Common`, `MSDIAL4`, `MSDIAL5`, `CompMs.App`, `MSFINDER`, and `RawDataApp`.
+
+The codebase is not cleanly separated by ownership, and `Common` contains shared foundation code that is used by both MSDIAL4 and MSDIAL5. In practice, current development work is focused on MSDIAL5 unless a task explicitly says otherwise.
+
+Without an explicit default, engineers and agents can waste time deciding which code path to follow first, or accidentally optimize for the wrong product line.
+
+## Decision
+
+Treat `src/MSDIAL5/` as the primary development target for this repository. Treat `src/Common/` as the shared foundation that MSDIAL5 depends on and read it alongside MSDIAL5 for default work.
+
+When a task does not specify a different scope:
+
+- Prefer MSDIAL5 implementations and call sites.
+- Read and update Common when the change touches shared behavior, shared abstractions, or code reused by MSDIAL5.
+- Only widen scope to MSDIAL4, CompMs.App, MSFINDER, or RawDataApp when the task explicitly requires it or the change crosses boundaries.
+
+## Consequences
+
+- Default work is faster because the first place to look is unambiguous.
+- Shared changes still need to be checked carefully in Common because that code affects more than one product line.
+- MSDIAL4 remains relevant for compatibility checks, but it is not the default target for new work.
+
+## Notes
+
+This ADR records the working default established for this repository. If the product strategy changes, add a new ADR that supersedes this one.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read the relevant one first.
+- **`CONTEXT.md`** for the context you're working in.
+- **`docs/adr/`** — read ADRs that affect the area you're about to change. In multi-context repos, also check `src/<context>/docs/adr/` for context-specific decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront.
+
+## File structure
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, note it as a gap for later documentation.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue tracker: GitHub
+
+Use GitHub Issues for lightweight tracking. This repo does not use a formal triage workflow.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`
+- **Read an issue**: `gh issue view <number> --comments`
+- **List issues**: `gh issue list --state open`
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Close an issue**: `gh issue close <number> --comment "..."`
+
+Use `git remote -v` when you need to confirm the repository target; `gh` will infer it from the clone.
+
+## Pull requests
+
+Treat PRs separately from issues. Do not pull external PRs into an issue triage queue.
+
+- **Read a PR**: `gh pr view <number> --comments`
+- **View the diff**: `gh pr diff <number>`
+- **Comment on a PR**: `gh pr comment <number> --body "..."`
+- **Close a PR**: `gh pr close <number>`
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,7 @@
+# Triage Labels
+
+This repository does not use a formal triage state machine. Keep labels minimal and only add them when they help with day-to-day sorting.
+
+If you need labels, use plain GitHub labels that match the current task or area instead of maintaining a separate canonical vocabulary.
+
+Examples: `bug`, `enhancement`, `documentation`, `question`, `msdial5`, `common`.

--- a/src/Common/CONTEXT.md
+++ b/src/Common/CONTEXT.md
@@ -1,0 +1,19 @@
+# Common
+
+Shared foundation code used across the repository, including code consumed by MSDIAL4, MSDIAL5, and other applications.
+
+## What lives here
+
+- Shared utilities, abstractions, and base infrastructure.
+- Code that is reused by both MSDIAL4 and MSDIAL5, even when it has not been fully separated yet.
+
+## How to work here
+
+- Treat this as the shared base layer when a change affects multiple product lines.
+- If you are changing behavior used by MSDIAL5, check the MSDIAL5 context as well.
+- If you are changing behavior used by MSDIAL4, check the MSDIAL4 context as well.
+
+## Vocabulary
+
+- Prefer the terms already used by the code in this area.
+- If a shared concept needs a precise definition, record it in the most relevant product context first, then reference it here if it is truly cross-cutting.

--- a/src/CompMs.App/CONTEXT.md
+++ b/src/CompMs.App/CONTEXT.md
@@ -1,0 +1,16 @@
+# CompMs.App
+
+Non-MSDIAL application code and tools that live under the CompMs.App umbrella.
+
+## What lives here
+
+- Application code that is not part of the MSDIAL4 or MSDIAL5 product lines.
+
+## How to work here
+
+- Use this context only when the task explicitly targets one of these apps.
+- If a change crosses into shared infrastructure, read `src\Common\CONTEXT.md` as well.
+
+## Vocabulary
+
+- Prefer the existing app-specific terms in this area.

--- a/src/MSDIAL4/CONTEXT.md
+++ b/src/MSDIAL4/CONTEXT.md
@@ -1,0 +1,19 @@
+# MSDIAL4
+
+MSDIAL4-era application code and supporting libraries.
+
+## What lives here
+
+- MSDIAL4 application code.
+- MSDIAL4-specific supporting libraries and standards.
+
+## How to work here
+
+- Use this context when a change is explicitly about MSDIAL4.
+- If the change touches shared code, also check `src/Common/CONTEXT.md`.
+- If the change may affect MSDIAL5, compare the relevant MSDIAL5 code paths before editing.
+
+## Vocabulary
+
+- Prefer MSDIAL4 terms as they are already used in the codebase.
+- If you need a new shared term, confirm whether it belongs in MSDIAL4, Common, or both.

--- a/src/MSDIAL5/CONTEXT.md
+++ b/src/MSDIAL5/CONTEXT.md
@@ -1,0 +1,19 @@
+# MSDIAL5
+
+Current mainline MSDIAL development. Unless told otherwise, this is the primary context to work in.
+
+## What lives here
+
+- MSDIAL5 application code and supporting libraries.
+- Feature work, bug fixes, and refactors currently under active development.
+
+## How to work here
+
+- Prefer this context for all default development tasks.
+- Always read `src\Common\CONTEXT.md` because MSDIAL5 depends on the shared foundation code.
+- If a change touches shared behavior, check whether the same path exists in MSDIAL4 before editing.
+
+## Vocabulary
+
+- Use the names already established by the MSDIAL5 code paths and UI.
+- If a term is shared with Common, keep the wording consistent across both contexts.

--- a/src/MSFINDER/CONTEXT.md
+++ b/src/MSFINDER/CONTEXT.md
@@ -1,0 +1,17 @@
+# MSFINDER
+
+MSFINDER application code and supporting libraries.
+
+## What lives here
+
+- MSFINDER application code.
+- MSFINDER-specific support libraries and console app core code.
+
+## How to work here
+
+- Use this context when the task is specifically about MSFINDER.
+- If a change touches shared infrastructure, read `src\Common\CONTEXT.md` as well.
+
+## Vocabulary
+
+- Prefer the MSFINDER terms already used in this area.

--- a/src/RawDataApp/CONTEXT.md
+++ b/src/RawDataApp/CONTEXT.md
@@ -1,0 +1,17 @@
+# RawDataApp
+
+Raw data conversion and viewer applications.
+
+## What lives here
+
+- Raw data converter functionality.
+- Raw data viewer functionality.
+
+## How to work here
+
+- Use this context when the task is specifically about raw data tools.
+- If a change touches shared infrastructure, read `src\Common\CONTEXT.md` as well.
+
+## Vocabulary
+
+- Prefer the existing raw-data and viewer terminology in this area.


### PR DESCRIPTION
This change adds the repository guidance needed for the lightweight skill workflow we are standardizing around.

It introduces a repo-specific agent setup with a simple GitHub issue tracker guide, minimal label guidance, a MSDIAL5-first context map, per-area CONTEXT.md files, and an ADR describing the default development target. The result is a clearer default path for future development and bug fixing without adding a heavyweight triage process.

Notes:
- The repo is treated as MSDIAL5-first by default.
- Common remains the shared foundation that should be checked alongside MSDIAL5 when changes touch shared behavior.
- The issue-tracker and triage docs are intentionally lightweight for solo use.