### PR TITLE
Fix long CSV and large JSON export failures

### DIFF
--- a/src/MSDIAL5/MsdialCore/DataObj/AlignmentChromPeakFeature.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/AlignmentChromPeakFeature.cs
@@ -35,6 +35,10 @@ namespace CompMs.MsdialCore.DataObj
         [Key(0)]
         public int FileID { get; set; }
         [Key(1)]
+        /// <summary>
+        /// The file name captured when the alignment result was created; it can differ from
+        /// the current analysis file name after a file property edit.
+        /// </summary>
         public string FileName { get; set; } = string.Empty;
         [Key(2)]
         public int MasterPeakID { get; set; } // sequential IDs parsing all peak features extracted from an MS data

--- a/src/MSDIAL5/MsdialCore/DataObj/AnalysisFile.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/AnalysisFile.cs
@@ -23,6 +23,10 @@ namespace CompMs.MsdialCore.DataObj {
         [Key(0)]
         public string AnalysisFilePath { get; set; } = string.Empty;
         [Key(1)]
+        /// <summary>
+        /// The current display name. Persisted alignment peak names may be an older snapshot;
+        /// use <see cref="AnalysisFileId"/> to associate persisted peak data with this file.
+        /// </summary>
         public string AnalysisFileName { get; set; } = string.Empty;
         [Key(2)]
         public AnalysisFileType AnalysisFileType { get; set; }

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
@@ -76,8 +76,10 @@ namespace CompMs.MsdialCore.Export
             var id = spot.MasterAlignmentID.ToString();
             var dicts = quantAccessors.Select(accessor => accessor.GetQuantValues(spot)).ToList();
             foreach (var file in files) {
+                var peak = spot.AlignedPeakProperties.FirstOrDefault(peak => peak.FileID == file.AnalysisFileId);
+                var peakFileName = peak?.FileName ?? file.AnalysisFileName;
                 IEnumerable<string> row = new[] { id, file.AnalysisFileName, file.AnalysisFileClass }
-                    .Concat(dicts.Select(dict => dict[file.AnalysisFileName]))
+                    .Concat(dicts.Select(dict => dict[peakFileName]))
                     .Select(WrapField);
                 writer.WriteLine(string.Join(_separator, row));
             }

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
@@ -39,7 +39,7 @@ namespace CompMs.MsdialCore.Export
             // Content
             var contents = accessor.GetContents(files);
             foreach (var content in contents) {
-                sw.WriteLine(string.Join(_separator, content));
+                sw.WriteLine(string.Join(_separator, content.Select(WrapField)));
             }
         }
 
@@ -76,9 +76,18 @@ namespace CompMs.MsdialCore.Export
             var id = spot.MasterAlignmentID.ToString();
             var dicts = quantAccessors.Select(accessor => accessor.GetQuantValues(spot)).ToList();
             foreach (var file in files) {
-                IEnumerable<string> row = new[] { id, file.AnalysisFileName, file.AnalysisFileClass }.Concat(dicts.Select(dict => dict[file.AnalysisFileName]));
+                IEnumerable<string> row = new[] { id, file.AnalysisFileName, file.AnalysisFileClass }
+                    .Concat(dicts.Select(dict => dict[file.AnalysisFileName]))
+                    .Select(WrapField);
                 writer.WriteLine(string.Join(_separator, row));
             }
