### PR TITLE
Optimize repeated MSDec chromatogram metadata lookups

### DIFF
--- a/src/MSDIAL5/MsdialCore/MSDec/MSDecResult.cs
+++ b/src/MSDIAL5/MsdialCore/MSDec/MSDecResult.cs
@@ -46,10 +46,10 @@ namespace CompMs.MsdialCore.MSDec {
             var chroms = new ExtractedIonChromatogram[spectrum.Length];
             var modelPeaks = ModelPeakChromatogram;
             var maxIntensity = modelPeaks.DefaultIfEmpty().Max(n => n?.Intensity) ?? 1e-10;
+            var type = modelPeaks.Select(p => p.ChromXs.MainType).FirstOrDefault();
+            var unit = modelPeaks.Select(p => p.ChromXs.Unit).FirstOrDefault();
             for (int i = 0; i < spectrum.Length; i++) {
                 var chrom = new ValuePeak[ModelPeakChromatogram.Count];
-                var type = modelPeaks.Select(p => p.ChromXs.MainType).FirstOrDefault();
-                var unit = modelPeaks.Select(p => p.ChromXs.Unit).FirstOrDefault();
                 for (int j = 0; j < ModelPeakChromatogram.Count; j++) {
                     chrom[j] = new ValuePeak(modelPeaks[j].ID, modelPeaks[j].ChromXs.Value, spectrum[i].Mass, modelPeaks[j].Intensity * spectrum[i].Intensity / maxIntensity);
                 }


### PR DESCRIPTION
## Summary
- audited the MSDIAL5/Common processing and visualization paths for performance opportunities
- hoisted invariant chromatogram type/unit lookups out of the per-spectrum loop in `MSDecResult.DecChromPeaks`
- preserves existing output while avoiding repeated LINQ enumeration and allocations during chart refreshes

## Ranked performance opportunities
1. **Hoist `DecChromPeaks` metadata lookups** — high impact in repeated chart refreshes, one-line surgical fix (implemented here).
2. Replace `OrderByDescending(...).Take(n)` in spectrum display paths with a bounded top-N selection when spectra are large.
3. Replace nearest-RT `OrderBy(...).First()` with a linear minimum scan in retention-time chart rendering.
4. Cache repeated `ModelPeakChromatogram.Count` and collection references in EIC generation loops.
5. Avoid repeated `Where(...).OrderBy(...).FirstOrDefault()` scans in raw spectrum S/N distribution calculation.
6. Reuse a mass-indexed lookup for MS1/MS2 partial-link matching instead of repeatedly traversing candidate peaks.
7. Cache chromatogram extraction results across correlation comparisons in `PeakCharacterEstimator`.
8. Replace repeated `Select(...).ToArray()` materialization in coefficient calculations with direct array reuse where safe.
9. Use a `HashSet` for repeated feature-ID membership tests in alignment/linking workflows.
10. Review repeated `GroupBy(...).OrderByDescending(...).Take(...)` network pruning for a bounded per-group selection algorithm.

## Validation
- `dotnet test tests\\MSDIAL5\\MsdialCoreTests\\MsdialCoreTests.csproj --no-restore --filter FullyQualifiedName~MSDec`
- `dotnet test tests\\MSDIAL5\\MsdialCoreTests\\MsdialCoreTests.csproj --no-restore --filter FullyQualifiedName~AnnotatedMSDecResult`
- `git diff --check`