### PR TITLE
Add filter reset and clear controls

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/KeywordFilterModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/KeywordFilterModel.cs
@@ -57,9 +57,15 @@ namespace CompMs.App.Msdial.Model.Search
             }
         }
 
-        public void ClearKeywords() {
-            SetKeywords([]);
-        }
+public void ClearKeywords() {
+    _sem.Wait();
+    try {
+        SetKeywords([]);
+    }
+    finally {
+        _sem.Release();
+    }
+}
 
         private void SetKeywords(IEnumerable<string> keywords) {
             _keywords.Clear();

--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/KeywordFilterModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/KeywordFilterModel.cs
@@ -23,7 +23,7 @@ namespace CompMs.App.Msdial.Model.Search
 
         public KeywordFilterModel(string label, KeywordFilteringType type = KeywordFilteringType.IgnoreIfWordIsNull) {
             _sem = new SemaphoreSlim(1, 1).AddTo(Disposables);
-            _keywords = new List<string>();
+            _keywords = [];
             Keywords = _keywords.AsReadOnly();
             switch (type) {
                 case KeywordFilteringType.ExactMatch:
@@ -33,6 +33,7 @@ namespace CompMs.App.Msdial.Model.Search
                     _method = new KeepIfWordIsNull();
                     break;
                 case KeywordFilteringType.IgnoreIfWordIsNull:
+                case KeywordFilteringType.None:
                 default:
                     _method = new IgnoreIfWordIsNull();
                     break;
@@ -57,13 +58,14 @@ namespace CompMs.App.Msdial.Model.Search
         }
 
         public void ClearKeywords() {
-            SetKeywords(Enumerable.Empty<string>());
+            SetKeywords([]);
         }
 
         private void SetKeywords(IEnumerable<string> keywords) {
             _keywords.Clear();
             _keywords.AddRange(keywords);
             IsEnabled = _keywords.Count > 0;
+            OnPropertyChanged(nameof(Keywords));
         }
 
         public bool Match(string word) {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/KeywordFilterModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/KeywordFilterModel.cs
@@ -56,6 +56,10 @@ namespace CompMs.App.Msdial.Model.Search
             }
         }
 
+        public void ClearKeywords() {
+            SetKeywords(Enumerable.Empty<string>());
+        }
+
         private void SetKeywords(IEnumerable<string> keywords) {
             _keywords.Clear();
             _keywords.AddRange(keywords);

--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/PeakSpotNavigatorModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/PeakSpotNavigatorModel.cs
@@ -47,6 +47,9 @@ namespace CompMs.App.Msdial.Model.Search
         public ObservableCollection<PeakFilterModel> PeakFilters { get; } = new ObservableCollection<PeakFilterModel>();
 
         public void ResetFilters() {
+            foreach (var peakFilterModel in PeakFilters) {
+                peakFilterModel.CheckedFilter = DisplayFilter.Unset;
+            }
             AmplitudeFilterModel.Reset();
             foreach (var valueFilterModel in ValueFilterModels) {
                 valueFilterModel.Reset();

--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/PeakSpotNavigatorModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/PeakSpotNavigatorModel.cs
@@ -46,6 +46,17 @@ namespace CompMs.App.Msdial.Model.Search
         public PeakSpotTagSearchQueryBuilderModel TagSearchQueryBuilder { get; }
         public ObservableCollection<PeakFilterModel> PeakFilters { get; } = new ObservableCollection<PeakFilterModel>();
 
+        public void ResetFilters() {
+            AmplitudeFilterModel.Reset();
+            foreach (var valueFilterModel in ValueFilterModels) {
+                valueFilterModel.Reset();
+            }
+            foreach (var keywordFilterModel in KeywordFilterModels) {
+                keywordFilterModel.ClearKeywords();
+            }
+            TagSearchQueryBuilder.Reset();
+        }
+
         public void RefreshCollectionViews() {
             foreach (var view in PeakSpotsCollection) {
                 view.Refresh();

--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/PeakSpotTagSearchQueryBuilderModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/PeakSpotTagSearchQueryBuilderModel.cs
@@ -42,6 +42,15 @@ namespace CompMs.App.Msdial.Model.Search
         }
         private bool _excludes;
 
+        public void Reset() {
+            Confirmed = false;
+            LowQualitySpectrum = false;
+            Misannotation = false;
+            Coelution = false;
+            Overannotation = false;
+            Excludes = false;
+        }
+
         public PeakSpotTagSearchQuery CreateQuery() {
             var tags = new List<PeakSpotTag>();
             if (Confirmed) {

--- a/src/MSDIAL5/MsdialGuiApp/Model/Search/ValueFilterModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Search/ValueFilterModel.cs
@@ -58,6 +58,12 @@ namespace CompMs.App.Msdial.Model.Search
             return Lower <= value && value <= Upper;
         }
 
+        public void Reset() {
+            Lower = Minimum;
+            Upper = Maximum;
+            IsEnabled = false;
+        }
+
         public bool IsEnabled {
             get => _isEnabled;
             set => SetProperty(ref _isEnabled, value);

--- a/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAlignmentSpotTableView.xaml
@@ -86,8 +86,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                   <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAlignmentSpotTableView.xaml
@@ -127,6 +127,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAnalysisPeakTableView.xaml
@@ -87,8 +87,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -128,6 +162,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Dims/DimsAnalysisPeakTableView.xaml
@@ -87,7 +87,7 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      HorizontalAlignment="Stretch"/>
                         </StackPanel>
                     </DataTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAlignmentSpotTableView.xaml
@@ -86,8 +86,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                   <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAlignmentSpotTableView.xaml
@@ -127,6 +127,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAnalysisPeakTableView.xaml
@@ -86,7 +86,7 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      HorizontalAlignment="Stretch"/>
                         </StackPanel>
                     </DataTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Gcms/GcmsAnalysisPeakTableView.xaml
@@ -86,8 +86,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -127,6 +161,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAlignmentSpotTableView.xaml
@@ -86,8 +86,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                   <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAlignmentSpotTableView.xaml
@@ -127,6 +127,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAnalysisPeakTableView.xaml
@@ -86,7 +86,7 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      HorizontalAlignment="Stretch"/>
                         </StackPanel>
                     </DataTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Imms/ImmsAnalysisPeakTableView.xaml
@@ -86,8 +86,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -127,6 +161,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAlignmentSpotTableView.xaml
@@ -82,8 +82,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                   <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAlignmentSpotTableView.xaml
@@ -123,6 +123,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAnalysisPeakTableView.xaml
@@ -82,7 +82,7 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                      HorizontalAlignment="Stretch"/>
                         </StackPanel>
                     </DataTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcimms/LcimmsAnalysisPeakTableView.xaml
@@ -82,8 +82,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -123,6 +157,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAlignmentSpotTableView.xaml
@@ -86,8 +86,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                   <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAlignmentSpotTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAlignmentSpotTableView.xaml
@@ -127,6 +127,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAnalysisPeakTableView.xaml
@@ -88,7 +88,7 @@
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
                             <Grid>
-                                <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding Keywords.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                          HorizontalAlignment="Stretch"/>
                                 <Button Content="&#xE894;"
                                         FontFamily="Segoe MDL2 Assets"

--- a/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAnalysisPeakTableView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Lcms/LcmsAnalysisPeakTableView.xaml
@@ -87,8 +87,42 @@
                     <DataTemplate DataType="{x:Type searchvm:KeywordFilterViewModel}">
                         <StackPanel Margin="5,0,0,0">
                             <TextBlock Text="{Binding Label, Mode=OneTime}"/>
-                            <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
-                                     HorizontalAlignment="Stretch"/>
+                            <Grid>
+                                <TextBox Text="{Binding Keywords.Value, UpdateSourceTrigger=PropertyChanged}"
+                                         HorizontalAlignment="Stretch"/>
+                                <Button Content="&#xE894;"
+                                        FontFamily="Segoe MDL2 Assets"
+                                        FontSize="6"
+                                        Width="12"
+                                        Height="12"
+                                        Margin="0,0,2,0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Right"
+                                        Command="{Binding ClearCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="10">
+                                                <ContentPresenter
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"/>
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter TargetName="border"
+                                                            Property="Background"
+                                                            Value="#CCC"/>
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -128,6 +162,11 @@
                         Margin="8,0"
                         VerticalAlignment="Center" HorizontalAlignment="Left"
                         Width="128"/>
+                <Button Content="Reset filter"
+                        Command="{Binding PeakSpotNavigatorViewModel.ResetFiltersCommand, Mode=OneTime, FallbackValue={x:Static commonmvvm:NeverCommand.Instance}}"
+                        Margin="8,0"
+                        VerticalAlignment="Center" HorizontalAlignment="Left"
+                        Width="64"/>
             </StackPanel>
         </Grid>
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/KeywordFilterViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/KeywordFilterViewModel.cs
@@ -17,6 +17,8 @@ namespace CompMs.App.Msdial.ViewModel.Search
         public KeywordFilterViewModel(KeywordFilterModel model) {
             _model = model ?? throw new ArgumentNullException(nameof(model));
             Keywords = new ReactivePropertySlim<string>(string.Empty).AddTo(Disposables);
+            ClearCommand = new ReactiveCommand().AddTo(Disposables);
+            ClearCommand.Subscribe(_ => Clear()).AddTo(Disposables);
             Keywords.Where(keywords => keywords != null)
                 .SelectSwitch(keywords => Observable.FromAsync(token => model.SetKeywordsAsync(keywords.Split(), token)))
                 .Subscribe()
@@ -25,6 +27,11 @@ namespace CompMs.App.Msdial.ViewModel.Search
 
         public string Label => _model.Label;
         public ReactivePropertySlim<string> Keywords { get; }
+        public ReactiveCommand ClearCommand { get; }
+
+        public void Clear() {
+            Keywords.Value = string.Empty;
+        }
 
         public IObservable<Unit> ObserveChanged => Keywords.ToUnit();
     }

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/KeywordFilterViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/KeywordFilterViewModel.cs
@@ -23,6 +23,9 @@ namespace CompMs.App.Msdial.ViewModel.Search
                 .SelectSwitch(keywords => Observable.FromAsync(token => model.SetKeywordsAsync(keywords.Split(), token)))
                 .Subscribe()
                 .AddTo(Disposables);
+            model.ObserveProperty(m => m.Keywords)
+                .Subscribe(_ => Keywords.Value = string.Join(" ", model.Keywords))
+                .AddTo(Disposables);
         }
 
         public string Label => _model.Label;

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/PeakFilterViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/PeakFilterViewModel.cs
@@ -18,7 +18,10 @@ namespace CompMs.App.Msdial.ViewModel.Search
 
             EnabledFilter = model.EnabledFilter;
             CheckedFilter = model.ObserveProperty(m => m.CheckedFilter).ToReactiveProperty().AddTo(Disposables);
-            CheckedFilter.Subscribe(filter => model.CheckedFilter = filter).AddTo(Disposables);
+            CheckedFilter.Subscribe(filter => {
+                model.CheckedFilter = filter;
+                OnPropertyChanged("");
+            }).AddTo(Disposables);
         }
 
         public PeakFilterViewModel(params PeakFilterModel[] models) {
@@ -29,6 +32,7 @@ namespace CompMs.App.Msdial.ViewModel.Search
                 foreach (var m in models) {
                     m.CheckedFilter = filter;
                 }
+                OnPropertyChanged("");
             }).AddTo(Disposables);
         }
 
@@ -110,6 +114,10 @@ namespace CompMs.App.Msdial.ViewModel.Search
             set => WriteFilter(DisplayFilter.MscleanrRmd, value);
         }
         public bool EnableMscleanrRmd => EnabledFilter.All(DisplayFilter.MscleanrRmd);
+
+        public void Reset() {
+            CheckedFilter.Value = DisplayFilter.Unset;
+        }
 
         private bool ReadFilter(DisplayFilter flag) {
             return (flag & CheckedFilter.Value & EnabledFilter) != 0;

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/PeakSpotNavigatorViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/PeakSpotNavigatorViewModel.cs
@@ -23,6 +23,8 @@ namespace CompMs.App.Msdial.ViewModel.Search
                 .AddTo(Disposables);
             PeakFilterViewModel = new PeakFilterViewModel(model.PeakFilters.ToArray()).AddTo(Disposables);
             TagSearchBuilderViewModel = new PeakSpotTagSearchQueryBuilderViewModel(model.TagSearchQueryBuilder).AddTo(Disposables);
+            ResetFiltersCommand = new ReactiveCommand().AddTo(Disposables);
+            ResetFiltersCommand.Subscribe(_ => model.ResetFilters()).AddTo(Disposables);
 
             AmplitudeLowerValue = model.AmplitudeFilterModel
                 .ToReactivePropertyAsSynchronized(m => m.Lower)
@@ -74,6 +76,7 @@ namespace CompMs.App.Msdial.ViewModel.Search
         public ICollectionView PeakSpotsView { get; }
 
         public ReactivePropertySlim<bool> IsEditting { get; }
+        public ReactiveCommand ResetFiltersCommand { get; }
 
         public ReactiveProperty<double> AmplitudeLowerValue { get; }
         public ReactiveProperty<double> AmplitudeUpperValue { get; }

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/PeakSpotTagSearchQueryBuilderViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/PeakSpotTagSearchQueryBuilderViewModel.cs
@@ -38,6 +38,15 @@ namespace CompMs.App.Msdial.ViewModel.Search
         public ReactivePropertySlim<bool> Overannotation { get; }
         public ReactivePropertySlim<bool> Excludes { get; }
 
+        public void Reset() {
+            Confirmed.Value = false;
+            LowQualitySpectrum.Value = false;
+            Misannotation.Value = false;
+            Coelution.Value = false;
+            Overannotation.Value = false;
+            Excludes.Value = false;
+        }
+
         public IObservable<Unit> ObserveChanged { get; }
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/ValueFilterViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/Search/ValueFilterViewModel.cs
@@ -37,6 +37,10 @@ namespace CompMs.App.Msdial.ViewModel.Search
         public ReactiveProperty<double> Lower { get; }
         public ReactiveProperty<double> Upper { get; }
 
+        public void Reset() {
+            _model.Reset();
+        }
+
         public IObservable<Unit> ObserveChanged { get; }
         public IObservable<bool> ObserveHasErrors { get; }
     }


### PR DESCRIPTION
Add a global filter reset action and per-textbox clear affordances for the peak spot and alignment tables.

This keeps the filter UI consistent across the analysis and alignment views while letting users clear individual keyword fields without manually deleting text. The reset path also clears the underlying filter state so checkbox, range, and tag selections all return to their default values together.

Changes
* Add reset wiring in the shared peak spot navigator model and view model
* Add clear buttons for keyword text boxes across the peak and alignment tables
* Propagate the same reset UI into the alignment tables