### PR TITLE
Add string-to-color binding converter

### DIFF
--- a/src/Common/ChartDrawing/Converter/StringToColorConverter.cs
+++ b/src/Common/ChartDrawing/Converter/StringToColorConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace CompMs.Graphics.Converter
+{
+    [ValueConversion(typeof(string), typeof(Color))]
+    public sealed class StringToColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value is Color color) {
+                return color.ToString();
+            }
+            return Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value is string text) {
+                try {
+                    return ColorConverter.ConvertFromString(text);
+                }
+                catch (FormatException) {
+                }
+            }
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/src/MSDIAL5/MsdialGuiApp/View/Setting/FileClassSetView.xaml
+++ b/src/MSDIAL5/MsdialGuiApp/View/Setting/FileClassSetView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:converter="clr-namespace:CompMs.Graphics.Converter;assembly=ChartDrawing"
              xmlns:ui="clr-namespace:CompMs.Graphics.UI;assembly=ChartDrawing"
              xmlns:behavior="clr-namespace:CompMs.Graphics.Behavior;assembly=ChartDrawing"
              xmlns:vm="clr-namespace:CompMs.App.Msdial.ViewModel.Setting"
@@ -11,6 +12,7 @@
              d:Background="White"
              d:DesignHeight="450" d:DesignWidth="400">
     <UserControl.Resources>
+        <converter:StringToColorConverter x:Key="StringToColorConverter"/>
         <Style TargetType="DataGrid">
             <Setter Property="CanUserAddRows" Value="False"/>
             <Setter Property="CanUserDeleteRows" Value="False"/>
@@ -48,6 +50,9 @@
                         </ui:CompositeColorPicker>
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>
+                <DataGridTemplateColumn.ClipboardContentBinding>
+                    <Binding Path="Color.Value" Converter="{StaticResource StringToColorConverter}" />
+                </DataGridTemplateColumn.ClipboardContentBinding>
             </DataGridTemplateColumn>
             <DataGridTextColumn Header="Order"
                                 Binding="{Binding Order.Value, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
The sample class color editor needed to accept pasted color codes directly in the DataGrid cell, not just through the picker UI. This change moves that behavior into the binding layer so the grid can translate text input into a color value naturally.

## What changed
- Added a shared `StringToColorConverter` that formats `Color` values as strings and parses pasted text back into `Color`.
- Wired the `FileClassSetView` DataGrid color cell to use the converter on `CompositeColorPicker.SelectedColor`.

## Notes
- Invalid text is ignored by returning `Binding.DoNothing`, which keeps the grid from throwing on bad paste input.
- No picker-internal paste handling is needed for this flow.