### PR TITLE
Add LC-MS alignment light mode for console exports

### DIFF
--- a/docs/adr/0002-alignment-light-streaming.md
+++ b/docs/adr/0002-alignment-light-streaming.md
@@ -1,0 +1,375 @@
+# ADR 0002: Alignment-light streaming export path
+
+## Status
+
+Accepted for incremental implementation. Phase 1 is implemented for LC-MS
+Console.
+
+## Context
+
+Large-scale LC-MS projects with thousands to tens of thousands of samples can
+run out of memory during alignment. The current alignment path keeps a large
+object graph in memory:
+
+- one `AlignmentSpotProperty` per aligned feature,
+- each `AlignmentSpotProperty.AlignedPeakProperties` contains one
+  `AlignmentChromPeakFeature` per analysis file,
+- additional GUI chromatogram cache data may be serialized for later project
+  browsing.
+
+The first alignment-light change disables GUI chromatogram serialization when
+the console method file contains:
+
+```txt
+Alignment light mode: True
+```
+
+Validation on the FastLC WIFF demo confirmed that `mdalign`, `mdmsp`, and
+`mzTab` text outputs are unchanged except for the expected mzTab ID line, while
+the GUI alignment object serialization path is skipped. Alignment `.dcl`
+spectra are still written because they represent the aligned MSDecResult set
+used by spectrum-aware text exports and downstream spectrum reuse.
+
+The next target is to avoid holding all per-file aligned peak objects in memory
+when only text exports are required.
+
+## Current Dependency Map
+
+### Join and gap filling
+
+`LcmsPeakJoiner` currently allocates the full per-file peak list during spot
+initialization:
+
+- `LcmsPeakJoiner.InitSpots`
+- `AlignmentSpotProperty.AlignedPeakProperties`
+- `AlignmentChromPeakFeature` dummy rows for every file
+
+`PeakAligner.CollectPeakSpots` then visits files one by one and mutates the
+matching file entry for each spot:
+
+- `Filler.NeedsGapFill`
+- `Filler.GapFill`
+- `DataObjConverter.SetRepresentativeFileID`
+- `DataObjConverter.SetRepresentativeProperty`
+
+The gap filler needs, for each spot:
+
+- detected peaks across files to estimate center and peak width,
+- the current file entry to update missing peak values,
+- estimated noise from detected peaks.
+
+### Filtering and refining
+
+Filtering uses per-file values:
+
+- `PeakCountFilter`: count of detected peaks.
+- `QcFilter`: QC file detection.
+- `DetectedNumberFilter`: per-class detection count.
+- `BlankFilter`: blank/sample peak-height summaries.
+
+`LcmsAlignmentRefiner` uses per-file values for:
+
+- representative peak selection,
+- fold-change and ANOVA,
+- blank filtering,
+- adduct/isotope/representative peak links,
+- ion abundance correlation links.
+
+The ion abundance correlation step is especially expensive because it compares
+peak-height vectors between RT-neighboring spots.
+
+### Text export
+
+`AlignmentCSVExporter` and `MztabFormatExporter` mostly consume per-file
+values through `IQuantValueAccessor`.
+
+For LC-MS console defaults, the required per-file values are:
+
+| Export need | Source field |
+| --- | --- |
+| Height matrix | `PeakHeightTop` |
+| Area matrix | `PeakAreaAboveZero` |
+| Normalized height | `NormalizedPeakHeight` |
+| Normalized area | `NormalizedPeakAreaAboveZero` |
+| Peak ID matrix | `MasterPeakID` |
+| RT matrix | `ChromXsTop.RT.Value` |
+| Mass matrix | `Mass` |
+| S/N matrix | `PeakShape.SignalToNoise` |
+| MS/MS presence | `MS2RawSpectrumID` or `MS2RawSpectrumID2CE` |
+| mzTab spectra_ref | `MS1RawSpectrumIdTop`, `MS2RawSpectrumID`, `FileID` |
+| representative MSDec lookup | representative `MasterPeakID` or `MSDecResultIdUsed` |
+
+Spot-level metadata can remain in `AlignmentSpotProperty`:
+
+- `AlignmentID`, `MasterAlignmentID`, `RepresentativeFileID`
+- `TimesCenter`, `TimesMin`, `TimesMax`
+- `MassCenter`, `MassMin`, `MassMax`
+- annotation fields and `MatchResults`
+- `HeightAverage`, `HeightMin`, `HeightMax`
+- `FillParcentage`, `PeakWidthAverage`
+- S/N and estimated-noise summaries
+- adduct, formula, ontology, comment, internal standard IDs
+
+## Decision
+
+Introduce an LC-MS console-only alignment-light path that separates:
+
+1. spot-level metadata retained in memory,
+2. per-file aligned peak values stored in a compact row/chunk store,
+3. text exporters that read per-file values on demand.
+
+Do not attempt to preserve full GUI-compatible `.arf2` project data in the
+first streaming implementation. The initial success criterion is stable
+generation of `mdalign`, `mdmsp`, and `mzTab`.
+
+In alignment-light mode, the Console treats `-p` as incompatible with the light
+text-only contract and skips project saving with a console message.
+
+## Proposed Design
+
+### Compact peak row
+
+Create a compact DTO for the text-export-required subset:
+
+```csharp
+internal readonly record struct AlignmentLightPeakRow(
+    int SpotId,
+    int FileId,
+    string FileName,
+    int MasterPeakId,
+    int PeakId,
+    double Height,
+    double Area,
+    double NormalizedHeight,
+    double NormalizedArea,
+    double Rt,
+    double Mz,
+    float SignalToNoise,
+    int Ms1RawSpectrumIdTop,
+    int Ms2RawSpectrumId,
+    bool IsMsmsAssigned);
+```
+
+This is intentionally smaller than `AlignmentChromPeakFeature` and avoids nested
+objects such as `ChromXs`, `IonFeatureCharacter`, `ChromatogramPeakShape`,
+annotation dictionaries, and match result containers for every file.
+
+### Fixed-size matrix store
+
+Add an internal alignment-light store:
+
+```csharp
+internal interface IAlignmentLightPeakStore : IDisposable {
+    void Initialize(int spotCount, IReadOnlyList<AnalysisFileBean> files);
+    void WriteSpotPeaks(int spotId, IReadOnlyList<AlignmentChromPeakFeature> peaks);
+    IReadOnlyList<AlignmentLightPeakRow> ReadSpotPeaks(int spotId);
+}
+```
+
+The current implementation uses a binary temporary file as a fixed-size matrix:
+
+- physical layout: `spotCount x fileCount`
+- offset: `(physicalSpotId * fileCount + fileIndex) * recordSize`
+- record size is fixed because file names are not written per cell
+- `AnalysisFileBean` supplies file names and file IDs during reads
+- refined/reordered spot IDs are handled by a small logical-to-physical ID map
+
+This avoids one `List<long>` offset list per spot and avoids repeating file
+name strings for every spot/sample cell.
+
+### Export adapter
+
+Add a quant accessor that reads from the chunk store:
+
+```csharp
+internal sealed class AlignmentLightQuantValueAccessor : IQuantValueAccessor {
+    // ReadSpotPeaks(spot.AlignmentID) and produce the same dictionaries as
+    // LegacyQuantValueAccessor.
+}
+```
+
+Then `AlignmentCSVExporter` and `MztabFormatExporter` can be reused at first.
+
+### Refiner boundary
+
+The hardest question is when to clear `AlignedPeakProperties`.
+
+Recommended first streaming phase:
+
+1. Keep full `AlignedPeakProperties` through join, filtering, gap filling, and
+   refiner.
+2. After `Refiner.Refine`, write per-file rows to the chunk store.
+3. Replace each spot's `AlignedPeakProperties` with a minimal representative
+   row or clear it after all existing metadata and representative MSDec results
+   are resolved.
+4. Export text through `AlignmentLightQuantValueAccessor`.
+
+This reduces memory during export and project packing, but not during join and
+gap filling. It is the lowest-risk bridge because it should preserve current
+text output exactly.
+
+Recommended second streaming phase:
+
+1. Replace `LcmsPeakJoiner.InitSpots` full dummy peak allocation with a compact
+   matrix or file-wise sparse map.
+2. Run gap filling file-by-file and write final rows directly to the chunk
+   store.
+3. Compute spot-level summaries incrementally.
+4. Keep optional expensive features, such as ion-abundance correlation links,
+   behind a console flag.
+
+## Implementation Phases
+
+### Phase 1: export-time detachment
+
+Goal: prove that text exporters can work from a chunk store and that full
+`AlignedPeakProperties` can be dropped before project packing.
+
+Expected output:
+
+- `mdalign` identical to baseline.
+- `mzTab` identical except filename-derived metadata.
+- `mdmsp` identical.
+- no GUI EIC cache, `.arf2` alignment object, alignment peak-property object
+  file, or project file in alignment-light mode.
+- alignment `.dcl` is still written.
+
+Implemented bridge:
+
+- `AlignmentLightPeakStore` writes compact per-file peak rows to a temporary
+  fixed-size binary matrix.
+- `AlignmentLightQuantValueAccessor` lets existing text exporters read
+  quantitative values from that store.
+- LC-MS Console skips GUI chromatogram serialization, alignment object
+  serialization, and `-p` project saving when `Alignment light mode: True`.
+- LC-MS Console still writes alignment representative spectra `.dcl`.
+- LC-MS Console forces ion-abundance correlation links off in alignment-light
+  mode.
+
+### Phase 2: refiner-light mode
+
+Goal: avoid expensive optional cross-spot vector work.
+
+Candidate switches:
+
+```txt
+Alignment light correlation links: False
+Alignment light isotope/adduct links: True
+Alignment light blank filtering: True
+```
+
+The default can preserve existing behavior for validation; large-scale users can
+turn off correlation links if needed.
+
+### Phase 3: join/gap-fill streaming
+
+Goal: remove the main `spots x files` object graph.
+
+Implemented prototype:
+
+- LC-MS Console uses `LcmsAlignmentLightRunner` when `Alignment light mode:
+  True`.
+- `AlignmentLightPeakStore` is initialized once the master peak count is known,
+  then stores rows in a fixed-size `spot x file` binary matrix.
+- The runner builds an LC-MS master peak list, then visits analysis files in a
+  detected-peak pass and writes matched rows directly to `AlignmentLightPeakStore`.
+- Gap filling runs file-by-file for retained spots; gap-filled rows are also
+  written directly to the compact store.
+- `AlignmentSpotProperty.AlignedPeakProperties` is reduced to a single
+  representative peak per spot. The full `spots x files` peak object graph is
+  no longer retained in memory in the light path.
+- Spot-level filtering no longer keeps a `HashSet<int>` of detected file IDs
+  per spot. It keeps aggregate QC and class detection counts instead.
+- The LC-MS spot-level refiner keeps the current priority order for
+  reference-matched and high-abundance features, but ion-abundance correlation
+  links remain disabled.
+- The representative alignment `.dcl` is still written from the selected
+  representative per-file deconvolution results.
+- Representative alignment MSDec results are written to `.dcl` from a streaming
+  enumerable and exposed to existing exporters through a file-backed
+  `IReadOnlyList<MSDecResult>`. This avoids holding the full representative
+  alignment MSDec list in memory during light-mode text export.
+- The file-backed MSDec list keeps a small bounded LRU cache. This preserves
+  lazy file access while avoiding repeated deserialization when an exporter asks
+  for the same alignment MSDec result again immediately.
+- Light-mode export forces a full GC between alignment text exporters. The
+  file-backed MSDec list reduces retained memory, but current exporters
+  intentionally reread MSDec objects for separate `mdalign`, `mdmsp`, and
+  `mzTab` passes; the GC boundary prevents these temporary allocations from
+  accumulating across exporter stages.
+- Light-mode mzTab export writes the SML section directly and spools SMF/SME
+  sections to temporary text files during the same spot pass. This preserves
+  mzTab section ordering while reducing repeated spot metadata and MSDec reads.
+
+FastLC validation after the prototype:
+
+- full alignment retained 908 LC-MS alignment spots.
+- alignment-light streaming retained 908 LC-MS alignment spots.
+- `mdalign`: same line count and identical SHA256 hash as full output.
+- `mzTab`: same line count and identical SHA256 hash after normalizing the
+  filename-derived `MTD mzTab-ID`.
+- `mdmsp`: same line count and identical SHA256 hash as full output.
+- light mode generated the alignment `.dcl`, but did not generate a GUI project
+  file.
+
+The only remaining non-identical text detail is the expected filename-derived
+`MTD mzTab-ID` value.
+
+Additional performance validation after MS1/raw-read reuse and fixed-size
+matrix storage:
+
+| Input | Mode | Elapsed | Peak private memory |
+| --- | --- | ---: | ---: |
+| 7 FastLC files | Full | 112.3 s | 854.2 MB |
+| 7 FastLC files | Light | 113.2 s | 837.7 MB |
+| 14 duplicated rows | Full | 223.8 s | 2568.4 MB |
+| 14 duplicated rows | Light | 216.8 s | 2386.1 MB |
+
+Additional validation after file-backed alignment MSDec access:
+
+| Input | Mode | Elapsed | Peak private memory | Output comparison |
+| --- | --- | ---: | ---: | --- |
+| 7 FastLC files | Light | 110.9 s | 795.4 MB | `mdalign`/`mdmsp` byte-identical; `mzTab` identical after normalizing `MTD mzTab-ID` |
+| 14 duplicated rows | Light | 217.7 s | 2509.0 MB | `mdalign`/`mdmsp` byte-identical; `mzTab` identical after normalizing `MTD mzTab-ID` |
+
+Additional validation after light-mode mzTab section spooling and bounded
+file-backed MSDec cache:
+
+| Input | Mode | Elapsed | Peak private memory | Output comparison |
+| --- | --- | ---: | ---: | --- |
+| 7 FastLC files | Light | 110.1 s | 837.3 MB | `mdalign`/`mdmsp` byte-identical; `mzTab` identical after normalizing `MTD mzTab-ID` |
+| 14 duplicated rows | Light | 212.6 s | 2473.5 MB | `mdalign`/`mdmsp` byte-identical; `mzTab` identical after normalizing `MTD mzTab-ID` |
+
+The small demo is not representative of thousands of files, but it confirms
+that the light path now has equal text output and lower peak memory than the
+full baseline in the sample-count direction. The 14-row file-backed MSDec run
+is slightly higher than the matrix-store-only light run because current
+exporters still read MSDec objects in separate `mdalign`, `mdmsp`, and `mzTab`
+passes. The mzTab spooler removes repeated reads inside the mzTab pass itself,
+improving elapsed time in the 14-row validation while preserving text output.
+
+## Risks
+
+- `AlignmentRefiner` currently expects full per-file peak objects for multiple
+  behaviors. Clearing too early will change annotations and links.
+- `MztabFormatExporter.WriteSmeDataLine` uses per-file MS/MS scan IDs for
+  `spectra_ref`; the chunk store must retain these fields.
+- Normalization exports require normalized values. If normalization is enabled
+  before export, the chunk store must capture post-normalization values.
+- Full GUI project compatibility cannot be guaranteed once per-file peak
+  objects are detached.
+- The streaming prototype currently targets LC-MS only. Other processes need
+  separate join/gap-fill implementations.
+
+## Validation Plan
+
+Use the FastLC WIFF demo:
+
+- baseline console mode,
+- alignment-light mode,
+- compare SHA256 for `mdalign` and `mdmsp`,
+- compare `mzTab` after normalizing filename-derived `mzTab-ID`,
+- verify no `.EIC.aef` is created in alignment-light mode.
+
+Then repeat with a larger synthetic CSV that references duplicated demo files
+to measure peak memory and runtime behavior.

