### PR TITLE
Enforce minimum datapoints after peak edge detection

### DIFF
--- a/src/Common/CommonStandard/Algorithm/PeakPick/PeakPick.cs
+++ b/src/Common/CommonStandard/Algorithm/PeakPick/PeakPick.cs
@@ -33,6 +33,7 @@ public class PeakDetectionResult {
     public float AreaAboveZero { get; set; } = -1.0F;
     public float EstimatedNoise { get; set; } = -1.0F;
     public float SignalToNoise { get; set; } = -1.0F;
+    public int DataPointCount => ScanNumAtRightPeakEdge - ScanNumAtLeftPeakEdge + 1;
 
     private static readonly double INTENSITY_FOLDCHANGE_THREASHOLD = .1d;
     public bool IsWeakCompareTo(double maxIntensityAtPeaks) {
@@ -125,6 +126,9 @@ public sealed class PeakDetection {
                     continue;
                 }
                 curateDatapoints(datapoints, averagePeakWidth, out var peaktopID);
+                if (datapoints.Count < minimumDatapointCriteria) {
+                    continue;
+                }
 
                 peakHeightFromBaseline(datapoints, peaktopID, out var maxPeakHeight, out var minPeakHeight);
                 if (maxPeakHeight < noise) continue;
@@ -133,6 +137,7 @@ public sealed class PeakDetection {
 
                 var result = GetPeakDetectionResult(datapoints, peaktopID);
                 if (result == null) continue;
+                if (result.DataPointCount < minimumDatapointCriteria) continue;
                 result.PeakID = peakCounter;
                 result.EstimatedNoise = (float)(noise / noiseFactor);
                 if (result.EstimatedNoise < 1.0) result.EstimatedNoise = 1.0F;

--- a/src/Common/CommonStandard/Components/ChromatogramGlobalProperty_temp2.cs
+++ b/src/Common/CommonStandard/Components/ChromatogramGlobalProperty_temp2.cs
@@ -242,12 +242,16 @@ internal sealed class ChroChroChromatogram : IDisposable {
                     continue;
                 }
                 var (newStart, peakTopID, newEnd) = _chromatogram.ShrinkPeakRange(start, j + 1, averagePeakWidth);
+                if (newEnd - newStart < minimumDatapointCriteria) {
+                    continue;
+                }
                 var (minPeakHeight, maxPeakHeight) = _chromatogram.PeakHeightFromBounds(newStart, newEnd, peakTopID);
                 if (IsNoise(maxPeakHeight, minPeakHeight, minimumAmplitudeCriteria, amplitudeNoiseFoldCriteria, newStart, newEnd)) {
                     continue;
                 }
                 var result = GetPeakDetectionResult(peakTopID, newStart, newEnd, noiseFactor, maxPeakHeight);
                 if (result is null) continue;
+                if (result.DataPointCount < minimumDatapointCriteria) continue;
                 result.PeakID = results.Count;
                 results.Add(result);
             }

--- a/src/MSDIAL5/MsdialCore/Algorithm/PeakSpottingCore.cs
+++ b/src/MSDIAL5/MsdialCore/Algorithm/PeakSpottingCore.cs
@@ -770,7 +770,8 @@ namespace CompMs.MsdialCore.Algorithm {
         public List<ChromatogramPeakFeature> GetRecalculatedChromPeakFeaturesByMs1MsTolerance(List<ChromatogramPeakFeature> chromPeakFeatures, IDataProvider provider, AcquisitionType type) {
             // var spectrumList = param.MachineCategory == MachineCategory.LCIMMS ? rawObj.AccumulatedSpectrumList : rawObj.SpectrumList;
             var recalculatedPeakspots = new List<ChromatogramPeakFeature>();
-            var minDatapoint = 3;
+            var minimumDatapoints = Math.Max(1, (int)Math.Ceiling(_parameter.MinimumDatapoints));
+            var minDatapoint = Math.Max(3, (int)Math.Ceiling((minimumDatapoints - 1) * 0.5));
             // var counter = 0;
             var rawSpectra = new RawSpectra(provider.LoadMs1Spectrums(), _parameter.IonMode, type);
             foreach ((ChromatogramPeakFeature peakFeature, IChromatogramPeakFeature peak) in chromPeakFeatures.ZipInternal(chromPeakFeatures)) {
@@ -884,6 +885,7 @@ namespace CompMs.MsdialCore.Algorithm {
 
                 if (Math.Max(sPeaklist[minLeftId].Intensity, sPeaklist[minRightId].Intensity) >= sPeaklist[maxID].Intensity) continue;
                 if (sPeaklist[maxID].Intensity - Math.Min(sPeaklist[minLeftId].Intensity, sPeaklist[minRightId].Intensity) < _parameter.MinimumAmplitude) continue;
+                if (minRightId - minLeftId + 1 < minimumDatapoints) continue;
 
                 //calculating peak area and finding real max ID
                 var realMaxInt = double.MinValue;

--- a/tests/Common/CommonStandardTests/Algorithm/PeakPick/PeakDetectionTests.cs
+++ b/tests/Common/CommonStandardTests/Algorithm/PeakPick/PeakDetectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using CompMs.Common.Components;
+using CompMs.Common.Enum;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,9 +35,31 @@ namespace CompMs.Common.Algorithm.PeakPick.Tests
             Assert.AreEqual(0, actual[0].ScanNumAtLeftPeakEdge);
             Assert.AreEqual(10, actual[0].ScanNumAtPeakTop);
             Assert.AreEqual(19, actual[0].ScanNumAtRightPeakEdge);
+            Assert.AreEqual(20, actual[0].DataPointCount);
             Assert.AreEqual(19, actual[1].ScanNumAtLeftPeakEdge);
             Assert.AreEqual(31, actual[1].ScanNumAtPeakTop);
             Assert.AreEqual(41, actual[1].ScanNumAtRightPeakEdge);
+            Assert.AreEqual(23, actual[1].DataPointCount);
+        }
+
+        [TestMethod()]
+        public void PeakDetectionVS1FiltersPeaksNarrowerThanMinimumDatapoints()
+        {
+            var peak = BuildPeak(0, 10, 700d, 10000d, 1000000d, 0.01);
+            var actual = PeakDetection.PeakDetectionVS1(peak.ToList(), 21, 1000);
+
+            Assert.AreEqual(0, actual.Count);
+        }
+
+        [TestMethod()]
+        public void PeakDetectionVS1ChromatogramFiltersPeaksNarrowerThanMinimumDatapoints()
+        {
+            var peak = BuildPeak(0, 10, 700d, 10000d, 1000000d, 0.01);
+            using var chromatogram = new Chromatogram(peak, ChromXType.RT, ChromXUnit.Min);
+            var detector = new PeakDetection(21, 1000);
+            var actual = detector.PeakDetectionVS1(chromatogram);
+
+            Assert.AreEqual(0, actual.Count);
         }
 
         private ChromatogramPeak[] BuildPeak(int start, int radian, double mass, double baseIntensity, double topIntensity, double baseTime)


### PR DESCRIPTION
## Summary
- Add a DataPointCount accessor to PeakDetectionResult.
- Re-check MinimumDatapoints after peak edge curation/recalculation so narrow detected features are filtered consistently.
- Add unit tests covering both static PeakDetectionVS1 and Chromatogram-based detection paths.

## Validation
- dotnet test tests/Common/CommonStandardTests/CommonStandardTests.csproj -c Debug --no-restore --filter PeakDetectionTests
- dotnet build tests/MSDIAL5/MsdialCoreTestApp/MsdialCoreTestApp.csproj -c Debug --no-restore
- Demo WIFF validation: D:/0_SourceCode/MsdialWorkbenchDemo/console_fastlc_demo/20230406_feces_1_NEG.wiff
  - Minimum peak width 9: 1045 peaks before, 1045 peaks after
  - Minimum peak width 20 stress test: 1002 peaks before, 1000 peaks after; minimum RT peak width increased from 0.099 min to 0.163 min

## Notes
This addresses cases where candidate peak ranges can become narrower than the configured MinimumDatapoints after edge curation or MS1/MS tolerance-based recalculation.