+        }
+
+        private string WrapField(string field) {
+            if (field is null || (!field.Contains(_separator) && !field.Contains('"') && !field.Contains('\r') && !field.Contains('\n'))) {
+                return field;
+            }
+            return $"\"{field.Replace("\"", "\"\"")}\"";
         }
     }
 }

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
@@ -75,8 +75,9 @@ namespace CompMs.MsdialCore.Export
         private void WriteValueContent(StreamWriter writer, AlignmentSpotProperty spot, IReadOnlyList<AnalysisFileBean> files, IQuantValueAccessor[] quantAccessors) {
             var id = spot.MasterAlignmentID.ToString();
             var dicts = quantAccessors.Select(accessor => accessor.GetQuantValues(spot)).ToList();
+            var lookupTable = spot.AlignedPeakProperties.ToLookup(p => p.FileID);
             foreach (var file in files) {
-                var peak = spot.AlignedPeakProperties.FirstOrDefault(peak => peak.FileID == file.AnalysisFileId);
+                var peak = lookupTable[file.AnalysisFileId].FirstOrDefault();
                 var peakFileName = peak?.FileName ?? file.AnalysisFileName;
                 IEnumerable<string> row = new[] { id, file.AnalysisFileName, file.AnalysisFileClass }
                     .Concat(dicts.Select(dict => dict[peakFileName]))

--- a/src/MSDIAL5/MsdialGuiApp/Model/Export/AlignmentReferenceMatchedProductIonExportModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Export/AlignmentReferenceMatchedProductIonExportModel.cs
@@ -8,6 +8,7 @@ using CompMs.CommonMVVM;
 using CompMs.MsdialCore.Algorithm;
 using CompMs.MsdialCore.Algorithm.Annotation;
 using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Parser;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -62,7 +63,8 @@ internal sealed class AlignmentReferenceMatchedProductIonExportModel : BindableB
 
         var dt = DateTime.Now;
         var outFilePath = Path.Combine(exportDirectory, $"{dt:yyyy_MM_dd_HH_mm_ss}_{alignmentFile.FileName}.json");
-        using var writer = new StreamWriter(outFilePath);
+        using var tempFileStream = new TemporaryFileStream(outFilePath, moveBeforeDispose: false);
+        using var writer = new StreamWriter(tempFileStream);
         using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(writer) { Formatting = Newtonsoft.Json.Formatting.Indented };
         var serializer = new Newtonsoft.Json.JsonSerializer();
         jsonWriter.WriteStartArray();
@@ -137,5 +139,6 @@ internal sealed class AlignmentReferenceMatchedProductIonExportModel : BindableB
 
         jsonWriter.WriteEndArray();
         await writer.FlushAsync().ConfigureAwait(false);
+        tempFileStream.Move();
     }
 }

--- a/src/MSDIAL5/MsdialGuiApp/Model/Export/AlignmentReferenceMatchedProductIonExportModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Export/AlignmentReferenceMatchedProductIonExportModel.cs
@@ -60,7 +60,12 @@ internal sealed class AlignmentReferenceMatchedProductIonExportModel : BindableB
         double mzTolerance = .05d;
         var spots = _peakSpotSupplyer.Supply(alignmentFile, token).Select(s => new AlignmentSpotPropertyModel(s));
 