--- a/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/Alignment/PeakAligner.cs
@@ -145,7 +145,7 @@ public class PeakAligner {
                 if (Filler.NeedsGapFill(spot, analysisFile)) {
                     Filler.GapFill(ms1Spectra, rawSpectra, spectra, spot, analysisFile.AnalysisFileId);
                 }
-                if (DataObjConverter.GetRepresentativeFileID(spot.AlignedPeakProperties.Where(p => p.PeakID >= 0).ToArray()) == analysisFile.AnalysisFileId) {
+                if (spot.RepresentativeFileID == analysisFile.AnalysisFileId) {
                     var index = spectra.LowerBound(peak.MS1RawSpectrumIdTop, (s, id) => s.Index.CompareTo(id));
                     if (index < 0 || spectra == null || index >= spectra.Count) {
                         spot.IsotopicPeaks = new List<IsotopicPeak>(0);

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLightPeakStore.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLightPeakStore.cs
@@ -1,0 +1,387 @@
+using CompMs.Common.Mathematics.Basic;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Parameter;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CompMs.MsdialCore.Export;
+
+public readonly struct AlignmentLightPeakRow {
+    public AlignmentLightPeakRow(
+        int fileID,
+        string fileName,
+        int masterPeakID,
+        int peakID,
+        double peakHeightTop,
+        double peakAreaAboveZero,
+        double normalizedPeakHeight,
+        double normalizedPeakAreaAboveZero,
+        double rt,
+        double ri,
+        double mobility,
+        double collisionCrossSection,
+        double mass,
+        float signalToNoise,
+        int ms1RawSpectrumIdTop,
+        int ms2RawSpectrumID,
+        int representativeLibraryID,
+        bool isMsmsAssigned) {
+        FileID = fileID;
+        FileName = fileName;
+        MasterPeakID = masterPeakID;
+        PeakID = peakID;
+        PeakHeightTop = peakHeightTop;
+        PeakAreaAboveZero = peakAreaAboveZero;
+        NormalizedPeakHeight = normalizedPeakHeight;
+        NormalizedPeakAreaAboveZero = normalizedPeakAreaAboveZero;
+        Rt = rt;
+        Ri = ri;
+        Mobility = mobility;
+        CollisionCrossSection = collisionCrossSection;
+        Mass = mass;
+        SignalToNoise = signalToNoise;
+        MS1RawSpectrumIdTop = ms1RawSpectrumIdTop;
+        MS2RawSpectrumID = ms2RawSpectrumID;
+        RepresentativeLibraryID = representativeLibraryID;
+        IsMsmsAssigned = isMsmsAssigned;
+    }
+
+    public int FileID { get; }
+    public string FileName { get; }
+    public int MasterPeakID { get; }
+    public int PeakID { get; }
+    public double PeakHeightTop { get; }
+    public double PeakAreaAboveZero { get; }
+    public double NormalizedPeakHeight { get; }
+    public double NormalizedPeakAreaAboveZero { get; }
+    public double Rt { get; }
+    public double Ri { get; }
+    public double Mobility { get; }
+    public double CollisionCrossSection { get; }
+    public double Mass { get; }
+    public float SignalToNoise { get; }
+    public int MS1RawSpectrumIdTop { get; }
+    public int MS2RawSpectrumID { get; }
+    public int RepresentativeLibraryID { get; }
+    public bool IsMsmsAssigned { get; }
+}
+
+public sealed class AlignmentLightPeakStore : IDisposable {
+    private const int RecordSize = 102;
+
+    private readonly string _filePath;
+    private readonly FileStream _stream;
+    private readonly BinaryWriter _writer;
+    private IReadOnlyList<AnalysisFileBean> _files = Array.Empty<AnalysisFileBean>();
+    private Dictionary<int, int> _fileIdToIndex = new Dictionary<int, int>();
+    private Dictionary<int, int>? _logicalToPhysicalSpotId;
+    private int _spotCount;
+    private bool _disposed;
+    private bool _initialized;
+
+    private AlignmentLightPeakStore(string filePath) {
+        _filePath = filePath;
+        _stream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+        _writer = new BinaryWriter(_stream);
+    }
+
+    public static AlignmentLightPeakStore CreateTemp() {
+        return new AlignmentLightPeakStore(Path.GetTempFileName());
+    }
+
+    public void Initialize(int spotCount, IReadOnlyList<AnalysisFileBean> files) {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(AlignmentLightPeakStore));
+        }
+        if (_initialized) {
+            throw new InvalidOperationException("Alignment light peak matrix store was already initialized.");
+        }
+        if (spotCount < 0) {
+            throw new ArgumentOutOfRangeException(nameof(spotCount));
+        }
+        if (files is null || files.Count == 0) {
+            throw new ArgumentException("At least one analysis file is required.", nameof(files));
+        }
+
+        _spotCount = spotCount;
+        _files = files.OrderBy(file => file.AnalysisFileId).ToArray();
+        _fileIdToIndex = _files
+            .Select((file, index) => (file.AnalysisFileId, index))
+            .ToDictionary(pair => pair.AnalysisFileId, pair => pair.index);
+        _stream.SetLength((long)_spotCount * _files.Count * RecordSize);
+        _initialized = true;
+    }
+
+    public void WriteSpotPeaks(int spotID, IReadOnlyList<AlignmentChromPeakFeature> peaks) {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(AlignmentLightPeakStore));
+        }
+
+        foreach (var peak in peaks) {
+            WriteSpotPeak(spotID, peak);
+        }
+        _writer.Flush();
+    }
+
+    public void WriteSpotPeak(int spotID, AlignmentChromPeakFeature peak) {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(AlignmentLightPeakStore));
+        }
+        EnsureInitialized();
+
+        var offset = GetOffset(spotID, peak.FileID);
+        _stream.Seek(offset, SeekOrigin.Begin);
+        WritePeak(peak);
+    }
+
+    public IReadOnlyList<AlignmentLightPeakRow> ReadSpotPeaks(int spotID) {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(AlignmentLightPeakStore));
+        }
+        EnsureInitialized();
+
+        _writer.Flush();
+        using var reader = new BinaryReader(_stream, System.Text.Encoding.UTF8, leaveOpen: true);
+        var physicalSpotId = GetPhysicalSpotId(spotID);
+        var rows = new List<AlignmentLightPeakRow>(_files.Count);
+        foreach (var file in _files) {
+            var offset = GetOffset(physicalSpotId, file.AnalysisFileId);
+            _stream.Seek(offset, SeekOrigin.Begin);
+            rows.Add(ReadPeak(reader, file));
+        }
+        return rows;
+    }
+
+    public void RemapSpotIds(IReadOnlyDictionary<int, int> oldToNewSpotIDs) {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(AlignmentLightPeakStore));
+        }
+        EnsureInitialized();
+
+        var remapped = new Dictionary<int, int>(oldToNewSpotIDs.Count);
+        foreach (var pair in oldToNewSpotIDs) {
+            remapped[pair.Value] = pair.Key;
+        }
+        _logicalToPhysicalSpotId = remapped;
+    }
+
+    private void WritePeak(AlignmentChromPeakFeature peak) {
+        _writer.Write(true);
+        _writer.Write(peak.FileID);
+        _writer.Write(peak.MasterPeakID);
+        _writer.Write(peak.PeakID);
+        _writer.Write(peak.PeakHeightTop);
+        _writer.Write(peak.PeakAreaAboveZero);
+        _writer.Write(peak.NormalizedPeakHeight);
+        _writer.Write(peak.NormalizedPeakAreaAboveZero);
+        _writer.Write(peak.ChromXsTop?.RT.Value ?? 0d);
+        _writer.Write(peak.ChromXsTop?.RI.Value ?? 0d);
+        _writer.Write(peak.ChromXsTop?.Drift.Value ?? 0d);
+        _writer.Write(peak.CollisionCrossSection);
+        _writer.Write(peak.Mass);
+        _writer.Write(peak.PeakShape?.SignalToNoise ?? 0f);
+        _writer.Write(peak.MS1RawSpectrumIdTop);
+        _writer.Write(peak.MS2RawSpectrumID);
+        _writer.Write(peak.MatchResults?.Representative?.LibraryID ?? -1);
+        _writer.Write(peak.IsMsmsAssigned);
+    }
+
+    private static AlignmentLightPeakRow ReadPeak(BinaryReader reader, AnalysisFileBean file) {
+        var occupied = reader.ReadBoolean();
+        if (!occupied) {
+            return CreateMissingPeak(file);
+        }
+
+        return new AlignmentLightPeakRow(
+            reader.ReadInt32(),
+            file.AnalysisFileName,
+            reader.ReadInt32(),
+            reader.ReadInt32(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadDouble(),
+            reader.ReadSingle(),
+            reader.ReadInt32(),
+            reader.ReadInt32(),
+            reader.ReadInt32(),
+            reader.ReadBoolean());
+    }
+
+    private static AlignmentLightPeakRow CreateMissingPeak(AnalysisFileBean file) {
+        return new AlignmentLightPeakRow(
+            file.AnalysisFileId,
+            file.AnalysisFileName,
+            -1,
+            -1,
+            0d,
+            0d,
+            0d,
+            0d,
+            0d,
+            0d,
+            0d,
+            0d,
+            0d,
+            0f,
+            -1,
+            -1,
+            -1,
+            false);
+    }
+
+    private long GetOffset(int spotID, int fileID) {
+        if (spotID < 0 || spotID >= _spotCount) {
+            throw new ArgumentOutOfRangeException(nameof(spotID));
+        }
+        if (!_fileIdToIndex.TryGetValue(fileID, out var fileIndex)) {
+            throw new ArgumentOutOfRangeException(nameof(fileID), $"Unknown analysis file ID: {fileID}");
+        }
+        return ((long)spotID * _files.Count + fileIndex) * RecordSize;
+    }
+
+    private int GetPhysicalSpotId(int spotID) {
+        return _logicalToPhysicalSpotId is not null && _logicalToPhysicalSpotId.TryGetValue(spotID, out var physicalSpotId)
+            ? physicalSpotId
+            : spotID;
+    }
+
+    private void EnsureInitialized() {
+        if (!_initialized) {
+            throw new InvalidOperationException("Alignment light peak matrix store is not initialized.");
+        }
+    }
+
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+        _disposed = true;
+        _writer.Dispose();
+        _stream.Dispose();
+        if (File.Exists(_filePath)) {
+            File.Delete(_filePath);
+        }
+    }
+}
+
+public sealed class AlignmentLightQuantValueAccessor : IQuantValueAccessor {
+    private readonly string _exportType;
+    private readonly ParameterBase _parameter;
+    private readonly AlignmentLightPeakStore _store;
+
+    public AlignmentLightQuantValueAccessor(string exportType, ParameterBase parameter, AlignmentLightPeakStore store) {
+        _exportType = exportType;
+        _parameter = parameter;
+        _store = store;
+    }
+
+    public List<string> GetQuantHeaders(IReadOnlyList<AnalysisFileBean> files) {
+        return files.OrderBy(file => file.AnalysisFileId).Select(file => file.AnalysisFileName).ToList();
+    }
+
+    public List<string> GetStatHeaders() {
+        return _parameter.ClassnameToOrder.OrderBy(kvp => kvp.Value).Select(kvp => kvp.Key).ToList();
+    }
+
+    public Dictionary<string, string> GetQuantValues(AlignmentSpotProperty spot) {
+        var quantValues = new Dictionary<string, string>();
+        var peaks = _store.ReadSpotPeaks(spot.MasterAlignmentID);
+        var nonZeroMin = GetInterpolatedValueForMissingValue(peaks);
+        foreach (var peak in peaks) {
+            var spotValue = GetSpotValueAsString(peak);
+            if (nonZeroMin >= 0) {
+                double.TryParse(spotValue, out var doubleValue);
+                if (doubleValue == 0) {
+                    doubleValue = nonZeroMin * 0.1;
+                }
+                spotValue = doubleValue.ToString();
+            }
+            quantValues.Add(peak.FileName, spotValue);
+        }
+        return quantValues;
+    }
+
+    public Dictionary<string, string> GetStatsValues(AlignmentSpotProperty spot, StatsValue stat) {
+        var groups = _store.ReadSpotPeaks(spot.MasterAlignmentID).GroupBy(
+            peak => _parameter.FileID_ClassName[peak.FileID],
+            peak => GetSpotValue(peak));
+        switch (stat) {
+            case StatsValue.Average:
+                return groups.ToDictionary(
+                    group => group.Key,
+                    group => group.Average().ToString()
+                );
+            case StatsValue.Stdev:
+                return groups.ToDictionary(
+                    group => group.Key,
+                    group => ReplaceNaN(BasicMathematics.Stdev(group.ToArray())).ToString()
+                );
+        }
+        return new Dictionary<string, string>();
+    }
+
+    private double GetInterpolatedValueForMissingValue(IReadOnlyList<AlignmentLightPeakRow> peaks) {
+        if (_exportType != "Height" && _exportType != "Area" && _exportType != "Normalized height" && _exportType != "Normalized area") {
+            return -1;
+        }
+        if (!_parameter.IsReplaceTrueZeroValuesWithHalfOfMinimumPeakHeightOverAllSamples) {
+            return -1;
+        }
+
+        var nonZeroMin = double.MaxValue;
+        foreach (var peak in peaks) {
+            var variable = GetSpotValue(peak);
+            if (variable > 0 && nonZeroMin > variable) {
+                nonZeroMin = variable;
+            }
+        }
+        return nonZeroMin == double.MaxValue ? 1 : nonZeroMin;
+    }
+
+    private string GetSpotValueAsString(AlignmentLightPeakRow peak) {
+        switch (_exportType) {
+            case "Height": return Math.Round(peak.PeakHeightTop, 0).ToString();
+            case "Normalized height": return peak.NormalizedPeakHeight.ToString();
+            case "Normalized area": return peak.NormalizedPeakAreaAboveZero.ToString();
+            case "Area": return Math.Round(peak.PeakAreaAboveZero, 0).ToString();
+            case "ID": return peak.MasterPeakID.ToString();
+            case "RT": return Math.Round(peak.Rt, 3).ToString();
+            case "RI": return Math.Round(peak.Ri, 2).ToString();
+            case "Mobility": return Math.Round(peak.Mobility, 5).ToString();
+            case "CCS": return Math.Round(peak.CollisionCrossSection, 3).ToString();
+            case "MZ": return Math.Round(peak.Mass, 5).ToString();
+            case "SN": return Math.Round(peak.SignalToNoise, 1).ToString();
+            case "MSMS": return peak.MS2RawSpectrumID >= 0 ? "TRUE" : "FALSE";
+            default: return string.Empty;
+        }
+    }
+
+    private double GetSpotValue(AlignmentLightPeakRow peak) {
+        switch (_exportType) {
+            case "Height": return peak.PeakHeightTop;
+            case "Normalized height": return peak.NormalizedPeakHeight;
+            case "Normalized area": return peak.NormalizedPeakAreaAboveZero;
+            case "Area": return peak.PeakAreaAboveZero;
+            case "ID": return peak.MasterPeakID;
+            case "RT": return peak.Rt;
+            case "RI": return peak.Ri;
+            case "Mobility": return peak.Mobility;
+            case "CCS": return peak.CollisionCrossSection;
+            case "MZ": return peak.Mass;
+            case "SN": return peak.SignalToNoise;
+            case "MSMS": return peak.MS2RawSpectrumID;
+            default: return -1;
+        }
+    }
+
+    private static double ReplaceNaN(double val) => double.IsNaN(val) ? 0d : val;
+
+}

