### PR TITLE
Fix imaging peak filter selection

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingDims/ImagingDimsMainViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingDims/ImagingDimsMainViewModel.cs
@@ -12,6 +12,7 @@ using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Notifiers;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ internal class ImagingDimsMainViewModel: MethodViewModel
 {
     private readonly ImagingDimsMethodModel _model;
     private readonly IMessageBroker _broker;
+    private readonly ReactiveProperty<IResultViewModel?> _selectedImageResultViewModel;
 
     public ImagingDimsMainViewModel(ImagingDimsMethodModel model, IMessageBroker broker, IWindowService<PeakSpotTableViewModelBase> peakSpotTableService)
         : base(model,
@@ -30,8 +32,11 @@ internal class ImagingDimsMainViewModel: MethodViewModel
               new ViewModelSwitcher(Observable.Never<ViewModelBase>(), Observable.Never<ViewModelBase>())) {
         _model = model ?? throw new ArgumentNullException(nameof(model));
         _broker = broker;
+        _selectedImageResultViewModel = new ReactiveProperty<IResultViewModel?>().AddTo(Disposables);
+        SelectedViewModel = _selectedImageResultViewModel;
         var focusManager = new FocusControlManager().AddTo(Disposables);
         ImageViewModels = model.ImageModels.ToReadOnlyReactiveCollection(m => new ImagingDimsImageViewModel(m, focusManager, broker, peakSpotTableService)).AddTo(Disposables);
+        SelectedImageViewModel = ImageViewModels.FirstOrDefault();
         RoiCompareViewModels = new ReadOnlyObservableCollection<ImagingRoiCompareViewModel>([]);
         ExportParameterCommand = new AsyncReactiveCommand().WithSubscribe(model.ParameterExporModel.ExportAsync).AddTo(Disposables);
     }
@@ -42,7 +47,11 @@ internal class ImagingDimsMainViewModel: MethodViewModel
 
     public ImagingDimsImageViewModel? SelectedImageViewModel {
         get => _selectedImageViewModel;
-        set => SetProperty(ref _selectedImageViewModel, value);
+        set {
+            if (SetProperty(ref _selectedImageViewModel, value)) {
+                _selectedImageResultViewModel.Value = value?.ImageResultViewModel;
+            }
+        }
     }
     private ImagingDimsImageViewModel? _selectedImageViewModel;
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingDims/WholeImageResultViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingDims/WholeImageResultViewModel.cs
@@ -1,7 +1,10 @@
 ﻿using CompMs.App.Msdial.Model.ImagingDims;
+using CompMs.App.Msdial.Model.Core;
 using CompMs.App.Msdial.ViewModel.Chart;
 using CompMs.App.Msdial.ViewModel.Dims;
+using CompMs.App.Msdial.ViewModel.Core;
 using CompMs.App.Msdial.ViewModel.Imaging;
+using CompMs.App.Msdial.ViewModel.Search;
 using CompMs.App.Msdial.ViewModel.Service;
 using CompMs.App.Msdial.ViewModel.Table;
 using CompMs.CommonMVVM;
@@ -16,7 +19,7 @@ using System.Windows.Input;
 
 namespace CompMs.App.Msdial.ViewModel.ImagingDims;
 
-internal sealed class WholeImageResultViewModel : ViewModelBase
+internal sealed class WholeImageResultViewModel : ViewModelBase, IResultViewModel
 {
     private readonly WholeImageResultModel _model;
 
@@ -40,4 +43,12 @@ internal sealed class WholeImageResultViewModel : ViewModelBase
     public ICommand ShowIonTableCommand => AnalysisViewModel.ShowIonTableCommand;
 
     public ICommand SearchCompoundCommand => AnalysisViewModel.SearchCompoundCommand;
+
+    // IResultViewModel
+    public IResultModel Model => ((IResultViewModel)AnalysisViewModel).Model;
+    public PeakSpotNavigatorViewModel PeakSpotNavigatorViewModel => AnalysisViewModel.PeakSpotNavigatorViewModel;
+    public FocusNavigatorViewModel FocusNavigatorViewModel => AnalysisViewModel.FocusNavigatorViewModel;
+    public ICommand SetUnknownCommand => AnalysisViewModel.SetUnknownCommand;
+    public UndoManagerViewModel UndoManagerViewModel => AnalysisViewModel.UndoManagerViewModel;
+    public ViewModelBase[] PeakDetailViewModels => AnalysisViewModel.PeakDetailViewModels;
 }

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingImms/ImagingImmsMainViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingImms/ImagingImmsMainViewModel.cs
@@ -12,6 +12,7 @@ using Reactive.Bindings.Extensions;
 using Reactive.Bindings.Notifiers;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ namespace CompMs.App.Msdial.ViewModel.ImagingImms
     {
         private readonly ImagingImmsMethodModel _model;
         private readonly IMessageBroker _broker;
+        private readonly ReactiveProperty<IResultViewModel?> _selectedImageResultViewModel;
 
         public ImagingImmsMainViewModel(ImagingImmsMethodModel model, IMessageBroker broker, IWindowService<PeakSpotTableViewModelBase> peakSpotTableService)
             : base(model,
@@ -30,8 +32,11 @@ namespace CompMs.App.Msdial.ViewModel.ImagingImms
                   new ViewModelSwitcher(Observable.Never<ViewModelBase>(), Observable.Never<ViewModelBase>())) {
             _model = model ?? throw new ArgumentNullException(nameof(model));
             _broker = broker;
+            _selectedImageResultViewModel = new ReactiveProperty<IResultViewModel?>().AddTo(Disposables);
+            SelectedViewModel = _selectedImageResultViewModel;
             var focusManager = new FocusControlManager().AddTo(Disposables);
             ImageViewModels = model.ImageModels.ToReadOnlyReactiveCollection(m => new ImagingImmsImageViewModel(m, focusManager, broker, peakSpotTableService)).AddTo(Disposables);
+            SelectedImageViewModel = ImageViewModels.FirstOrDefault();
             RoiCompareViewModels = new ReadOnlyObservableCollection<ImagingRoiCompareViewModel>([]);
             ExportParameterCommand = new AsyncReactiveCommand().WithSubscribe(model.ParameterExporModel.ExportAsync).AddTo(Disposables);
         }
@@ -40,7 +45,11 @@ namespace CompMs.App.Msdial.ViewModel.ImagingImms
         public ReadOnlyObservableCollection<ImagingRoiCompareViewModel> RoiCompareViewModels { get; }
         public ImagingImmsImageViewModel? SelectedImageViewModel {
             get => _selectedImageViewModel;
-            set => SetProperty(ref _selectedImageViewModel, value);
+            set {
+                if (SetProperty(ref _selectedImageViewModel, value)) {
+                    _selectedImageResultViewModel.Value = value?.ImageResultViewModel;
+                }
+            }
         }
         private ImagingImmsImageViewModel? _selectedImageViewModel;
 

--- a/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingImms/WholeImageResultViewModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/ViewModel/ImagingImms/WholeImageResultViewModel.cs
@@ -1,7 +1,10 @@
 ﻿using CompMs.App.Msdial.Model.ImagingImms;
+using CompMs.App.Msdial.Model.Core;
 using CompMs.App.Msdial.ViewModel.Chart;
+using CompMs.App.Msdial.ViewModel.Core;
 using CompMs.App.Msdial.ViewModel.Imaging;
 using CompMs.App.Msdial.ViewModel.Imms;
+using CompMs.App.Msdial.ViewModel.Search;
 using CompMs.App.Msdial.ViewModel.Service;
 using CompMs.App.Msdial.ViewModel.Table;
 using CompMs.CommonMVVM;
@@ -14,7 +17,7 @@ using System.Windows.Input;
 
 namespace CompMs.App.Msdial.ViewModel.ImagingImms
 {
-    internal sealed class WholeImageResultViewModel : ViewModelBase
+    internal sealed class WholeImageResultViewModel : ViewModelBase, IResultViewModel
     {
         private readonly WholeImageResultModel _model;
 
@@ -38,5 +41,12 @@ namespace CompMs.App.Msdial.ViewModel.ImagingImms
         public ICommand ShowIonTableCommand => AnalysisViewModel.ShowIonTableCommand;
 
         public ICommand SearchCompoundCommand => AnalysisViewModel.SearchCompoundCommand;
+
+        // IResultViewModel
+        public IResultModel Model => ((IResultViewModel)AnalysisViewModel).Model;
+        public PeakSpotNavigatorViewModel PeakSpotNavigatorViewModel => AnalysisViewModel.PeakSpotNavigatorViewModel;
+        public ICommand SetUnknownCommand => AnalysisViewModel.SetUnknownCommand;
+        public UndoManagerViewModel UndoManagerViewModel => AnalysisViewModel.UndoManagerViewModel;
+        public ViewModelBase[] PeakDetailViewModels => AnalysisViewModel.PeakDetailViewModels;
     }
 }


### PR DESCRIPTION
## Why

Peak filtering from the shared ribbon was not applied in DIMS/IMMS imaging because the selected imaging result was not exposed through `MethodViewModel.SelectedViewModel`.

## What changed

- Treat `WholeImageResultViewModel` as the imaging result display unit by implementing the existing `IResultViewModel` contract through its nested analysis ViewModel.
- Synchronize the selected image with `MethodViewModel.SelectedViewModel` in both DIMS and IMMS imaging MainViewModels.
- Initialize the selection to the first available image so the ribbon has a result immediately when imaging data is loaded.

This reuses the existing result interface and ribbon path without introducing an imaging-specific result interface. The GUI project builds successfully.