### PR TITLE
Add GCMS normalized feature export

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/Gcms/GcmsMethodModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Gcms/GcmsMethodModel.cs
@@ -88,8 +88,8 @@ namespace CompMs.App.Msdial.Model.Gcms
                 [
                     new ExportType("Raw data (Height)", new LegacyQuantValueAccessor("Height", storage.Parameter), "Height", stats, true),
                     new ExportType("Raw data (Area)", new LegacyQuantValueAccessor("Area", storage.Parameter), "Area", stats),
-                    //new ExportType("Normalized data (Height)", new LegacyQuantValueAccessor("Normalized height", storage.Parameter), "NormalizedHeight", stats, isNormalized),
-                    //new ExportType("Normalized data (Area)", new LegacyQuantValueAccessor("Normalized area", storage.Parameter), "NormalizedArea", stats, isNormalized),
+                    new ExportType("Normalized data (Height)", new LegacyQuantValueAccessor("Normalized height", storage.Parameter), "NormalizedHeight", stats, isNormalized),
+                    new ExportType("Normalized data (Area)", new LegacyQuantValueAccessor("Normalized area", storage.Parameter), "NormalizedArea", stats, isNormalized),
                     new ExportType("Peak ID", new LegacyQuantValueAccessor("ID", storage.Parameter), "PeakID"),
                     new ExportType("Quant mass", new LegacyQuantValueAccessor("MZ", storage.Parameter), "Quant mass"),
                     new ExportType("Retention time", new LegacyQuantValueAccessor("RT", storage.Parameter), "Rt"),


### PR DESCRIPTION
GCMS exports now include normalized feature output after normalization is available, so downstream analysis can consume the normalized peak data directly from the alignment export flow.

This change wires the normalized export options into the GCMS method model and keeps them gated on the existing normalized-data availability check, matching the behavior already used by other export surfaces.

**Notes**
- Normalized height and normalized area are enabled only when normalized data can be exported.
- No other export behavior is changed.