--- a/src/MSDIAL5/MsdialCore/Export/MztabFormatExport.cs
+++ b/src/MSDIAL5/MsdialCore/Export/MztabFormatExport.cs
@@ -13,9 +13,12 @@ namespace CompMs.MsdialCore.Export
 {
     public sealed class MztabFormatExporter
     {
-        public MztabFormatExporter(DataBaseStorage dataBaseStorage)
+        private readonly AlignmentLightPeakStore? _lightPeakStore;
+
+        public MztabFormatExporter(DataBaseStorage dataBaseStorage, AlignmentLightPeakStore? lightPeakStore = null)
         {
             _dataBaseStorage = dataBaseStorage;
+            _lightPeakStore = lightPeakStore;
 
             _annotatorID2DataBaseID = new Dictionary<string, string>();
             foreach (var db in dataBaseStorage.MetabolomicsDataBases) {
@@ -64,6 +67,11 @@ namespace CompMs.MsdialCore.Export
             string outfile
         )
         {
+            if (_lightPeakStore is not null) {
+                MztabFormatExporterCoreWithTemporarySectionSpooling(stream, spots, msdecResults, files, metaAccessor, quantAccessor, stats, outfile);
+                return;
+            }
+
             var exportFileName = Path.GetFileNameWithoutExtension(outfile);
             var mztabId = exportFileName; // as filename
             var meta = (metaAccessor as BaseMetadataAccessor).Parameter;
@@ -87,7 +95,7 @@ namespace CompMs.MsdialCore.Export
 
             var internalStandardDic = SetStandardDic(spots);
             //MTD section
-            WriteMtdSection(sw, mztabId, meta, [.. spots], RawFileMetadataDic, AnalysisFileClassDic, idConfidenceMeasure, database);
+            WriteMtdSection(sw, mztabId, meta, spots, RawFileMetadataDic, AnalysisFileClassDic, idConfidenceMeasure, database);
             sw.WriteLine();
 
             //SML section
@@ -179,6 +187,143 @@ namespace CompMs.MsdialCore.Export
                 sw.WriteLine("");
             }
             sw.WriteLine("");
+        }
+
+        private void MztabFormatExporterCoreWithTemporarySectionSpooling(
+            Stream stream,
+            IReadOnlyList<AlignmentSpotProperty> spots,
+            IReadOnlyList<MSDecResult> msdecResults,
+            IReadOnlyList<AnalysisFileBean> files,
+            IMetadataAccessor metaAccessor,
+            IQuantValueAccessor quantAccessor,
+            IReadOnlyList<StatsValue> stats,
+            string outfile
+        )
+        {
+            var exportFileName = Path.GetFileNameWithoutExtension(outfile);
+            var mztabId = exportFileName; // as filename
+            var meta = (metaAccessor as BaseMetadataAccessor).Parameter;
+            using var sw = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true);
+
+            var idConfidenceMeasure = SetIdConfidenceMeasure(meta.MachineCategory, idConfidenceDefault);
+            var manualAssigned = new List<bool>(spots.Select(n => n.IsManuallyModifiedForAnnotation));
+            if (manualAssigned.Contains(true))
+            {
+                idConfidenceMeasure.Add(idConfidenceMeasure.Count + 1, idConfidenceManual);
+            }
+            var database = SetDatabaseList(meta, spots);
+            var RawFileMetadataDic = SetRawFileMetadataDic(files, meta.IonMode);
+            var AnalysisFileClassDic = files
+                    .Select(file => file.AnalysisFileClass)
+                    .Distinct()
+                    .Select((cls, idx) => new { Key = idx + 1, Value = cls })
+                    .ToDictionary(x => x.Key, x => x.Value);
+
+            var internalStandardDic = SetStandardDic(spots);
+            WriteMtdSection(sw, mztabId, meta, spots, RawFileMetadataDic, AnalysisFileClassDic, idConfidenceMeasure, database);
+            sw.WriteLine();
+
+            var hasComment = spots.Any(s => !string.IsNullOrEmpty(s.Comment));
+            var hasMs2 = spots.Any(n => n.IsMsmsAssigned);
+            var SmlDataHeader = WriteSmlHeader(sw, meta, RawFileMetadataDic, AnalysisFileClassDic, hasComment, hasMs2);
+
+            var smfTemp = Path.GetTempFileName();
+            var smeTemp = Path.GetTempFileName();
+            try {
+                using (var smfWriter = new StreamWriter(File.Open(smfTemp, FileMode.Create, FileAccess.Write, FileShare.Read), Encoding.ASCII))
+                using (var smeWriter = new StreamWriter(File.Open(smeTemp, FileMode.Create, FileAccess.Write, FileShare.Read), Encoding.ASCII)) {
+                    var SmfDataHeader = WriteSmfHeader(smfWriter, meta, RawFileMetadataDic);
+                    if (hasMs2) {
+                        WriteSmeHeader(smeWriter, idConfidenceMeasure);
+                    }
+
+                    foreach (var spot in spots)
+                    {
+                        var msdec = msdecResults[spot.MasterAlignmentID];
+                        var metadata = metaAccessor.GetContent(spot, msdec);
+                        WriteSmlDataLine(
+                            sw, spot, meta, metadata, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
+                            database, SmlDataHeader, internalStandardDic, hasComment, hasMs2
+                            );
+                        WriteSmfDataLine(
+                            smfWriter, spot, meta, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
+                            SmfDataHeader, internalStandardDic, metadata
+                            );
+                        foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>())
+                        {
+                            WriteSmlDataLine(
+                                sw, driftSpot, meta, metadata, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
+                                database, SmlDataHeader, internalStandardDic, hasComment, hasMs2
+                                );
+                            WriteSmfDataLine(
+                                smfWriter, driftSpot, meta, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
+                                SmfDataHeader, internalStandardDic, metadata
+                                );
+                        }
+
+                        if (!ShouldWriteSmeLine(spot, meta, metadata)) {
+                            continue;
+                        }
+
+                        WriteSmeDataLine(
+                            smeWriter, spot, meta, msdec,
+                            database, RawFileMetadataDic, idConfidenceMeasure, files, metadata
+                            );
+                        foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>())
+                        {
+                            if (!driftSpot.IsMsmsAssigned) { continue; }
+
+                            WriteSmeDataLine(
+                                smeWriter, driftSpot, meta, msdec,
+                                database, RawFileMetadataDic, idConfidenceMeasure, files, metadata
+                                );
+                        }
+                        smeWriter.WriteLine("");
+                    }
+                }
+
+                sw.WriteLine();
+                ReplayTemporarySection(sw, smfTemp);
+                sw.WriteLine();
+                if (!hasMs2) { return; }
+                ReplayTemporarySection(sw, smeTemp);
+                sw.WriteLine("");
+            }
+            finally {
+                TryDeleteTemporaryFile(smfTemp);
+                TryDeleteTemporaryFile(smeTemp);
+            }
+        }
+
+        private static bool ShouldWriteSmeLine(
+            AlignmentSpotProperty spot,
+            ParameterBase meta,
+            IReadOnlyDictionary<string, string> metadata) {
+            if (spot.IsMsmsAssigned != true) { return false; }
+            if (spot.IsManuallyModifiedForAnnotation == true) { return false; }
+            if (spot.MatchResults.IsTextDbBasedRepresentative == true) { return false; }
+            if (spot.Name == "") { return false; }
+            if (spot.IsBlankFilteredByPostCurator) { return false; }
+            if (meta.IsNormalizeSplash && spot.InternalStandardAlignmentID == -1) { return false; }
+            if (meta.IsNormalizeIS && spot.InternalStandardAlignmentID == -1) { return false; }
+            return !metadata["Metabolite name"].Contains("no MS2");
+        }
+
+        private static void ReplayTemporarySection(StreamWriter sw, string path) {
+            using var reader = new StreamReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read), Encoding.ASCII);
+            string line;
+            while ((line = reader.ReadLine()) != null) {
+                sw.WriteLine(line);
+            }
+        }
+
+        private static void TryDeleteTemporaryFile(string path) {
+            try {
+                File.Delete(path);
+            }
+            catch {
+                // Temporary export spools are best-effort cleanup files.
+            }
         }
 
         private void WriteSmlDataLine(
@@ -411,50 +556,31 @@ namespace CompMs.MsdialCore.Export
                 charge = "-" + spot.AdductType.ChargeNumber.ToString();
             }
 
