### PR TITLE
Improve fragment search query checks

### DIFF
--- a/src/MSDIAL5/MsdialCore/Algorithm/FragmentSearcher.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/FragmentSearcher.cs
@@ -33,7 +33,7 @@ namespace CompMs.MsdialCore.Algorithm {
 
             var maxIntensity = features.Max(n => n.PeakFeature.PeakHeightTop);
             var maxIntensityOnDrift = isIonMobility ? features.SelectMany(n => n.DriftChromFeatures).Max(n => n.PeakFeature.PeakHeightTop) : 0.0;
-            var isAllQueriesFocusOnMS1 = queries.Count() == queries.Where(n => n.PeakFeatureQueryLevel == PeakFeatureQueryLevel.MS1).Count();
+            var isAllQueriesFocusOnMS1 = queries.All(n => n.PeakFeatureQueryLevel == PeakFeatureQueryLevel.MS1);
             foreach (var feature in features) {
                 var featureStatus = feature.FeatureFilterStatus;
                 featureStatus.IsFragmentExistFiltered = false;
@@ -120,7 +120,7 @@ namespace CompMs.MsdialCore.Algorithm {
 
             var maxIntensity = features.Max(n => n.HeightAverage);
             var maxIntensityOnDrift = isIonMobility ? features.SelectMany(n => n.AlignmentDriftSpotFeatures).Max(n => n.HeightAverage) : 0.0;
-            var isAllQueriesFocusOnMS1 = queries.Count() == queries.Where(n => n.PeakFeatureQueryLevel == PeakFeatureQueryLevel.MS1).Count();
+            var isAllQueriesFocusOnMS1 = queries.All(n => n.PeakFeatureQueryLevel == PeakFeatureQueryLevel.MS1);
 
             foreach (var feature in features) {
                 var featureStatus = feature.FeatureFilterStatus;


### PR DESCRIPTION
This PR implements the highest-impact, lowest-effort performance fix identified in the MSDIAL5 scan: replace two redundant Count() scans with a single All() check in FragmentSearcher.

The repo scan also surfaced 9 additional performance improvement candidates for follow-up:
1. MztabFormatExport.cs — replace .ToList()[0] with First(...).
2. AlignmentSpotProperty.cs — cache MspBasedMatchResult lookup.
3. AnalysisFileBeanModelCollection.cs — avoid Distinct().Count() uniqueness validation.
4. DataAccess.cs — replace Count() == 0 / repeated scans with cheaper checks.
5. PeakFilterViewModel.cs — cache repeated computed filter properties.
6. AbundanceRatioCalculator.cs — reduce repeated matrix allocation.
7. AlignmentSpotProperty.cs — cache AlignedPeakProperties task result access.
8. SpectraGroupingModel.cs / AlignmentCSVExporter.cs — reduce LINQ chain overhead on large collections.
9. DataAccess.cs — collapse multiple SWATH detection passes into a single scan.