-        var objects = new List<object>();
+        var dt = DateTime.Now;
+        var outFilePath = Path.Combine(exportDirectory, $"{dt:yyyy_MM_dd_HH_mm_ss}_{alignmentFile.FileName}.json");
+        using var writer = new StreamWriter(outFilePath);
+        using var jsonWriter = new Newtonsoft.Json.JsonTextWriter(writer) { Formatting = Newtonsoft.Json.Formatting.Indented };
+        var serializer = new Newtonsoft.Json.JsonSerializer();
+        jsonWriter.WriteStartArray();
         foreach (var spot in spots) {
             token.ThrowIfCancellationRequested();
             if (!spot.IsRefMatched(_evaluator)) {
@@ -116,7 +121,7 @@ internal sealed class AlignmentReferenceMatchedProductIonExportModel : BindableB
             }
 
             var ontology = _dataBaseMapper.MoleculeMsRefer(spot.MatchResultsModel.Representative)?.OntologyOrCompoundClass;
-            objects.Add(new
+            serializer.Serialize(jsonWriter, new
             {
                 MasterAlignemntID = spot.MasterAlignmentID,
                 RepresentativeReference = spot.MatchResultsModel.Representative.Name,
@@ -130,9 +135,7 @@ internal sealed class AlignmentReferenceMatchedProductIonExportModel : BindableB
             });
         }
 
-        var dt = DateTime.Now;
-        var outFilePath = Path.Combine(exportDirectory, $"{dt:yyyy_MM_dd_HH_mm_ss}_{alignmentFile.FileName}.json");
-        using var writer = new StreamWriter(outFilePath);
-        await writer.WriteAsync(Newtonsoft.Json.JsonConvert.SerializeObject(objects, Newtonsoft.Json.Formatting.Indented)).ConfigureAwait(false);
+        jsonWriter.WriteEndArray();
+        await writer.FlushAsync().ConfigureAwait(false);
     }
 }

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentLongCSVExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentLongCSVExporterTests.cs
@@ -1,0 +1,45 @@
+using CompMs.Common.Enum;
+using CompMs.Common.Interfaces;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.MSDec;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CompMs.MsdialCore.Export.Tests;
+
+[TestClass]
+public class AlignmentLongCSVExporterTests
+{
+    [TestMethod]
+    public void ExportFileMetaEscapesDelimiterAndQuotes()
+    {
+        var exporter = new AlignmentLongCSVExporter(",");
+        var files = new[]
+        {
+            new AnalysisFileBean
+            {
+                AnalysisFileName = "sample,\"1\"",
+                AnalysisFileClass = "class",
+                AnalysisFileType = AnalysisFileType.Sample,
+            },
+        };
+        using var stream = new MemoryStream();
+
+        exporter.ExportFileMeta(stream, files, new FakeFileMetaAccessor());
+
+        Assert.AreEqual("Name,Class\r\n\"sample,\"\"1\"\"\",class\r\n", Encoding.ASCII.GetString(stream.ToArray()));
+    }
+
+    private sealed class FakeFileMetaAccessor : IFileClassMetaAccessor
+    {
+        public IReadOnlyList<string> GetHeaders() => new[] { "Name", "Class" };
+
+        public string[] GetContent(AnalysisFileBean file) => new[] { file.AnalysisFileName, file.AnalysisFileClass };
+
+        public string[][] GetContents(IEnumerable<AnalysisFileBean> files)
+            => files.Select(GetContent).ToArray();
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentLongCSVExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentLongCSVExporterTests.cs
@@ -33,6 +33,35 @@ public class AlignmentLongCSVExporterTests
         Assert.AreEqual("Name,Class\r\n\"sample,\"\"1\"\"\",class\r\n", Encoding.ASCII.GetString(stream.ToArray()));
     }
 
+    [TestMethod]
+    public void ExportValueUsesFileIdWhenAlignmentPeakHasOldFileName()
+    {
+        var exporter = new AlignmentLongCSVExporter();
+        var file = new AnalysisFileBean
+        {
+            AnalysisFileId = 7,
+            AnalysisFileName = "renamed.raw",
+            AnalysisFileClass = "class",
+        };
+        var spot = new AlignmentSpotProperty
+        {
+            MasterAlignmentID = 1,
+            AlignedPeakProperties = new List<AlignmentChromPeakFeature>
+            {
+                new AlignmentChromPeakFeature
+                {
+                    FileID = 7,
+                    FileName = "original.raw",
+                },
+            },
+        };
+        using var stream = new MemoryStream();
+
+        exporter.ExportValue(stream, new[] { spot }, new[] { file }, ("Height", new FakeQuantValueAccessor()));
+
+        Assert.AreEqual("ID\tFile\tClass\tHeight\r\n1\trenamed.raw\tclass\tvalue\r\n", Encoding.ASCII.GetString(stream.ToArray()));
+    }
+
     private sealed class FakeFileMetaAccessor : IFileClassMetaAccessor
     {
         public IReadOnlyList<string> GetHeaders() => new[] { "Name", "Class" };
@@ -41,5 +70,17 @@ public class AlignmentLongCSVExporterTests
 
         public string[][] GetContents(IEnumerable<AnalysisFileBean> files)
             => files.Select(GetContent).ToArray();
+    }
+
+    private sealed class FakeQuantValueAccessor : IQuantValueAccessor
+    {
+        public List<string> GetQuantHeaders(IReadOnlyList<AnalysisFileBean> files) => new();
+
+        public List<string> GetStatHeaders() => new();
+
+        public Dictionary<string, string> GetQuantValues(AlignmentSpotProperty spot)
+            => spot.AlignedPeakProperties.ToDictionary(peak => peak.FileName, _ => "value");
+
+        public Dictionary<string, string> GetStatsValues(AlignmentSpotProperty spot, StatsValue stat) => new();
     }
 }


### PR DESCRIPTION
## Why
Long-format CSV export could throw `KeyNotFoundException` after an analysis file was renamed, because persisted alignment peaks retain the original file name. Large alignment JSON exports could also fail when one serialized array exceeded in-memory size limits.

## What changed
- Resolve long CSV quant values through the stable `AnalysisFileId`, using the persisted alignment peak name only for the lookup key.
- Preserve CSV escaping for commas, quotes, and line breaks.
- Stream alignment JSON array entries with `JsonTextWriter` and `JsonSerializer` instead of serializing the complete result collection into one large string.
- Document the lifecycle difference between current analysis file names and alignment-time file name snapshots.
- Add regression coverage for renamed analysis files and CSV escaping.

## Validation
- Focused long CSV exporter tests pass.
- `MsdialGuiApp.csproj` builds successfully with 0 errors.