-            var properties = spot.AlignedPeakProperties;
             var repName = spot.MatchResults.Representative.Name.Split('|').Last();
             var repLibraryID = spot.MatchResults.Representative.LibraryID;
             var chemicalFormula = metadata["Formula"];
             var smiles = metadata["SMILES"];
             var theoreticalMassToCharge = metadata.TryGetValue("Reference m/z", out var refmz) ? refmz : "0";
             var spectraRefList = new List<string>();  //  multiple files
-            for (int i = 0; i < properties.Count; i++)
-            {
-                if (properties[i].PeakID < 0) continue;
-                if (!properties[i].IsMsmsAssigned) continue;
-                if (properties[i].MatchResults.Representative.LibraryID != repLibraryID)
-                { continue; }
+            if (_lightPeakStore is null) {
+                var properties = spot.AlignedPeakProperties;
+                for (int i = 0; i < properties.Count; i++)
+                {
+                    if (properties[i].PeakID < 0) continue;
+                    if (!properties[i].IsMsmsAssigned) continue;
+                    if (properties[i].MatchResults.Representative.LibraryID != repLibraryID)
+                    { continue; }
 
-                /// to get file id, peak id in aligned spots
-
-                var ms1ScanID = properties[i].MS1RawSpectrumIdTop;
-                var ms2ScanID = properties[i].MS2RawSpectrumID;
-                /////
-
-                var ms1ScanIDString = "ms1scanID";
-                var ms2ScanIDString = "ms2scanID";
-
-                var ScanIDString = ms1ScanIDString + "=" + ms1ScanID + " " + ms2ScanIDString + "=" + ms2ScanID;
-
-                //switch (RawFileMetadataDic[i+1].Id_format_cv)
-                //{
-                //    case ("[MS, MS:1000770, WIFF nativeID format, ]"):
-                //        ScanIDString = "scanId=" + ms2ScanID;
-                //        break;
-                //    case ("[MS, MS:1001508, Agilent MassHunter nativeID format, ]"):
-                //        ScanIDString = "scanId=" + ms2ScanID;
-                //        break;
-                //    case ("[MS, MS:1000776, scan number only nativeID format, ]"):
-                //    case ("[MS, MS:1000526, Waters raw format, ]"):
-                //    case ("[MS, MS:1000768, Thermo nativeID format, ]"):
-                //    case ("[MS, MS:1000929, Shimadzu Biotech nativeID format, ]"):
-                //        ScanIDString = "scan=" + ms2ScanID;
-                //        break; 
-                //    default:
-                //        ScanIDString = ms1ScanIDString + "=" + ms1ScanID + " " + ms2ScanIDString + "=" + ms2ScanID;
-                //        break;
-                //}
-                spectraRefList.Add("ms_run[" + (i + 1) + "]:" + ScanIDString);
+                    AddSpectraRef(spectraRefList, i + 1, properties[i].MS1RawSpectrumIdTop, properties[i].MS2RawSpectrumID);
+                }
+            }
+            else {
+                foreach (var peak in _lightPeakStore.ReadSpotPeaks(spot.MasterAlignmentID)) {
+                    if (peak.PeakID < 0) continue;
+                    if (!peak.IsMsmsAssigned) continue;
+                    if (peak.RepresentativeLibraryID != repLibraryID) continue;
+                    AddSpectraRef(spectraRefList, peak.FileID + 1, peak.MS1RawSpectrumIdTop, peak.MS2RawSpectrumID);
+                }
             }
 
             var spectraRef = spectraRefList.Count > 0 ? string.Join("| ", spectraRefList) : "null";
@@ -489,6 +615,13 @@ namespace CompMs.MsdialCore.Export
             SmeLine.Add(rank);
             sw.Write(String.Join("\t", SmeLine.Select(item => string.IsNullOrEmpty(item) ? "null" : item).ToList()) + "\t");
 
+        }
+
+        private static void AddSpectraRef(List<string> spectraRefList, int msRunID, int ms1ScanID, int ms2ScanID) {
+            var ms1ScanIDString = "ms1scanID";
+            var ms2ScanIDString = "ms2scanID";
+            var ScanIDString = ms1ScanIDString + "=" + ms1ScanID + " " + ms2ScanIDString + "=" + ms2ScanID;
+            spectraRefList.Add("ms_run[" + msRunID + "]:" + ScanIDString);
         }
 
         internal void WriteMtdSection(

--- a/src/MSDIAL5/MsdialCore/Parser/FileBackedMsdecResults.cs
+++ b/src/MSDIAL5/MsdialCore/Parser/FileBackedMsdecResults.cs
@@ -1,0 +1,74 @@
+using CompMs.MsdialCore.MSDec;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CompMs.MsdialCore.Parser;
+
+public sealed class FileBackedMsdecResults : IReadOnlyList<MSDecResult>, IDisposable {
+    private FileStream? _stream;
+    private readonly int _version;
+    private readonly IReadOnlyList<long> _seekPointers;
+    private readonly bool _isAnnotationInfoIncluded;
+    private readonly int _cacheCapacity;
+    private readonly LinkedList<(int Index, MSDecResult Result)> _cacheOrder = new LinkedList<(int Index, MSDecResult Result)>();
+    private readonly Dictionary<int, LinkedListNode<(int Index, MSDecResult Result)>> _cache = new Dictionary<int, LinkedListNode<(int Index, MSDecResult Result)>>();
+
+    public FileBackedMsdecResults(string file, int cacheCapacity = 16) {
+        _stream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+        MsdecResultsReader.GetSeekPointers(_stream, out _version, out var seekPointers, out _isAnnotationInfoIncluded);
+        _seekPointers = seekPointers;
+        _cacheCapacity = Math.Max(0, cacheCapacity);
+    }
+
+    public int Count => _seekPointers.Count;
+
+    public MSDecResult this[int index] {
+        get {
+            if (_stream is null) {
+                throw new ObjectDisposedException(nameof(FileBackedMsdecResults));
+            }
+            if ((uint)index >= (uint)_seekPointers.Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            if (_cache.TryGetValue(index, out var node)) {
+                _cacheOrder.Remove(node);
+                _cacheOrder.AddFirst(node);
+                return node.Value.Result;
+            }
+
+            var result = MsdecResultsReader.ReadMSDecResult(_stream, _seekPointers[index], _version, _isAnnotationInfoIncluded);
+            if (_cacheCapacity > 0) {
+                var newNode = new LinkedListNode<(int Index, MSDecResult Result)>((index, result));
+                _cacheOrder.AddFirst(newNode);
+                _cache[index] = newNode;
+                if (_cache.Count > _cacheCapacity) {
+                    var last = _cacheOrder.Last;
+                    if (last != null) {
+                        _cache.Remove(last.Value.Index);
+                        _cacheOrder.RemoveLast();
+                    }
+                }
+            }
+            return result;
+        }
+    }
+
+    public IEnumerator<MSDecResult> GetEnumerator() {
+        for (var i = 0; i < Count; i++) {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    public void Dispose() {
+        _cache.Clear();
+        _cacheOrder.Clear();
+        _stream?.Dispose();
+        _stream = null;
+    }
+}

--- a/src/MSDIAL5/MsdialCore/Parser/MsdecResultsWriter.cs
+++ b/src/MSDIAL5/MsdialCore/Parser/MsdecResultsWriter.cs
@@ -13,17 +13,25 @@ namespace CompMs.MsdialCore.Parser {
 
         #region Writer
         public static void Write(string file, IReadOnlyList<MSDecResult> results, bool isAnnotationInfoIncluded = false) {
+            Write(file, results, results.Count, isAnnotationInfoIncluded);
+        }
+
+        public static void Write(string file, IEnumerable<MSDecResult> results, int totalPeakNumber, bool isAnnotationInfoIncluded = false) {
             using (var fs = File.Open(file, FileMode.Create, FileAccess.ReadWrite)) {
-                var totalPeakNumber = results.Count;
                 var seekPointer = new List<long>();
 
                 WriteHeaders(fs, seekPointer, totalPeakNumber, isAnnotationInfoIncluded);
-                for (int i = 0; i < results.Count; i++) {
+                var count = 0;
+                foreach (var result in results) {
                     var seekpoint = fs.Position;
                     seekPointer.Add(seekpoint);
 
-                    results[i].SeekPoint = seekpoint;
-                    MSDecWriterVer1(fs, results[i], isAnnotationInfoIncluded);
+                    result.SeekPoint = seekpoint;
+                    MSDecWriterVer1(fs, result, isAnnotationInfoIncluded);
+                    count++;
+                }
+                if (count != totalPeakNumber) {
+                    throw new InvalidOperationException($"The number of MSDec results ({count}) did not match the expected count ({totalPeakNumber}).");
                 }
                 WriteSeekpointer(fs, seekPointer);
             }

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsAlignmentProcessFactory.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsAlignmentProcessFactory.cs
@@ -14,6 +14,7 @@ public class LcmsAlignmentProcessFactory : AlignmentProcessFactory
 
     public MsdialLcmsParameter LcmsParameter { get; }
     public IProgress<int>? Progress { get; set; }
+    public bool SkipIonAbundanceCorrelationLinks { get; set; }
 
     public LcmsAlignmentProcessFactory(
         IMsdialDataStorage<MsdialLcmsParameter> storage, 
@@ -23,7 +24,7 @@ public class LcmsAlignmentProcessFactory : AlignmentProcessFactory
     }
 
     public override IAlignmentRefiner CreateAlignmentRefiner() {
-        return new LcmsAlignmentRefiner(LcmsParameter, Iupac, _evaluator, Progress);
+        return new LcmsAlignmentRefiner(LcmsParameter, Iupac, _evaluator, Progress, SkipIonAbundanceCorrelationLinks);
     }
 
     public override DataAccessor CreateDataAccessor() {

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsAlignmentRefiner.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsAlignmentRefiner.cs
@@ -20,8 +20,11 @@ namespace CompMs.MsdialLcMsApi.Algorithm.Alignment
     public class LcmsAlignmentRefiner : AlignmentRefiner
     {
         private IProgress<int>? _progress;
-        public LcmsAlignmentRefiner(MsdialLcmsParameter param, IupacDatabase iupac, IMatchResultEvaluator<MsScanMatchResult> evaluator, IProgress<int>? progress) : base(param, iupac, evaluator) {
+        private readonly bool _skipIonAbundanceCorrelationLinks;
+
+        public LcmsAlignmentRefiner(MsdialLcmsParameter param, IupacDatabase iupac, IMatchResultEvaluator<MsScanMatchResult> evaluator, IProgress<int>? progress, bool skipIonAbundanceCorrelationLinks = false) : base(param, iupac, evaluator) {
             _progress = progress;
+            _skipIonAbundanceCorrelationLinks = skipIonAbundanceCorrelationLinks;
         }
 
         protected override List<AlignmentSpotProperty> GetCleanedSpots(List<AlignmentSpotProperty> alignments) {
@@ -69,7 +72,9 @@ namespace CompMs.MsdialLcMsApi.Algorithm.Alignment
         protected override void SetLinks(List<AlignmentSpotProperty> alignments) {
             //checking alignment spot variable correlations
             var rtMargin = 0.06F;
-            AssignLinksByIonAbundanceCorrelations(alignments, rtMargin);
+            if (!_skipIonAbundanceCorrelationLinks) {
+                AssignLinksByIonAbundanceCorrelations(alignments, rtMargin);
+            }
 
             // assigning peak characters from the identified spots
             AssignLinksByIdentifiedIonFeatures(alignments);

--- a/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsGapFiller.cs
+++ b/src/MSDIAL5/MsdialLcMsApi/Algorithm/Alignment/LcmsGapFiller.cs
@@ -49,6 +49,11 @@ public class LcmsGapFiller : IGapFiller
         GapFillCore(target, ms1Spectra, rtCenter, peakWidth);
     }
 
+    public void GapFill(Ms1Spectra ms1Spectra, AlignmentChromPeakFeature target, ChromXs center, double peakWidth, float estimatedNoise) {
+        target.PeakShape.EstimatedNoise = estimatedNoise;
+        GapFillCore(target, ms1Spectra, center, peakWidth);
+    }
+
     public bool NeedsGapFill(AlignmentSpotProperty spot, AnalysisFileBean analysisFile) {
         return spot.AlignedPeakProperties.First(p => p.FileID == analysisFile.AnalysisFileId).MasterPeakID < 0;
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -88,6 +88,28 @@ namespace CompMs.App.MsdialConsole.Parser
             return ReadTextAnnotatorSettingsTable(settingsFilePath, param);
         }
 
+        public static bool ReadAlignmentLightMode(string filepath) {
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    readFieldValues(sr.ReadLine(), out string method, out string value, out bool isReadable);
+                    if (!isReadable) {
+                        continue;
+                    }
+                    switch (method.ToLower()) {
+                        case "alignment light mode":
+                        case "alignment light":
+                        case "console alignment light mode":
+                            var valueLower = value.ToLower();
+                            if (valueLower == "true" || valueLower == "false") {
+                                return bool.Parse(valueLower);
+                            }
+                            break;
+                    }
+                }
+            }
+            return false;
+        }
+
         private static string ReadMspAnnotatorSettingsFilePath(string filepath) {
             using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
                 while (sr.Peek() > -1) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsAlignmentLightRunner.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsAlignmentLightRunner.cs
@@ -1,0 +1,538 @@
+using CompMs.Common.Components;
+using CompMs.Common.DataObj;
+using CompMs.Common.DataObj.Result;
+using CompMs.Common.Enum;
+using CompMs.Common.Extension;
+using CompMs.Common.Interfaces;
+using CompMs.Common.Utility;
+using CompMs.MsdialCore.Algorithm;
+using CompMs.MsdialCore.Algorithm.Annotation;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Export;
+using CompMs.MsdialCore.MSDec;
+using CompMs.MsdialCore.Parser;
+using CompMs.MsdialCore.Utility;
+using CompMs.MsdialLcmsApi.Parameter;
+using CompMs.MsdialLcMsApi.Algorithm.Alignment;
+using CompMs.RawDataHandler.Core;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+
+namespace CompMs.App.MsdialConsole.Process;
+
+internal sealed class LcmsAlignmentLightRunner {
+    private static readonly IComparer<IMSScanProperty> Comparer = CompositeComparer.Build(MassComparer.Comparer, ChromXsComparer.RTComparer);
+
+    private readonly IMsdialDataStorage<MsdialLcmsParameter> _storage;
+    private readonly IMatchResultEvaluator<MsScanMatchResult> _evaluator;
+    private readonly IDataProviderFactory<AnalysisFileBean> _providerFactory;
+    private readonly IProgress<int>? _progress;
+    private readonly MsdialLcmsParameter _parameter;
+    private readonly double _mztol;
+    private readonly double _rttol;
+    private readonly double _mzfactor;
+    private readonly double _rtfactor;
+
+    public LcmsAlignmentLightRunner(
+        IMsdialDataStorage<MsdialLcmsParameter> storage,
+        IMatchResultEvaluator<MsScanMatchResult> evaluator,
+        IDataProviderFactory<AnalysisFileBean> providerFactory,
+        IProgress<int>? progress) {
+        _storage = storage;
+        _evaluator = evaluator;
+        _providerFactory = providerFactory;
+        _progress = progress;
+        _parameter = storage.Parameter;
+        _mztol = _parameter.Ms1AlignmentTolerance;
+        _rttol = _parameter.RetentionTimeAlignmentTolerance;
+        _mzfactor = _parameter.Ms1AlignmentFactor;
+        _rtfactor = _parameter.RetentionTimeAlignmentFactor;
+    }
+
+    public LcmsAlignmentLightResult Run(IReadOnlyList<AnalysisFileBean> analysisFiles, AlignmentFileBean alignmentFile, AlignmentLightPeakStore peakStore) {
+        var factory = new LcmsAlignmentProcessFactory(_storage, _evaluator) {
+            Progress = _progress,
+            SkipIonAbundanceCorrelationLinks = true,
+        };
+        var joiner = (LcmsPeakJoiner)factory.CreatePeakJoiner();
+        var accessor = (IFeatureAccessor<ChromatogramPeakFeature>)factory.CreateDataAccessor();
+        var master = joiner.GetMasterList(analysisFiles, _parameter.AlignmentReferenceFileID, accessor)
+            .OrderBy(prop => (prop.PrecursorMz, prop.ChromXs.RT.Value))
+            .ToList();
+        peakStore.Initialize(master.Count, analysisFiles);
+        var spots = InitializeSpots(master);
+        var accumulators = spots.Select(spot => new LightSpotAccumulator(spot, analysisFiles.Count)).ToList();
+        var qcFileCount = _parameter.FileID_AnalysisFileType.Count(pair => pair.Value == AnalysisFileType.QC);
+        var classFileCounts = _parameter.FileID_ClassName.Values
+            .GroupBy(className => className)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        Console.WriteLine("Alignment light mode: detected-peak pass started.");
+        var reporter = ReportProgress.FromLength(_progress, 20.0, 20.0);
+        var counter = 0;
+        var matchedSpotIdsByFileId = analysisFiles.ToDictionary(file => file.AnalysisFileId, _ => new HashSet<int>());
+        foreach (var file in analysisFiles) {
+            var targets = accessor.GetMSScanProperties(file);
+            foreach (var match in MatchTargetsToMaster(master, targets)) {
+                var peak = CreateAlignmentPeak(file, master[match.MasterIndex].IonMode);
+                DataObjConverter.SetAlignmentChromPeakFeatureFromChromatogramPeakFeature(peak, match.Target);
+                peakStore.WriteSpotPeak(spots[match.MasterIndex].MasterAlignmentID, peak);
+                _parameter.FileID_AnalysisFileType.TryGetValue(peak.FileID, out var fileType);
+                _parameter.FileID_ClassName.TryGetValue(peak.FileID, out var className);
+                accumulators[match.MasterIndex].AddDetectedPeak(peak, fileType, className);
+                matchedSpotIdsByFileId[file.AnalysisFileId].Add(spots[match.MasterIndex].MasterAlignmentID);
+            }
+            reporter.Report(++counter, analysisFiles.Count - 1);
+        }
+
+        var kept = accumulators
+            .Where(acc => PassesLightAlignmentFilters(acc, qcFileCount, classFileCounts))
+            .ToList();
+
+        Console.WriteLine($"Alignment light mode: {kept.Count} alignment spots retained from {accumulators.Count} master spots.");
+        Console.WriteLine("Alignment light mode: gap-fill pass started.");
+        var gapFiller = new LcmsGapFiller(_parameter);
+        reporter = ReportProgress.FromLength(_progress, 40.0, 40.0);
+        counter = 0;
+        foreach (var file in analysisFiles) {
+            FillMissingPeaks(file, kept, matchedSpotIdsByFileId[file.AnalysisFileId], gapFiller, peakStore);
+            reporter.Report(++counter, analysisFiles.Count - 1);
+        }
+
+        foreach (var acc in kept) {
+            acc.ApplySpotSummary();
+        }
+
+        kept = RefineLightSpots(kept);
+        kept = AssignLightAlignmentIds(kept, peakStore);
+        SetLightIsotopeAnalysis(kept);
+        Console.WriteLine($"Alignment light mode: {kept.Count} alignment spots retained after spot-level LC-MS refinement.");
+
+        var resultSpots = kept.Select(acc => acc.Spot).ToList();
+        SetRelativeAmplitude(resultSpots);
+        MsdecResultsWriter.Write(alignmentFile.SpectraFilePath, EnumerateRepresentativeDeconvolutions(analysisFiles, kept), kept.Count);
+        var msdecResults = new FileBackedMsdecResults(alignmentFile.SpectraFilePath);
+
+        var container = new AlignmentResultContainer {
+            Ionization = _parameter.Ionization,
+            AlignmentResultFileID = -1,
+            TotalAlignmentSpotCount = resultSpots.Count,
+            AlignmentSpotProperties = new ObservableCollection<AlignmentSpotProperty>(resultSpots),
+        };
+        return new LcmsAlignmentLightResult(container, msdecResults);
+    }
+
+    private List<AlignmentSpotProperty> InitializeSpots(IReadOnlyList<ChromatogramPeakFeature> master) {
+        var spots = new List<AlignmentSpotProperty>(master.Count);
+        for (var i = 0; i < master.Count; i++) {
+            var scanProp = master[i];
+            spots.Add(new AlignmentSpotProperty {
+                MasterAlignmentID = i,
+                AlignmentID = i,
+                ParentAlignmentID = -1,
+                TimesCenter = scanProp.ChromXs,
+                TimesMin = scanProp.ChromXs,
+                TimesMax = scanProp.ChromXs,
+                MassCenter = scanProp.PrecursorMz,
+                MassMin = (float)scanProp.PrecursorMz,
+                MassMax = (float)scanProp.PrecursorMz,
+                IonMode = scanProp.IonMode,
+                InternalStandardAlignmentID = -1,
+                AlignmentDriftSpotFeatures = [],
+            });
+        }
+        return spots;
+    }
+
+    private IEnumerable<(int MasterIndex, ChromatogramPeakFeature Target)> MatchTargetsToMaster(
+        IReadOnlyList<ChromatogramPeakFeature> masters,
+        IReadOnlyList<ChromatogramPeakFeature> targets) {
+        var n = masters.Count;
+        var maxMatchs = new double[n];
+        var matchedTargets = new ChromatogramPeakFeature[n];
+        var dummy = new ChromatogramPeakFeature();
+
+        foreach (var target in targets) {
+            int? matchIdx = null;
+            var matchFactor = double.MinValue;
+            dummy.ChromXs = new ChromXs(target.ChromXs.RT.Value - _rttol, ChromXType.RT);
+            dummy.PrecursorMz = target.PrecursorMz - _mztol;
+            var lo = masters.LowerBound(dummy, Comparer);
+            dummy.ChromXs.RT = new RetentionTime(target.ChromXs.RT.Value + _rttol, dummy.ChromXs.RT.Unit);
+            dummy.PrecursorMz = target.PrecursorMz + _mztol;
+            for (var i = lo; i < n; i++) {
+                if (Comparer.Compare(masters[i], dummy) > 0) {
+                    break;
+                }
+                if (!IsSimilarTo(masters[i], target)) {
+                    continue;
+                }
+                var factor = GetSimilarity(masters[i], target);
+                if (factor > maxMatchs[i] && factor > matchFactor) {
+                    matchIdx = i;
+                    maxMatchs[i] = matchFactor = factor;
+                }
+            }
+            if (matchIdx.HasValue) {
+                matchedTargets[matchIdx.Value] = target;
+            }
+        }
+        for (var i = 0; i < matchedTargets.Length; i++) {
+            if (matchedTargets[i] != null) {
+                yield return (i, matchedTargets[i]);
+            }
+        }
+    }
+
+    private bool IsSimilarTo(IMSScanProperty x, IMSScanProperty y) {
+        return Math.Abs(x.PrecursorMz - y.PrecursorMz) <= _mztol && Math.Abs(x.ChromXs.RT.Value - y.ChromXs.RT.Value) <= _rttol;
+    }
+
+    private double GetSimilarity(IMSScanProperty x, IMSScanProperty y) {
+        return _mzfactor * Math.Exp(-.5 * Math.Pow((x.PrecursorMz - y.PrecursorMz) / _mztol, 2))
+             + _rtfactor * Math.Exp(-0.5 * Math.Pow((x.ChromXs.RT.Value - y.ChromXs.RT.Value) / _rttol, 2));
+    }
+
+    private static AlignmentChromPeakFeature CreateAlignmentPeak(AnalysisFileBean file, IonMode ionMode) {
+        return new AlignmentChromPeakFeature {
+            MasterPeakID = -1,
+            PeakID = -1,
+            FileID = file.AnalysisFileId,
+            FileName = file.AnalysisFileName,
+            IonMode = ionMode,
+        };
+    }
+
+    private bool PassesLightAlignmentFilters(
+        LightSpotAccumulator acc,
+        int qcFileCount,
+        IReadOnlyDictionary<string, int> classFileCounts) {
+        if (acc.DetectedCount <= 0) {
+            return false;
+        }
+
+        var minCount = _parameter.PeakCountFilter / 100d * _parameter.FileID_AnalysisFileType.Count;
+        if (acc.DetectedCount < minCount) {
+            return false;
+        }
+
+        if (_parameter.QcAtLeastFilter && !acc.IsDetectedInEveryQc(qcFileCount)) {
+            return false;
+        }
+
+        var classThreshold = _parameter.NPercentDetectedInOneGroup / 100d;
+        return acc.IsDetectedEnoughInAnyClass(classFileCounts, classThreshold);
+    }
+
+    private List<LightSpotAccumulator> RefineLightSpots(IReadOnlyList<LightSpotAccumulator> accumulators) {
+        var cleaned = new List<LightSpotAccumulator>();
+        var done = new HashSet<int>();
+
+        foreach (var acc in accumulators.Where(acc => acc.Spot.MspID >= 0 && acc.Spot.IsReferenceMatched(_evaluator)).OrderByDescending(acc => acc.Spot.MspBasedMatchResult.TotalScore)) {
+            TryMergeToMaster(acc, cleaned, done);
+        }
+
+        foreach (var acc in accumulators.Where(acc => acc.Spot.IsReferenceMatched(_evaluator)).OrderByDescending(acc => acc.Spot.MatchResults.Representative.TotalScore)) {
+            TryMergeToMaster(acc, cleaned, done);
+        }
+
+        foreach (var acc in accumulators.Where(acc => acc.Spot.TextDbID >= 0 && acc.Spot.IsReferenceMatched(_evaluator)).OrderByDescending(acc => acc.Spot.TextDbBasedMatchResult.TotalScore)) {
+            TryMergeToMaster(acc, cleaned, done);
+        }
+
+        foreach (var acc in accumulators.OrderByDescending(acc => acc.Spot.HeightAverage)) {
+            if (acc.Spot.IsReferenceMatched(_evaluator)) {
+                continue;
+            }
+            if (acc.Spot.PeakCharacter.IsotopeWeightNumber > 0) {
+                continue;
+            }
+            TryMergeToMaster(acc, cleaned, done);
+        }
+
+        return cleaned;
+    }
+
+    private void TryMergeToMaster(LightSpotAccumulator acc, List<LightSpotAccumulator> cleaned, HashSet<int> done) {
+        var spot = acc.Spot;
+        if (done.Contains(spot.AlignmentID)) {
+            return;
+        }
+
+        var spotRt = spot.TimesCenter.Value;
+        var spotMz = spot.MassCenter;
+        var rtTol = Math.Min(_parameter.RetentionTimeAlignmentTolerance, 0.1);
+        var ms1Tol = (double)_parameter.Ms1AlignmentTolerance;
+        if (spotMz > 500d) {
+            ms1Tol = spotMz * (_parameter.Ms1AlignmentTolerance / 500d);
+        }
+
+        foreach (var existing in cleaned.Where(accum => Math.Abs(accum.Spot.MassCenter - spotMz) < ms1Tol)) {
+            if (Math.Abs(existing.Spot.TimesCenter.Value - spotRt) < rtTol * 0.5) {
+                return;
+            }
+        }
+
+        cleaned.Add(acc);
+        done.Add(spot.AlignmentID);
+    }
+
+    private static List<LightSpotAccumulator> AssignLightAlignmentIds(IReadOnlyList<LightSpotAccumulator> accumulators, AlignmentLightPeakStore peakStore) {
+        var ordered = accumulators
+            .OrderBy(acc => acc.Spot.MassCenter)
+            .ToList();
+        var oldToNew = new Dictionary<int, int>(ordered.Count);
+        for (var newId = 0; newId < ordered.Count; newId++) {
+            var acc = ordered[newId];
+            oldToNew[acc.Spot.MasterAlignmentID] = newId;
+            acc.Spot.MasterAlignmentID = acc.Spot.AlignmentID = newId;
+        }
+        peakStore.RemapSpotIds(oldToNew);
+        return ordered;
+    }
+
+    private static void SetLightIsotopeAnalysis(IReadOnlyList<LightSpotAccumulator> accumulators) {
+        foreach (var acc in accumulators) {
+            acc.Spot.PeakCharacter.IsotopeParentPeakID = acc.Spot.AlignmentID;
+            acc.Spot.PeakCharacter.IsotopeWeightNumber = 0;
+        }
+    }
+
+    private void SetRepresentativeIsotopicPeaks(
+        AnalysisFileBean file,
+        IReadOnlyList<LightSpotAccumulator> accumulators,
+        IReadOnlyList<RawSpectrum> spectra) {
+        foreach (var acc in accumulators) {
+            var representative = acc.RepresentativePeak ?? throw new InvalidOperationException("Alignment light spot has no representative peak.");
+            if (representative.FileID != file.AnalysisFileId) {
+                continue;
+            }
+            var index = spectra.LowerBound(representative.MS1RawSpectrumIdTop, (s, id) => s.Index.CompareTo(id));
+            acc.Spot.IsotopicPeaks = index < 0 || index >= spectra.Count
+                ? []
+                : DataAccess.GetIsotopicPeaks(
+                    spectra[index].Spectrum,
+                    (float)representative.Mass,
+                    _parameter.CentroidMs1Tolerance,
+                    _parameter.PeakPickBaseParam.MaxIsotopesDetectedInMs1Spectrum);
+        }
+    }
+
+    private void FillMissingPeaks(
+        AnalysisFileBean file,
+        IReadOnlyList<LightSpotAccumulator> spots,
+        HashSet<int> matchedSpotIds,
+        LcmsGapFiller gapFiller,
+        AlignmentLightPeakStore peakStore) {
+        var spectra = LoadMs1Spectra(file);
+        SetRepresentativeIsotopicPeaks(file, spots, spectra);
+        var ms1Spectra = new Ms1Spectra(spectra, _parameter.IonMode, file.AcquisitionType);
+        foreach (var acc in spots) {
+            if (matchedSpotIds.Contains(acc.Spot.MasterAlignmentID)) {
+                continue;
+            }
+            var peak = CreateAlignmentPeak(file, acc.Spot.IonMode);
+            gapFiller.GapFill(ms1Spectra, peak, acc.GapFillCenter, acc.PeakWidth, acc.EstimatedNoise);
+            peakStore.WriteSpotPeak(acc.Spot.MasterAlignmentID, peak);
+        }
+    }
+
+    private IReadOnlyList<RawSpectrum> LoadMs1Spectra(AnalysisFileBean analysisFile) {
+        var provider = _providerFactory?.Create(analysisFile);
+        var spectra = provider?.LoadMs1Spectrums();
+        if (spectra != null) {
+            return spectra;
+        }
+        using var rawDataAccess = new RawDataAccess(analysisFile.AnalysisFilePath, 0, false, false, true, analysisFile.RetentionTimeCorrectionBean.PredictedRt);
+        return rawDataAccess.GetMeasurement()?.SpectrumList ?? [];
+    }
+
+    private static IEnumerable<MSDecResult> EnumerateRepresentativeDeconvolutions(
+        IReadOnlyList<AnalysisFileBean> files,
+        IReadOnlyList<LightSpotAccumulator> spots) {
+        var deconvolutionInfo = new Dictionary<int, (int version, List<long> pointers, bool isAnnotationInfo)>();
+        foreach (var file in files) {
+            MsdecResultsReader.GetSeekPointers(file.DeconvolutionFilePath, out var version, out var pointers, out var isAnnotationInfo);
+            deconvolutionInfo[file.AnalysisFileId] = (version, pointers, isAnnotationInfo);
+        }
+
+        var streams = files.ToDictionary(file => file.AnalysisFileId, file => File.OpenRead(file.DeconvolutionFilePath));
+        try {
+            foreach (var acc in spots.OrderBy(acc => acc.Spot.MasterAlignmentID)) {
+                var representative = acc.RepresentativePeak ?? throw new InvalidOperationException("Alignment light spot has no representative peak.");
+                var fileId = representative.FileID;
+                var peakId = representative.MasterPeakID;
+                var info = deconvolutionInfo[fileId];
+                yield return MsdecResultsReader.ReadMSDecResult(
+                    streams[fileId], info.pointers[peakId],
+                    info.version, info.isAnnotationInfo);
+            }
+        }
+        finally {
+            foreach (var stream in streams.Values) {
+                stream.Close();
+            }
+        }
+    }
+
+    private static void SetRelativeAmplitude(IReadOnlyList<AlignmentSpotProperty> spots) {
+        if (spots.Count == 0) {
+            return;
+        }
+        var minInt = (double)spots.Min(spot => spot.HeightMin);
+        var maxInt = (double)spots.Max(spot => spot.HeightMax);
+        maxInt = maxInt > 1 ? Math.Log(maxInt, 2) : 1;
+        minInt = minInt > 1 ? Math.Log(minInt, 2) : 0;
+        foreach (var spot in spots) {
+            var relativeValue = (float)((Math.Log(spot.HeightMax, 2) - minInt) / (maxInt - minInt));
+            spot.RelativeAmplitudeValue = Math.Min(1, Math.Max(0, relativeValue));
+        }
+    }
+
+    private sealed class LightSpotAccumulator {
+        private double _rtSum;
+        private double _heightSum;
+        private double _snSum;
+        private double _rtMin = double.MaxValue;
+        private double _rtMax = double.MinValue;
+        private float _massMin = float.MaxValue;
+        private float _massMax = float.MinValue;
+        private float _heightMin = float.MaxValue;
+        private float _heightMax = float.MinValue;
+        private float _snMin = float.MaxValue;
+        private float _snMax = float.MinValue;
+        private double _maxHeightForMass = double.MinValue;
+        private double _massAtMaxHeight;
+        private readonly Dictionary<string, int> _detectedClassCounts = new Dictionary<string, int>();
+        private int _detectedQcCount;
+
+        public LightSpotAccumulator(AlignmentSpotProperty spot, int fileCount) {
+            Spot = spot;
+            FileCount = fileCount;
+        }
+
+        public AlignmentSpotProperty Spot { get; }
+        public int FileCount { get; }
+        public int DetectedCount { get; private set; }
+        public double PeakWidth { get; private set; } = 0.2d;
+        public float EstimatedNoise { get; private set; } = 1f;
+        public AlignmentChromPeakFeature? RepresentativePeak { get; private set; }
+
+        public ChromXs GapFillCenter => new ChromXs(new RetentionTime(_rtSum / Math.Max(1, DetectedCount), ChromXUnit.Min)) {
+            Mz = new MzValue(_massAtMaxHeight),
+        };
+
+        public void AddDetectedPeak(AlignmentChromPeakFeature peak, AnalysisFileType fileType, string? className) {
+            DetectedCount++;
+            if (fileType == AnalysisFileType.QC) {
+                _detectedQcCount++;
+            }
+            if (!string.IsNullOrEmpty(className)) {
+                _detectedClassCounts.TryGetValue(className, out var classCount);
+                _detectedClassCounts[className] = classCount + 1;
+            }
+            _rtSum += peak.ChromXsTop.RT.Value;
+            _heightSum += peak.PeakHeightTop;
+            _snSum += peak.PeakShape.SignalToNoise;
+            _rtMin = Math.Min(_rtMin, peak.ChromXsTop.RT.Value);
+            _rtMax = Math.Max(_rtMax, peak.ChromXsTop.RT.Value);
+            _massMin = Math.Min(_massMin, (float)peak.Mass);
+            _massMax = Math.Max(_massMax, (float)peak.Mass);
+            _heightMin = Math.Min(_heightMin, (float)peak.PeakHeightTop);
+            _heightMax = Math.Max(_heightMax, (float)peak.PeakHeightTop);
+            _snMin = Math.Min(_snMin, peak.PeakShape.SignalToNoise);
+            _snMax = Math.Max(_snMax, peak.PeakShape.SignalToNoise);
+            PeakWidth = Math.Max(PeakWidth, peak.PeakWidth(ChromXType.RT));
+            EstimatedNoise = Math.Max(EstimatedNoise, peak.PeakShape.EstimatedNoise);
+            if (peak.PeakHeightTop > _maxHeightForMass) {
+                _maxHeightForMass = peak.PeakHeightTop;
+                _massAtMaxHeight = peak.Mass;
+            }
+            if (RepresentativePeak is null || IsBetterRepresentative(peak, RepresentativePeak)) {
+                RepresentativePeak = peak;
+            }
+        }
+
+        public bool IsDetectedInEveryQc(int qcFileCount) {
+            return _detectedQcCount >= qcFileCount;
+        }
+
+        public bool IsDetectedEnoughInAnyClass(IReadOnlyDictionary<string, int> classFileCounts, double threshold) {
+            foreach (var groupCount in classFileCounts) {
+                _detectedClassCounts.TryGetValue(groupCount.Key, out var detected);
+                if (groupCount.Value * threshold <= detected) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void ApplySpotSummary() {
+            var rep = RepresentativePeak ?? throw new InvalidOperationException("Alignment light spot has no representative peak.");
+            Spot.RepresentativeFileID = rep.FileID;
+            Spot.AlignedPeakProperties = [rep];
+            Spot.IonMode = rep.IonMode;
+            Spot.Name = rep.Name;
+            Spot.Protein = rep.Protein;
+            Spot.ProteinGroupID = rep.ProteinGroupID;
+            Spot.Ontology = rep.Ontology;
+            Spot.SMILES = rep.SMILES;
+            Spot.InChIKey = rep.InChIKey;
+            Spot.SetAdductType(CompMs.Common.DataObj.Property.AdductIon.GetAdductIon(rep.PeakCharacter.AdductType.AdductIonName));
+            Spot.PeakCharacter = rep.PeakCharacter;
+            Spot.Formula = rep.Formula;
+            Spot.CollisionCrossSection = rep.CollisionCrossSection;
+            Spot.MSRawID2MspIDs = rep.MSRawID2MspIDs;
+            Spot.TextDbIDs = new List<int>(rep.TextDbIDs);
+            Spot.MSRawID2MspBasedMatchResult = new Dictionary<int, MsScanMatchResult>(rep.MSRawID2MspBasedMatchResult);
+            Spot.TextDbBasedMatchResult = rep.TextDbBasedMatchResult;
+            Spot.MatchResults.MergeContainers(rep.MatchResults);
+            Spot.MSDecResultIdUsed = rep.MSDecResultIdUsed;
+            Spot.HeightAverage = (float)(_heightSum / DetectedCount);
+            Spot.HeightMax = _heightMax;
+            Spot.HeightMin = _heightMin;
+            Spot.PeakWidthAverage = (float)PeakWidth;
+            Spot.SignalToNoiseAve = (float)(_snSum / DetectedCount);
+            Spot.SignalToNoiseMax = _snMax;
+            Spot.SignalToNoiseMin = _snMin;
+            Spot.EstimatedNoiseAve = EstimatedNoise;
+            Spot.EstimatedNoiseMax = EstimatedNoise;
+            Spot.EstimatedNoiseMin = EstimatedNoise;
+            Spot.TimesMin = new ChromXs(new RetentionTime(_rtMin, ChromXUnit.Min));
+            Spot.TimesMax = new ChromXs(new RetentionTime(_rtMax, ChromXUnit.Min));
+            Spot.MassCenter = _massAtMaxHeight;
+            Spot.MassMin = _massMin;
+            Spot.MassMax = _massMax;
+            Spot.FillParcentage = DetectedCount / (float)FileCount;
+            Spot.MonoIsotopicPercentage = rep.PeakCharacter.IsotopeWeightNumber == 0 ? 1f : 0f;
+            Spot.TimesCenter = new ChromXs {
+                MainType = ChromXType.RT,
+                RT = new RetentionTime(_rtSum / DetectedCount, ChromXUnit.Min),
+                Mz = new MzValue(Spot.MassCenter),
+            };
+            if (Spot.QuantMass > 0) {
+                Spot.MassCenter = Spot.QuantMass;
+            }
+        }
+
+        private static bool IsBetterRepresentative(AlignmentChromPeakFeature candidate, AlignmentChromPeakFeature current) {
+            var candidateScore = candidate.MatchResults?.Representative?.TotalScore ?? 0d;
+            var currentScore = current.MatchResults?.Representative?.TotalScore ?? 0d;
+            return (candidate.IsMsmsAssigned, candidateScore, candidate.PeakHeightTop)
+                 .CompareTo((current.IsMsmsAssigned, currentScore, current.PeakHeightTop)) > 0;
+        }
+    }
+}
+
+internal sealed class LcmsAlignmentLightResult {
+    public LcmsAlignmentLightResult(AlignmentResultContainer container, IReadOnlyList<MSDecResult> msdecResults) {
+        Container = container;
+        MsdecResults = msdecResults;
+    }
+
+    public AlignmentResultContainer Container { get; }
+    public IReadOnlyList<MSDecResult> MsdecResults { get; }
+}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -33,6 +33,7 @@ public sealed class LcmsProcess
     public int Run(string inputFolder, string outputFolder, string methodFile, bool isProjectSaved, float targetMz)
     {
         var param = ConfigParser.ReadForLcmsParameter(methodFile);
+        var isAlignmentLightMode = ConfigParser.ReadAlignmentLightMode(methodFile);
         var isCorrectlyImported = CommonProcess.SetProjectProperty(param, inputFolder, out List<AnalysisFileBean> analysisFiles, out AlignmentFileBean alignmentFile);
         if (!isCorrectlyImported) {
             return -1;
@@ -85,10 +86,10 @@ public sealed class LcmsProcess
         container.DataBases.SetDataBaseMapper(container.DataBaseMapper);
 
         Console.WriteLine("Start processing..");
-        return ExecuteAsync(container, outputFolder, isProjectSaved).Result;
+        return ExecuteAsync(container, outputFolder, isProjectSaved, isAlignmentLightMode).Result;
     }
 
-    private async Task<int> ExecuteAsync(IMsdialDataStorage<MsdialLcmsParameter> storage, string outputFolder, bool isProjectSaved) {
+    private async Task<int> ExecuteAsync(IMsdialDataStorage<MsdialLcmsParameter> storage, string outputFolder, bool isProjectSaved, bool isAlignmentLightMode) {
         var projectDataStorage = new ProjectDataStorage(new ProjectParameter(DateTime.Now, outputFolder, Path.ChangeExtension(storage.Parameter.ProjectParam.ProjectFileName, ".mdproject")));
         projectDataStorage.AddStorage(storage);
 
@@ -129,37 +130,57 @@ public sealed class LcmsProcess
 
         storage.Parameter.ProjectParam.MsdialVersionNumber = $"Msdial console {Resources.VERSION}";
         if (storage.Parameter.TogetherWithAlignment) {
-            var serializer = ChromatogramSerializerFactory.CreateSpotSerializer("CSS1");
             var alignmentFile = storage.AlignmentFiles.First();
-            var factory = new LcmsAlignmentProcessFactory(storage, evaluator);
-            factory.Progress = CreateConsoleProgressReporter("Alignment");
-            var aligner = factory.CreatePeakAligner();
-            Console.WriteLine("Alignment started.");
-            var result = aligner.Alignment(files, alignmentFile, serializer);
-            Console.WriteLine("Alignment finished.");
-            result.Save(alignmentFile);
-            var align_decResults = LoadRepresentativeDeconvolutions(storage, result.AlignmentSpotProperties).ToList();
-            MsdecResultsWriter.Write(alignmentFile.SpectraFilePath, align_decResults);
+            using var alignmentLightPeakStore = isAlignmentLightMode ? AlignmentLightPeakStore.CreateTemp() : null;
+            AlignmentResultContainer result;
+            IReadOnlyList<MSDecResult> align_decResults;
+            IDisposable? alignmentLightMsdecResults = null;
+            if (isAlignmentLightMode) {
+                Console.WriteLine("Alignment light mode: streaming peak matrix, file-backed alignment deconvolution access, GUI chromatogram serialization, GUI alignment object serialization, and ion-abundance correlation links are disabled; text exports remain enabled.");
+                Console.WriteLine("Alignment started.");
+                var lightRunner = new LcmsAlignmentLightRunner(storage, evaluator, providerFactory, CreateConsoleProgressReporter("Alignment"));
+                var lightResult = lightRunner.Run(files, alignmentFile, alignmentLightPeakStore!);
+                result = lightResult.Container;
+                align_decResults = lightResult.MsdecResults;
+                alignmentLightMsdecResults = lightResult.MsdecResults as IDisposable;
+                Console.WriteLine("Alignment finished.");
+            }
+            else {
+                var serializer = ChromatogramSerializerFactory.CreateSpotSerializer("CSS1");
+                var factory = new LcmsAlignmentProcessFactory(storage, evaluator);
+                factory.Progress = CreateConsoleProgressReporter("Alignment");
+                var aligner = factory.CreatePeakAligner();
+                Console.WriteLine("Alignment started.");
+                result = aligner.Alignment(files, alignmentFile, serializer);
+                Console.WriteLine("Alignment finished.");
+                result.Save(alignmentFile);
+                align_decResults = LoadRepresentativeDeconvolutions(storage, result.AlignmentSpotProperties).ToList();
+                MsdecResultsWriter.Write(alignmentFile.SpectraFilePath, align_decResults);
+            }
 
             var align_outputfile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdalign");
             var align_accessor = new LcmsMetadataAccessor(storage.DataBaseMapper, storage.Parameter, false);
-            var align_quantAccessor = new LegacyQuantValueAccessor("Height", storage.Parameter);
+            IQuantValueAccessor align_quantAccessor = alignmentLightPeakStore != null
+                ? new AlignmentLightQuantValueAccessor("Height", storage.Parameter, alignmentLightPeakStore)
+                : new LegacyQuantValueAccessor("Height", storage.Parameter);
             var align_stats = new[] { StatsValue.Average, StatsValue.Stdev };
             var align_exporter = new AlignmentCSVExporter();
             using var stream = File.Open(align_outputfile, FileMode.Create, FileAccess.Write);
             align_exporter.Export(stream, result.AlignmentSpotProperties, align_decResults, files, new MulticlassFileMetaAccessor(0), align_accessor, align_quantAccessor, align_stats);
+            CollectAlignmentLightExportGarbage(isAlignmentLightMode);
 
             var align_outputmspfile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdmsp");
             using var streammsp = File.Open(align_outputmspfile, FileMode.Create, FileAccess.Write);
             IAlignmentSpectraExporter align_mspexporter = new AlignmentMspExporter(storage.DataBaseMapper, storage.Parameter);
             align_mspexporter.BatchExport(streammsp, result.AlignmentSpotProperties, align_decResults);
+            CollectAlignmentLightExportGarbage(isAlignmentLightMode);
 
             var mztabm_filename = alignmentFile.FileName + ".mzTab";
             var mztabm_outputfile = Path.Combine(outputFolder, mztabm_filename);
             var spots = result.AlignmentSpotProperties; // TODO: cancellation
             var msdecs = align_decResults;
             var accessor = align_accessor;
-            var mztabM_exporter = new MztabFormatExporter(storage.DataBases);
+            var mztabM_exporter = new MztabFormatExporter(storage.DataBases, alignmentLightPeakStore);
 
             using var tabmstream = File.Open(mztabm_outputfile, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
             mztabM_exporter.MztabFormatExporterCore(
@@ -172,9 +193,14 @@ public sealed class LcmsProcess
                 align_stats,
                 mztabm_filename
             );
+            CollectAlignmentLightExportGarbage(isAlignmentLightMode);
+            alignmentLightMsdecResults?.Dispose();
         }
 
-        if (isProjectSaved) {
+        if (isProjectSaved && isAlignmentLightMode) {
+            Console.WriteLine("Alignment light mode: project saving (-p) is skipped because GUI-compatible alignment objects are intentionally not serialized.");
+        }
+        else if (isProjectSaved) {
             storage.Parameter.ProjectParam.FinalSavedDate = DateTime.Now;
             using var stream = File.Open(projectDataStorage.ProjectParameter.FilePath, FileMode.Create);
             using IStreamManager streamManager = new ZipStreamManager(stream, System.IO.Compression.ZipArchiveMode.Create);
@@ -183,6 +209,15 @@ public sealed class LcmsProcess
         }
 
         return 0;
+    }
+
+    private static IEnumerable<AlignmentSpotProperty> FlattenSpots(IEnumerable<AlignmentSpotProperty> spots) {
+        foreach (var spot in spots) {
+            yield return spot;
+            foreach (var driftSpot in spot.AlignmentDriftSpotFeatures.OrEmptyIfNull()) {
+                yield return driftSpot;
+            }
+        }
     }
 
     private static IProgress<int> CreateConsoleProgressReporter(string label) {
@@ -203,6 +238,15 @@ public sealed class LcmsProcess
                 nextBucket = percent < 100 ? Math.Min(100, ((percent / 10) + 1) * 10) : 101;
             }
         });
+    }
+
+    private static void CollectAlignmentLightExportGarbage(bool isAlignmentLightMode) {
+        if (!isAlignmentLightMode) {
+            return;
+        }
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
     }
 
     private static IEnumerable<MSDecResult> LoadRepresentativeDeconvolutions(IMsdialDataStorage<MsdialLcmsParameter> storage, IReadOnlyList<AlignmentSpotProperty>? spots) {


### PR DESCRIPTION
Summary: Adds an experimental LC-MS Console alignment light mode for text-export workflows, including compact file-backed aligned peak storage, file-backed MSDec result access, and light-mode mzTab section spooling. The mode is enabled by 'Alignment light mode: True' and skips GUI project serialization while keeping mdalign/mdmsp/mzTab text outputs and alignment dcl. Validation: dotnet build tests\MSDIAL5\MsdialCoreTestApp\MsdialCoreTestApp.csproj -c Debug --no-restore passed with existing warnings. FastLC validation during development matched mdalign/mdmsp byte-identically and mzTab after normalizing time-derived metadata.