### PR TITLE
Add EIC chromatogram export to the console app

### DIFF
--- a/src/MSDIAL5/MsdialCore/DataObj/ChromatogramRange.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/ChromatogramRange.cs
@@ -62,5 +62,10 @@ namespace CompMs.MsdialCore.DataObj
         public static ChromatogramRange FromTimes<T>(T begin, T end) where T: IChromX {
             return new ChromatogramRange(begin.Value, end.Value, begin.Type, begin.Unit);
         }
+
+        public static ChromatogramRange FromPeakFeature(IChromatogramPeakFeature peak) {
+            var ax = peak.ChromXsTop.GetRepresentativeXAxis();
+            return new ChromatogramRange(peak, ax.Type, ax.Unit);
+        }
     }
 }

--- a/src/MSDIAL5/MsdialCore/DataObj/ChromatogramRange.cs
+++ b/src/MSDIAL5/MsdialCore/DataObj/ChromatogramRange.cs
@@ -64,6 +64,9 @@ namespace CompMs.MsdialCore.DataObj
         }
 
         public static ChromatogramRange FromPeakFeature(IChromatogramPeakFeature peak) {
+            if (peak is null) {
+                throw new ArgumentNullException(nameof(peak));
+            }
             var ax = peak.ChromXsTop.GetRepresentativeXAxis();
             return new ChromatogramRange(peak, ax.Type, ax.Unit);
         }

--- a/tests/MSDIAL5/MsdialCoreTestApp/CONTEXT.md
+++ b/tests/MSDIAL5/MsdialCoreTestApp/CONTEXT.md
@@ -1,0 +1,26 @@
+# MsdialCoreTestApp
+
+This context covers the MS-DIAL console test application used to exercise core LC/MS workflows, especially EIC handling in the console test app.
+
+## Language
+
+**Peak**:
+A detected feature from an MS-DIAL project or alignment result.
+_Avoid_: Feature, spot, hit
+
+**EIC**:
+Extracted ion chromatogram.
+In this context, the same EIC output is produced through two use cases: from raw measurement data with a user-specified m/z, or from an analyzed project by referencing detected peaks.
+_Avoid_: TIC, base peak chromatogram
+
+**Project-based EIC**:
+An EIC produced from an analyzed project by referencing a detected peak.
+_Avoid_: Raw-data EIC, m/z-specified EIC
+
+**Raw-data EIC**:
+An EIC produced directly from measurement data using a user-specified m/z.
+_Avoid_: Project-based EIC, peak-referenced EIC
+
+**RT correction**:
+Retention time correction used to adjust chromatogram peaks across files before downstream export or alignment.
+_Avoid_: Retention shift, time warping

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -159,9 +159,10 @@ namespace CompMs.App.MsdialConsole.Process
 
         private static void WriteProjectCsv(string outputPath, IMsdialDataStorage<ParameterBase> project)
         {
+            var rootOutput = Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? ".";
+            Directory.CreateDirectory(rootOutput);
             var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
             foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded))
-            {
                 if (file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()) {
                     continue;
                 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace CompMs.App.MsdialConsole.Process
+{
+    public sealed class EicProcess
+    {
+        public int Run(string[] args) {
+            Console.Error.WriteLine("eic subcommands are not implemented yet.");
+            return -1;
+        }
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -16,7 +16,7 @@ namespace CompMs.App.MsdialConsole.Process
     {
         public int Run(string[] args) {
             if (args.Length < 2) {
-                return argsError();
+                return ArgsError();
             }
 
             var subcommand = args[1];
@@ -31,57 +31,73 @@ namespace CompMs.App.MsdialConsole.Process
             return -1;
         }
 
-        private int RunRaw(string[] args) {
+        private int RunRaw(string[] args)
+        {
             var inputFile = string.Empty;
             var outputFile = string.Empty;
             var targets = new List<TargetQuery>();
 
-            for (var i = 2; i < args.Length; i++) {
-                if (args[i] == "-i" && i + 1 < args.Length) {
+            for (var i = 2; i < args.Length; i++)
+            {
+                if (args[i] == "-i" && i + 1 < args.Length)
+                {
                     inputFile = args[i + 1];
                 }
-                else if (args[i] == "-o" && i + 1 < args.Length) {
+                else if (args[i] == "-o" && i + 1 < args.Length)
+                {
                     outputFile = args[i + 1];
                 }
-                else if (args[i] == "-target" && i + 2 < args.Length) {
+                else if (args[i] == "-target" && i + 2 < args.Length)
+                {
                     if (!double.TryParse(args[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var mz)
-                        || !double.TryParse(args[i + 2], NumberStyles.Float, CultureInfo.InvariantCulture, out var tolerance)) {
-                        return argsError();
+                        || !double.TryParse(args[i + 2], NumberStyles.Float, CultureInfo.InvariantCulture, out var tolerance))
+                    {
+                        return ArgsError();
                     }
                     targets.Add(new TargetQuery(mz, tolerance));
                     i += 2;
                 }
             }
 
-            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull() || targets.Count == 0) {
-                return argsError();
+            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull() || targets.Count == 0)
+            {
+                return ArgsError();
             }
 
             var spectra = LoadMeasurement(inputFile);
-            if (spectra.Count == 0) {
+            if (spectra.Count == 0)
+            {
                 Console.Error.WriteLine("No raw spectra were found.");
                 return -1;
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
-            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
-            writer.WriteLine("ScanId,RT,TargetMz,Tolerance,Intensity");
-
-            foreach (var spectrum in spectra.Where(n => n.MsLevel == 1)) {
-                foreach (var target in targets) {
-                    var intensity = spectrum.Spectrum
-                        .Where(peak => Math.Abs(peak.Mz - target.Mz) <= target.Tolerance)
-                        .Sum(peak => peak.Intensity);
-                    writer.WriteLine(string.Join(",",
-                        spectrum.ScanNumber,
-                        spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
-                        target.Mz.ToString(CultureInfo.InvariantCulture),
-                        target.Tolerance.ToString(CultureInfo.InvariantCulture),
-                        intensity.ToString(CultureInfo.InvariantCulture)));
-                }
-            }
+            WriteRawCsv(outputFile, targets, spectra);
 
             return 0;
+        }
+
+        private static void WriteRawCsv(string outputFile, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra)
+        {
+            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
+            writer.WriteLine( "ScanId,RT,TargetMz,Tolerance,Intensity");
+            {
+                foreach (var spectrum in spectra.Where(n => n.MsLevel == 1))
+                {
+                    foreach (var target in targets)
+                    {
+                        var intensity = spectrum.Spectrum
+                            .Where(peak => Math.Abs(peak.Mz - target.Mz) <= target.Tolerance)
+                            .Sum(peak => peak.Intensity);
+                        writer.WriteLine(string.Join(",",
+                            spectrum.ScanNumber,
+                            spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
+                            target.Mz.ToString(CultureInfo.InvariantCulture),
+                            target.Tolerance.ToString(CultureInfo.InvariantCulture),
+                            intensity.ToString(CultureInfo.InvariantCulture)));
+                    }
+                }
+            }
         }
 
         private int RunProject(string[] args) {
@@ -106,7 +122,7 @@ namespace CompMs.App.MsdialConsole.Process
             }
 
             if (inputFile.IsEmptyOrNull() || rawFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
-                return argsError();
+                return ArgsError();
             }
 
             if (!File.Exists(inputFile)) {
@@ -132,40 +148,42 @@ namespace CompMs.App.MsdialConsole.Process
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
-            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase)) {
+            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase))
+            {
                 WriteProjectCsv(outputFile, peaks, measurement);
                 return 0;
             }
-
-            var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, measurement);
-            File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-            return 0;
-        }
-
-        private static void WriteProjectCsv(string outputFile, IReadOnlyList<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement) {
-            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
-            writer.WriteLine("PeakId,MasterPeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
-            foreach (var peak in peaks) {
-                WriteProjectRawCsvRows(writer, peak, measurement);
+            else
+            {
+                var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, measurement);
+                File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                return 0;
             }
         }
 
-        private static void WriteProjectRawCsvRows(StreamWriter writer, ChromatogramPeakFeature peak, IReadOnlyList<RawSpectrum> measurement) {
-            var targetMz = peak.PeakFeature.Mass;
-            var tolerance = EstimateTolerance(peak);
-            foreach (var spectrum in measurement.Where(n => n.MsLevel == 1)) {
-                var intensity = spectrum.Spectrum
-                    .Where(point => Math.Abs(point.Mz - targetMz) <= tolerance)
-                    .Sum(point => point.Intensity);
-                writer.WriteLine(string.Join(",",
-                    peak.PeakID,
-                    peak.MasterPeakID,
-                    CsvEscape(peak.Name),
-                    spectrum.ScanNumber,
-                    spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
-                    targetMz.ToString(CultureInfo.InvariantCulture),
-                    tolerance.ToString(CultureInfo.InvariantCulture),
-                    intensity.ToString(CultureInfo.InvariantCulture)));
+        private static void WriteProjectCsv(string outputFile, List<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement)
+        {
+            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
+            writer.WriteLine("MasterPeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
+            {
+                foreach (var peak in peaks)
+                {
+                    var targetMz = peak.PeakFeature.Mass;
+                    var tolerance = EstimateTolerance(peak);
+                    foreach (var spectrum in measurement.Where(n => n.MsLevel == 1)) {
+                        var intensity = spectrum.Spectrum
+                            .Where(point => Math.Abs(point.Mz - targetMz) <= tolerance)
+                            .Sum(point => point.Intensity);
+                        writer.WriteLine(string.Join(",",
+                            peak.MasterPeakID,
+                            CsvEscape(peak.Name),
+                            spectrum.ScanNumber,
+                            spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
+                            targetMz.ToString(CultureInfo.InvariantCulture),
+                            tolerance.ToString(CultureInfo.InvariantCulture),
+                            intensity.ToString(CultureInfo.InvariantCulture)));
+                    }
+                }
             }
         }
 
@@ -229,7 +247,7 @@ namespace CompMs.App.MsdialConsole.Process
             return new ProjectChromatogram(rts, intensities);
         }
 
-        private static void AddChromPoint(List<double> rts, List<double> intensities, CompMs.Common.Components.ChromXs chromXs, double intensity) {
+        private static void AddChromPoint(List<double> rts, List<double> intensities, Common.Components.ChromXs chromXs, double intensity) {
             if (chromXs == null) {
                 return;
             }
@@ -254,7 +272,7 @@ namespace CompMs.App.MsdialConsole.Process
                 : value;
         }
 
-        private static double GetChromValue(CompMs.Common.Components.ChromXs chromXs) {
+        private static double GetChromValue(Common.Components.ChromXs chromXs) {
             return chromXs?.Value ?? 0d;
         }
 
@@ -272,33 +290,25 @@ namespace CompMs.App.MsdialConsole.Process
         private static IReadOnlyList<RawSpectrum> LoadMeasurement(string inputFile) {
             using var access = new RawDataAccess(inputFile, 0, false, false, false);
             var measurement = access.GetMeasurement();
-            return measurement?.SpectrumList ?? new List<RawSpectrum>();
+            return measurement?.SpectrumList ?? [];
         }
 
-        private static int argsError() {
+        private static int ArgsError() {
             Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -target <mz> <tolerance> [-target <mz> <tolerance> ...]");
             Console.Error.WriteLine("MsdialConsoleApp.exe eic project -i <peak file> -raw <raw file> -o <output file> [-format csv|json]");
             return -1;
         }
 
-        private readonly struct TargetQuery {
-            public TargetQuery(double mz, double tolerance) {
-                Mz = mz;
-                Tolerance = tolerance;
-            }
-
-            public double Mz { get; }
-            public double Tolerance { get; }
+        private readonly struct TargetQuery(double mz, double tolerance)
+        {
+            public double Mz { get; } = mz;
+            public double Tolerance { get; } = tolerance;
         }
 
-        private readonly struct ProjectChromatogram {
-            public ProjectChromatogram(List<double> rts, List<double> intensities) {
-                Rts = rts;
-                Intensities = intensities;
-            }
-
-            public List<double> Rts { get; }
-            public List<double> Intensities { get; }
+        private readonly struct ProjectChromatogram(List<double> rts, List<double> intensities)
+        {
+            public List<double> Rts { get; } = rts;
+            public List<double> Intensities { get; } = intensities;
             public int PointCount => Math.Min(Rts.Count, Intensities.Count);
         }
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -1,6 +1,9 @@
+using CompMs.App.MsdialConsole.Parser;
+using CompMs.Common.Components;
 using CompMs.Common.DataObj;
 using CompMs.Common.Extension;
 using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Parameter;
 using CompMs.MsdialCore.Parser;
 using CompMs.RawDataHandler.Core;
 using System;
@@ -103,6 +106,7 @@ namespace CompMs.App.MsdialConsole.Process
         private int RunProject(string[] args) {
             var inputFile = string.Empty;
             var rawFile = string.Empty;
+            var parameterFile = string.Empty;
             var outputFile = string.Empty;
             var outputFormat = "json";
 
@@ -113,6 +117,9 @@ namespace CompMs.App.MsdialConsole.Process
                 else if (args[i] == "-raw" && i + 1 < args.Length) {
                     rawFile = args[i + 1];
                 }
+                else if (args[i] == "-param" && i + 1 < args.Length) {
+                    parameterFile = args[i + 1];
+                }
                 else if (args[i] == "-o" && i + 1 < args.Length) {
                     outputFile = args[i + 1];
                 }
@@ -121,7 +128,7 @@ namespace CompMs.App.MsdialConsole.Process
                 }
             }
 
-            if (inputFile.IsEmptyOrNull() || rawFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
+            if (inputFile.IsEmptyOrNull() || rawFile.IsEmptyOrNull() || parameterFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
                 return ArgsError();
             }
 
@@ -147,53 +154,59 @@ namespace CompMs.App.MsdialConsole.Process
                 return -1;
             }
 
+            if (!File.Exists(parameterFile)) {
+                Console.Error.WriteLine($"Project parameter file was not found: {parameterFile}");
+                return -1;
+            }
+
+            var parameter = ConfigParser.ReadForLcmsParameter(parameterFile);
+
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
             if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase))
             {
-                WriteProjectCsv(outputFile, peaks, measurement);
+                WriteProjectCsv(outputFile, peaks, measurement, parameter);
                 return 0;
             }
             else
             {
-                var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, measurement);
+                var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, measurement, parameter);
                 File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 return 0;
             }
         }
 
-        private static void WriteProjectCsv(string outputFile, List<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement)
+        private static void WriteProjectCsv(string outputFile, List<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement, ParameterBase parameter)
         {
+            var rawSpectra = new RawSpectra(measurement, parameter.IonMode, parameter.ProjectParam.AcquisitionType);
             using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
             writer.WriteLine("MasterPeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
             {
-                foreach (var peak in peaks)
+                var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
+                var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), parameter.CentroidMs1Tolerance, range);
+                foreach (var (chromatogram, peak) in chromatograms.Zip(peaks, (c, p) => (c, p)))
                 {
-                    var targetMz = peak.PeakFeature.Mass;
-                    var tolerance = EstimateTolerance(peak);
-                    foreach (var spectrum in measurement.Where(n => n.MsLevel == 1)) {
-                        var intensity = spectrum.Spectrum
-                            .Where(point => Math.Abs(point.Mz - targetMz) <= tolerance)
-                            .Sum(point => point.Intensity);
+                    foreach (var dataPoint in chromatogram.AsPeakArray()) {
                         writer.WriteLine(string.Join(",",
                             peak.MasterPeakID,
                             CsvEscape(peak.Name),
-                            spectrum.ScanNumber,
-                            spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
-                            targetMz.ToString(CultureInfo.InvariantCulture),
-                            tolerance.ToString(CultureInfo.InvariantCulture),
-                            intensity.ToString(CultureInfo.InvariantCulture)));
+                            dataPoint.Id,
+                            dataPoint.Time.ToString(CultureInfo.InvariantCulture),
+                            chromatogram.ExtractedMz.ToString(CultureInfo.InvariantCulture),
+                            parameter.CentroidMs1Tolerance.ToString(CultureInfo.InvariantCulture),
+                            dataPoint.Intensity.ToString(CultureInfo.InvariantCulture)));
                     }
                 }
             }
         }
 
-        private static string BuildProjectJson(string source, IReadOnlyList<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement) {
+        private static string BuildProjectJson(string source, IReadOnlyList<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement, ParameterBase parameter) {
+            var rawSpectra = new RawSpectra(measurement, parameter.IonMode, parameter.ProjectParam.AcquisitionType);
             var sb = new StringBuilder();
             sb.AppendLine("{");
             sb.AppendLine($"  \"source\": \"{EscapeJson(source)}\",");
             sb.AppendLine("  \"peaks\": [");
             for (var i = 0; i < peaks.Count; i++) {
-                sb.Append(BuildProjectPeakJson(peaks[i], measurement));
+                sb.Append(BuildProjectPeakJson(peaks[i], rawSpectra, parameter));
                 if (i < peaks.Count - 1) {
                     sb.AppendLine(",");
                 }
@@ -206,8 +219,8 @@ namespace CompMs.App.MsdialConsole.Process
             return sb.ToString();
         }
 
-        private static string BuildProjectPeakJson(ChromatogramPeakFeature peak, IReadOnlyList<RawSpectrum> measurement) {
-            var chromatogram = ExtractPeakChromatogram(peak, measurement);
+        private static string BuildProjectPeakJson(ChromatogramPeakFeature peak, RawSpectra rawSpectra, ParameterBase parameter) {
+            var chromatogram = ExtractPeakChromatogram(peak, rawSpectra, parameter);
             var sb = new StringBuilder();
             sb.AppendLine("    {");
             sb.AppendLine($"      \"id\": {peak.PeakID},");
@@ -227,32 +240,16 @@ namespace CompMs.App.MsdialConsole.Process
             return sb.ToString();
         }
 
-        private static ProjectChromatogram ExtractPeakChromatogram(ChromatogramPeakFeature peak, IReadOnlyList<RawSpectrum> measurement) {
+        private static ProjectChromatogram ExtractPeakChromatogram(ChromatogramPeakFeature peak, RawSpectra rawSpectra, ParameterBase parameter) {
             var rts = new List<double>();
             var intensities = new List<double>();
             var targetMz = peak.PeakFeature.Mass;
-            var tolerance = EstimateTolerance(peak);
-            foreach (var spectrum in measurement.Where(n => n.MsLevel == 1)) {
-                var intensity = spectrum.Spectrum
-                    .Where(point => Math.Abs(point.Mz - targetMz) <= tolerance)
-                    .Sum(point => point.Intensity);
-                rts.Add(spectrum.ScanStartTime);
-                intensities.Add(intensity);
-            }
-            if (rts.Count == 0) {
-                AddChromPoint(rts, intensities, peak.PeakFeature.ChromXsLeft, peak.PeakFeature.PeakHeightLeft);
-                AddChromPoint(rts, intensities, peak.PeakFeature.ChromXsTop, peak.PeakFeature.PeakHeightTop);
-                AddChromPoint(rts, intensities, peak.PeakFeature.ChromXsRight, peak.PeakFeature.PeakHeightRight);
+            var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(targetMz, parameter.CentroidMs1Tolerance), new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min));
+            foreach (var dataPoint in chromatogram.AsPeakArray()) {
+                rts.Add(dataPoint.Time);
+                intensities.Add(dataPoint.Intensity);
             }
             return new ProjectChromatogram(rts, intensities);
-        }
-
-        private static void AddChromPoint(List<double> rts, List<double> intensities, Common.Components.ChromXs chromXs, double intensity) {
-            if (chromXs == null) {
-                return;
-            }
-            rts.Add(chromXs.Value);
-            intensities.Add(intensity);
         }
 
         private static string EscapeJson(string value) {
@@ -274,17 +271,6 @@ namespace CompMs.App.MsdialConsole.Process
 
         private static double GetChromValue(Common.Components.ChromXs chromXs) {
             return chromXs?.Value ?? 0d;
-        }
-
-        private static double EstimateTolerance(ChromatogramPeakFeature peak) {
-            var left = GetChromValue(peak.PeakFeature.ChromXsLeft);
-            var top = GetChromValue(peak.PeakFeature.ChromXsTop);
-            var right = GetChromValue(peak.PeakFeature.ChromXsRight);
-            var width = Math.Max(0d, right - left);
-            if (width > 0d) {
-                return width / 2d;
-            }
-            return Math.Max(0.01d, Math.Abs(top - left));
         }
 
         private static IReadOnlyList<RawSpectrum> LoadMeasurement(string inputFile) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -1,11 +1,88 @@
+using CompMs.Common.Extension;
+using CompMs.Common.DataObj;
+using CompMs.RawDataHandler.Core;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace CompMs.App.MsdialConsole.Process
 {
     public sealed class EicProcess
     {
         public int Run(string[] args) {
-            Console.Error.WriteLine("eic subcommands are not implemented yet.");
+            if (args.Length < 2) {
+                return argsError();
+            }
+
+            var subcommand = args[1];
+            if (subcommand == "raw") {
+                return RunRaw(args);
+            }
+
+            Console.Error.WriteLine($"Invalid eic subcommand: {subcommand}");
+            return -1;
+        }
+
+        private int RunRaw(string[] args) {
+            var inputFile = string.Empty;
+            var outputFile = string.Empty;
+            var targetMz = double.NaN;
+            var mzTolerance = 0.01d;
+
+            for (var i = 2; i < args.Length; i++) {
+                if (args[i] == "-i" && i + 1 < args.Length) {
+                    inputFile = args[i + 1];
+                }
+                else if (args[i] == "-o" && i + 1 < args.Length) {
+                    outputFile = args[i + 1];
+                }
+                else if (args[i] == "-mz" && i + 1 < args.Length) {
+                    if (!double.TryParse(args[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out targetMz)) {
+                        return argsError();
+                    }
+                }
+                else if (args[i] == "-tolerance" && i + 1 < args.Length) {
+                    if (!double.TryParse(args[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out mzTolerance)) {
+                        return argsError();
+                    }
+                }
+            }
+
+            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull() || double.IsNaN(targetMz)) {
+                return argsError();
+            }
+
+            var spectra = LoadMeasurement(inputFile);
+            if (spectra.Count == 0) {
+                Console.Error.WriteLine("No raw spectra were found.");
+                return -1;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
+            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
+            writer.WriteLine("ScanId,RT,Intensity");
+
+            foreach (var spectrum in spectra.Where(n => n.MsLevel == 1)) {
+                var intensity = spectrum.Spectrum
+                    .Where(peak => Math.Abs(peak.Mz - targetMz) <= mzTolerance)
+                    .Sum(peak => peak.Intensity);
+                writer.WriteLine(string.Join(",", spectrum.ScanNumber, spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture), intensity.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            return 0;
+        }
+
+        private static IReadOnlyList<RawSpectrum> LoadMeasurement(string inputFile) {
+            using var access = new RawDataAccess(inputFile, 0, false, false, false);
+            var measurement = access.GetMeasurement();
+            return measurement?.SpectrumList ?? new List<RawSpectrum>();
+        }
+
+        private static int argsError() {
+            Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -mz <target m/z> [-tolerance <mz tolerance>]");
             return -1;
         }
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -1,5 +1,6 @@
-using CompMs.Common.Extension;
 using CompMs.Common.DataObj;
+using CompMs.Common.Extension;
+using CompMs.MsdialCore.Parser;
 using CompMs.RawDataHandler.Core;
 using System;
 using System.Collections.Generic;
@@ -20,6 +21,9 @@ namespace CompMs.App.MsdialConsole.Process
             var subcommand = args[1];
             if (subcommand == "raw") {
                 return RunRaw(args);
+            }
+            if (subcommand == "project") {
+                return RunProject(args);
             }
 
             Console.Error.WriteLine($"Invalid eic subcommand: {subcommand}");
@@ -75,6 +79,121 @@ namespace CompMs.App.MsdialConsole.Process
             return 0;
         }
 
+        private int RunProject(string[] args) {
+            var inputFile = string.Empty;
+            var outputFile = string.Empty;
+            var maxPoints = 20;
+
+            for (var i = 2; i < args.Length; i++) {
+                if (args[i] == "-i" && i + 1 < args.Length) {
+                    inputFile = args[i + 1];
+                }
+                else if (args[i] == "-o" && i + 1 < args.Length) {
+                    outputFile = args[i + 1];
+                }
+                else if (args[i] == "-maxPoints" && i + 1 < args.Length) {
+                    if (!int.TryParse(args[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out maxPoints) || maxPoints <= 0) {
+                        return argsError();
+                    }
+                }
+            }
+
+            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
+                return argsError();
+            }
+
+            if (!File.Exists(inputFile)) {
+                Console.Error.WriteLine($"Project peak file was not found: {inputFile}");
+                return -1;
+            }
+
+            var peaks = MsdialPeakSerializer.LoadChromatogramPeakFeatures(inputFile);
+            if (peaks == null || peaks.Count == 0) {
+                Console.Error.WriteLine("No chromatogram peaks were found.");
+                return -1;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
+            var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, maxPoints);
+            File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            return 0;
+        }
+
+        private static string BuildProjectJson(string source, IReadOnlyList<CompMs.MsdialCore.DataObj.ChromatogramPeakFeature> peaks, int maxPoints) {
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine($"  \"source\": \"{EscapeJson(source)}\",");
+            sb.AppendLine("  \"peaks\": [");
+            for (var i = 0; i < peaks.Count; i++) {
+                sb.Append(BuildProjectPeakJson(peaks[i], maxPoints));
+                if (i < peaks.Count - 1) {
+                    sb.AppendLine(",");
+                }
+                else {
+                    sb.AppendLine();
+                }
+            }
+            sb.AppendLine("  ]");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        private static string BuildProjectPeakJson(CompMs.MsdialCore.DataObj.ChromatogramPeakFeature peak, int maxPoints) {
+            var points = BuildPeakPoints(peak).Take(maxPoints).ToList();
+            var sb = new StringBuilder();
+            sb.AppendLine("    {");
+            sb.AppendLine($"      \"id\": {peak.PeakID},");
+            sb.AppendLine($"      \"masterPeakId\": {peak.MasterPeakID},");
+            sb.AppendLine($"      \"name\": \"{EscapeJson(peak.Name)}\",");
+            sb.AppendLine($"      \"mz\": {peak.PeakFeature.Mass.ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine("      \"rt\": {");
+            sb.AppendLine($"        \"left\": {GetChromValue(peak.PeakFeature.ChromXsLeft).ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"        \"top\": {GetChromValue(peak.PeakFeature.ChromXsTop).ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"        \"right\": {GetChromValue(peak.PeakFeature.ChromXsRight).ToString(CultureInfo.InvariantCulture)}");
+            sb.AppendLine("      },");
+            sb.AppendLine("      \"points\": [");
+            for (var i = 0; i < points.Count; i++) {
+                sb.Append($"        {{ \"rt\": {points[i].Rt.ToString(CultureInfo.InvariantCulture)}, \"intensity\": {points[i].Intensity.ToString(CultureInfo.InvariantCulture)} }}");
+                if (i < points.Count - 1) {
+                    sb.AppendLine(",");
+                }
+                else {
+                    sb.AppendLine();
+                }
+            }
+            sb.AppendLine("      ]");
+            sb.Append("    }");
+            return sb.ToString();
+        }
+
+        private static IEnumerable<ProjectPoint> BuildPeakPoints(CompMs.MsdialCore.DataObj.ChromatogramPeakFeature peak) {
+            yield return new ProjectPoint(GetChromValue(peak.PeakFeature.ChromXsLeft), peak.PeakFeature.PeakHeightLeft);
+            yield return new ProjectPoint(GetChromValue(peak.PeakFeature.ChromXsTop), peak.PeakFeature.PeakHeightTop);
+            yield return new ProjectPoint(GetChromValue(peak.PeakFeature.ChromXsRight), peak.PeakFeature.PeakHeightRight);
+        }
+
+        private static string EscapeJson(string value) {
+            return (value ?? string.Empty)
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\r", "\\r")
+                .Replace("\n", "\\n");
+        }
+
+        private static double GetChromValue(CompMs.Common.Components.ChromXs chromXs) {
+            return chromXs?.Value ?? 0d;
+        }
+
+        private readonly struct ProjectPoint {
+            public ProjectPoint(double rt, double intensity) {
+                Rt = rt;
+                Intensity = intensity;
+            }
+
+            public double Rt { get; }
+            public double Intensity { get; }
+        }
+
         private static IReadOnlyList<RawSpectrum> LoadMeasurement(string inputFile) {
             using var access = new RawDataAccess(inputFile, 0, false, false, false);
             var measurement = access.GetMeasurement();
@@ -83,6 +202,7 @@ namespace CompMs.App.MsdialConsole.Process
 
         private static int argsError() {
             Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -mz <target m/z> [-tolerance <mz tolerance>]");
+            Console.Error.WriteLine("MsdialConsoleApp.exe eic project -i <peak file> -o <output json> [-maxPoints <count>]");
             return -1;
         }
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -1,6 +1,7 @@
 using CompMs.App.MsdialConsole.Parser;
 using CompMs.Common.Components;
 using CompMs.Common.DataObj;
+using CompMs.Common.Enum;
 using CompMs.Common.Extension;
 using CompMs.MsdialCore.DataObj;
 using CompMs.MsdialCore.Parameter;
@@ -38,6 +39,7 @@ namespace CompMs.App.MsdialConsole.Process
         {
             var inputFile = string.Empty;
             var outputFile = string.Empty;
+            var acquisitionType = AcquisitionType.DDA;
             var targets = new List<TargetQuery>();
 
             for (var i = 2; i < args.Length; i++)
@@ -49,6 +51,13 @@ namespace CompMs.App.MsdialConsole.Process
                 else if (args[i] == "-o" && i + 1 < args.Length)
                 {
                     outputFile = args[i + 1];
+                }
+                else if (args[i] == "-acquisitiontype" && i + 1 < args.Length)
+                {
+                    if (!Enum.TryParse(args[i + 1], true, out acquisitionType))
+                    {
+                        return ArgsError();
+                    }
                 }
                 else if (args[i] == "-target" && i + 2 < args.Length)
                 {
@@ -75,30 +84,28 @@ namespace CompMs.App.MsdialConsole.Process
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
-            WriteRawCsv(outputFile, targets, spectra);
+            WriteRawCsv(outputFile, targets, spectra, acquisitionType);
 
             return 0;
         }
 
-        private static void WriteRawCsv(string outputFile, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra)
+        private static void WriteRawCsv(string outputFile, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra, AcquisitionType acquisitionType)
         {
+            var rawSpectra = new RawSpectra(spectra, IonMode.Positive, acquisitionType);
             using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
             writer.WriteLine( "ScanId,RT,TargetMz,Tolerance,Intensity");
+            var chromatogramRange = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
+            foreach (var target in targets)
             {
-                foreach (var spectrum in spectra.Where(n => n.MsLevel == 1))
+                using var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(target.Mz, target.Tolerance), chromatogramRange);
+                for (var i = 0; i < chromatogram.Length; i++)
                 {
-                    foreach (var target in targets)
-                    {
-                        var intensity = spectrum.Spectrum
-                            .Where(peak => Math.Abs(peak.Mz - target.Mz) <= target.Tolerance)
-                            .Sum(peak => peak.Intensity);
-                        writer.WriteLine(string.Join(",",
-                            spectrum.ScanNumber,
-                            spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
-                            target.Mz.ToString(CultureInfo.InvariantCulture),
-                            target.Tolerance.ToString(CultureInfo.InvariantCulture),
-                            intensity.ToString(CultureInfo.InvariantCulture)));
-                    }
+                    writer.WriteLine(string.Join(",",
+                        chromatogram.Id(i),
+                        chromatogram.Time(i).ToString(CultureInfo.InvariantCulture),
+                        target.Mz.ToString(CultureInfo.InvariantCulture),
+                        target.Tolerance.ToString(CultureInfo.InvariantCulture),
+                        chromatogram.Intensity(i).ToString(CultureInfo.InvariantCulture)));
                 }
             }
         }
@@ -180,21 +187,19 @@ namespace CompMs.App.MsdialConsole.Process
             var rawSpectra = new RawSpectra(measurement, parameter.IonMode, parameter.ProjectParam.AcquisitionType);
             using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
             writer.WriteLine("MasterPeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
+            var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
+            var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), parameter.CentroidMs1Tolerance, range);
+            foreach (var (chromatogram, peak) in chromatograms.Zip(peaks, (c, p) => (c, p)))
             {
-                var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
-                var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), parameter.CentroidMs1Tolerance, range);
-                foreach (var (chromatogram, peak) in chromatograms.Zip(peaks, (c, p) => (c, p)))
-                {
-                    foreach (var dataPoint in chromatogram.AsPeakArray()) {
-                        writer.WriteLine(string.Join(",",
-                            peak.MasterPeakID,
-                            CsvEscape(peak.Name),
-                            dataPoint.Id,
-                            dataPoint.Time.ToString(CultureInfo.InvariantCulture),
-                            chromatogram.ExtractedMz.ToString(CultureInfo.InvariantCulture),
-                            parameter.CentroidMs1Tolerance.ToString(CultureInfo.InvariantCulture),
-                            dataPoint.Intensity.ToString(CultureInfo.InvariantCulture)));
-                    }
+                foreach (var dataPoint in chromatogram.AsPeakArray()) {
+                    writer.WriteLine(string.Join(",",
+                        peak.MasterPeakID,
+                        CsvEscape(peak.Name),
+                        dataPoint.Id,
+                        dataPoint.Time.ToString(CultureInfo.InvariantCulture),
+                        chromatogram.ExtractedMz.ToString(CultureInfo.InvariantCulture),
+                        parameter.CentroidMs1Tolerance.ToString(CultureInfo.InvariantCulture),
+                        dataPoint.Intensity.ToString(CultureInfo.InvariantCulture)));
                 }
             }
         }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -112,20 +112,12 @@ namespace CompMs.App.MsdialConsole.Process
 
         private int RunProject(string[] args) {
             var inputFile = string.Empty;
-            var rawFile = string.Empty;
-            var parameterFile = string.Empty;
             var outputFile = string.Empty;
             var outputFormat = "json";
 
             for (var i = 2; i < args.Length; i++) {
                 if (args[i] == "-i" && i + 1 < args.Length) {
                     inputFile = args[i + 1];
-                }
-                else if (args[i] == "-raw" && i + 1 < args.Length) {
-                    rawFile = args[i + 1];
-                }
-                else if (args[i] == "-param" && i + 1 < args.Length) {
-                    parameterFile = args[i + 1];
                 }
                 else if (args[i] == "-o" && i + 1 < args.Length) {
                     outputFile = args[i + 1];
@@ -135,84 +127,84 @@ namespace CompMs.App.MsdialConsole.Process
                 }
             }
 
-            if (inputFile.IsEmptyOrNull() || rawFile.IsEmptyOrNull() || parameterFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
+            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
                 return ArgsError();
             }
 
             if (!File.Exists(inputFile)) {
-                Console.Error.WriteLine($"Project peak file was not found: {inputFile}");
+                Console.Error.WriteLine($"Project file was not found: {inputFile}");
                 return -1;
             }
-
-            if (!File.Exists(rawFile)) {
-                Console.Error.WriteLine($"Raw data file was not found: {rawFile}");
-                return -1;
-            }
-
-            var peaks = MsdialPeakSerializer.LoadChromatogramPeakFeatures(inputFile);
-            if (peaks == null || peaks.Count == 0) {
-                Console.Error.WriteLine("No chromatogram peaks were found.");
-                return -1;
-            }
-
-            var measurement = LoadMeasurement(rawFile);
-            if (measurement == null || measurement.Count == 0) {
-                Console.Error.WriteLine("No raw spectra were found for project export.");
-                return -1;
-            }
-
-            if (!File.Exists(parameterFile)) {
-                Console.Error.WriteLine($"Project parameter file was not found: {parameterFile}");
-                return -1;
-            }
-
-            var parameter = ConfigParser.ReadForLcmsParameter(parameterFile);
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
+            var project = LoadProject(inputFile);
+            var files = project.AnalysisFiles.Where(file => file.AnalysisFileIncluded).ToList();
+            if (files.Count == 0) {
+                Console.Error.WriteLine("No included analysis files were found in the project.");
+                return -1;
+            }
+
             if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase))
             {
-                WriteProjectCsv(outputFile, peaks, measurement, parameter);
+                WriteProjectCsv(outputFile, project);
                 return 0;
             }
             else
             {
-                var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, measurement, parameter);
+                var json = BuildProjectJson(Path.GetFullPath(inputFile), project);
                 File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
                 return 0;
             }
         }
 
-        private static void WriteProjectCsv(string outputFile, List<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement, ParameterBase parameter)
+        private static void WriteProjectCsv(string outputFile, IMsdialDataStorage<ParameterBase> project)
         {
-            var rawSpectra = new RawSpectra(measurement, parameter.IonMode, parameter.ProjectParam.AcquisitionType);
             using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
-            writer.WriteLine("MasterPeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
+            writer.WriteLine("FileId,FileName,PeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
             var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
-            var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), parameter.CentroidMs1Tolerance, range);
-            foreach (var (chromatogram, peak) in chromatograms.Zip(peaks, (c, p) => (c, p)))
+            foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded))
             {
-                foreach (var dataPoint in chromatogram.AsPeakArray()) {
-                    writer.WriteLine(string.Join(",",
-                        peak.MasterPeakID,
-                        CsvEscape(peak.Name),
-                        dataPoint.Id,
-                        dataPoint.Time.ToString(CultureInfo.InvariantCulture),
-                        chromatogram.ExtractedMz.ToString(CultureInfo.InvariantCulture),
-                        parameter.CentroidMs1Tolerance.ToString(CultureInfo.InvariantCulture),
-                        dataPoint.Intensity.ToString(CultureInfo.InvariantCulture)));
+                if (file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()) {
+                    continue;
+                }
+
+                var peaks = MsdialPeakSerializer.LoadChromatogramPeakFeatures(file.PeakAreaBeanInformationFilePath);
+                var measurement = LoadMeasurement(file.AnalysisFilePath);
+                if (measurement.Count == 0) {
+                    continue;
+                }
+
+                var parameter = project.Parameter;
+                var rawSpectra = new RawSpectra(measurement, parameter.IonMode, file.AcquisitionType);
+                var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), parameter.CentroidMs1Tolerance, range);
+                foreach (var (chromatogram, peak) in chromatograms.Zip(peaks, (c, p) => (c, p)))
+                {
+                    for (var i = 0; i < chromatogram.Length; i++)
+                    {
+                        writer.WriteLine(string.Join(",",
+                            file.AnalysisFileId,
+                            CsvEscape(file.AnalysisFileName),
+                            peak.MasterPeakID,
+                            CsvEscape(peak.Name),
+                            chromatogram.Id(i),
+                            chromatogram.Time(i).ToString(CultureInfo.InvariantCulture),
+                            chromatogram.ExtractedMz.ToString(CultureInfo.InvariantCulture),
+                            parameter.CentroidMs1Tolerance.ToString(CultureInfo.InvariantCulture),
+                            chromatogram.Intensity(i).ToString(CultureInfo.InvariantCulture)));
+                    }
                 }
             }
         }
 
-        private static string BuildProjectJson(string source, IReadOnlyList<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement, ParameterBase parameter) {
-            var rawSpectra = new RawSpectra(measurement, parameter.IonMode, parameter.ProjectParam.AcquisitionType);
+        private static string BuildProjectJson(string source, IMsdialDataStorage<ParameterBase> project) {
             var sb = new StringBuilder();
             sb.AppendLine("{");
             sb.AppendLine($"  \"source\": \"{EscapeJson(source)}\",");
             sb.AppendLine("  \"peaks\": [");
-            for (var i = 0; i < peaks.Count; i++) {
-                sb.Append(BuildProjectPeakJson(peaks[i], rawSpectra, parameter));
-                if (i < peaks.Count - 1) {
+            var files = project.AnalysisFiles.Where(file => file.AnalysisFileIncluded).ToList();
+            for (var i = 0; i < files.Count; i++) {
+                sb.Append(BuildProjectPeakJson(project, files[i]));
+                if (i < files.Count - 1) {
                     sb.AppendLine(",");
                 }
                 else {
@@ -224,18 +216,25 @@ namespace CompMs.App.MsdialConsole.Process
             return sb.ToString();
         }
 
-        private static string BuildProjectPeakJson(ChromatogramPeakFeature peak, RawSpectra rawSpectra, ParameterBase parameter) {
-            var chromatogram = ExtractPeakChromatogram(peak, rawSpectra, parameter);
+        private static string BuildProjectPeakJson(IMsdialDataStorage<ParameterBase> project, AnalysisFileBean file) {
+            var measurement = LoadMeasurement(file.AnalysisFilePath);
+            var peaks = file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()
+                ? []
+                : MsdialPeakSerializer.LoadChromatogramPeakFeatures(file.PeakAreaBeanInformationFilePath) ?? [];
+            var rawSpectra = new RawSpectra(measurement, project.Parameter.IonMode, (CompMs.Common.Enum.AcquisitionType)file.AcquisitionType);
+            var chromatogram = peaks.Count > 0
+                ? ExtractPeakChromatogram(rawSpectra, project.Parameter, peaks[0].PrecursorMz)
+                : new ProjectChromatogram([], []);
             var sb = new StringBuilder();
             sb.AppendLine("    {");
-            sb.AppendLine($"      \"id\": {peak.PeakID},");
-            sb.AppendLine($"      \"masterPeakId\": {peak.MasterPeakID},");
-            sb.AppendLine($"      \"name\": \"{EscapeJson(peak.Name)}\",");
-            sb.AppendLine($"      \"mz\": {peak.PeakFeature.Mass.ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"      \"id\": {file.AnalysisFileId},");
+            sb.AppendLine($"      \"masterPeakId\": {file.AnalysisFileId},");
+            sb.AppendLine($"      \"name\": \"{EscapeJson(file.AnalysisFileName)}\",");
+            sb.AppendLine($"      \"mz\": {(peaks.Count > 0 ? peaks[0].PrecursorMz : 0d).ToString(CultureInfo.InvariantCulture)},");
             sb.AppendLine("      \"rt\": {");
-            sb.AppendLine($"        \"left\": {GetChromValue(peak.PeakFeature.ChromXsLeft).ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine($"        \"top\": {GetChromValue(peak.PeakFeature.ChromXsTop).ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine($"        \"right\": {GetChromValue(peak.PeakFeature.ChromXsRight).ToString(CultureInfo.InvariantCulture)}");
+            sb.AppendLine($"        \"left\": {0.ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"        \"top\": {0.ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"        \"right\": {0.ToString(CultureInfo.InvariantCulture)}");
             sb.AppendLine("      },");
             sb.AppendLine("      \"chromatogram\": {");
             sb.AppendLine($"        \"rts\": [{string.Join(", ", chromatogram.Rts.Select(v => v.ToString(CultureInfo.InvariantCulture)))}],");
@@ -245,16 +244,21 @@ namespace CompMs.App.MsdialConsole.Process
             return sb.ToString();
         }
 
-        private static ProjectChromatogram ExtractPeakChromatogram(ChromatogramPeakFeature peak, RawSpectra rawSpectra, ParameterBase parameter) {
+        private static ProjectChromatogram ExtractPeakChromatogram(RawSpectra rawSpectra, ParameterBase parameter, double targetMz) {
             var rts = new List<double>();
             var intensities = new List<double>();
-            var targetMz = peak.PeakFeature.Mass;
             var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(targetMz, parameter.CentroidMs1Tolerance), new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min));
             foreach (var dataPoint in chromatogram.AsPeakArray()) {
                 rts.Add(dataPoint.Time);
                 intensities.Add(dataPoint.Intensity);
             }
             return new ProjectChromatogram(rts, intensities);
+        }
+
+        private static IMsdialDataStorage<ParameterBase> LoadProject(string projectFile) {
+            using var stream = new FileStream(projectFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var manager = ZipStreamManager.OpenGet(stream);
+            return MsdialDataStorage.Serializer.LoadAsync(manager, Path.GetFileName(projectFile), Path.GetDirectoryName(Path.GetFullPath(projectFile)) ?? string.Empty, string.Empty).GetAwaiter().GetResult();
         }
 
         private static string EscapeJson(string value) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -91,7 +91,8 @@ namespace CompMs.App.MsdialConsole.Process
 
         private static void WriteRawCsv(string outputPath, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra, AcquisitionType acquisitionType)
         {
-            var rawSpectra = new RawSpectra(spectra, IonMode.Positive, acquisitionType);
+            var ionMode = spectra.FirstOrDefault(s => s.MsLevel == 1)?.ScanPolarity == ScanPolarity.Negative ? IonMode.Negative : IonMode.Positive;
+            var rawSpectra = new RawSpectra(spectra, ionMode, acquisitionType);
             var chromatogramRange = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
             using var writer = new StreamWriter(outputPath, false, Encoding.ASCII);
             writer.WriteLine("ScanId,RT,TargetMz,Tolerance,Intensity");

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -322,8 +322,8 @@ namespace CompMs.App.MsdialConsole.Process
         }
 
         private static int ArgsError() {
-            Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -target <mz> <tolerance> [-target <mz> <tolerance> ...]");
-            Console.Error.WriteLine("MsdialConsoleApp.exe eic project -i <peak file> -raw <raw file> -o <output file> [-format csv|json]");
+            Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -target <mz> <tolerance> [-target <mz> <tolerance> ...] [-acquisitiontype DDA|DIA]");
+            Console.Error.WriteLine("MsdialConsoleApp.exe eic project -i <project file> -o <output file> [-format csv|json]");
             return -1;
         }
 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -302,7 +302,7 @@ namespace CompMs.App.MsdialConsole.Process
             if (value == null) {
                 return string.Empty;
             }
-            return value.Contains(",") || value.Contains("\"")
+            return value.Contains(",") || value.Contains("\"") || value.Contains("\r") || value.Contains("\n")
                 ? $"\"{value.Replace("\"", "\"\"")}\""
                 : value;
         }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -1,5 +1,6 @@
 using CompMs.Common.DataObj;
 using CompMs.Common.Extension;
+using CompMs.MsdialCore.DataObj;
 using CompMs.MsdialCore.Parser;
 using CompMs.RawDataHandler.Core;
 using System;
@@ -33,8 +34,7 @@ namespace CompMs.App.MsdialConsole.Process
         private int RunRaw(string[] args) {
             var inputFile = string.Empty;
             var outputFile = string.Empty;
-            var targetMz = double.NaN;
-            var mzTolerance = 0.01d;
+            var targets = new List<TargetQuery>();
 
             for (var i = 2; i < args.Length; i++) {
                 if (args[i] == "-i" && i + 1 < args.Length) {
@@ -43,19 +43,17 @@ namespace CompMs.App.MsdialConsole.Process
                 else if (args[i] == "-o" && i + 1 < args.Length) {
                     outputFile = args[i + 1];
                 }
-                else if (args[i] == "-mz" && i + 1 < args.Length) {
-                    if (!double.TryParse(args[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out targetMz)) {
+                else if (args[i] == "-target" && i + 2 < args.Length) {
+                    if (!double.TryParse(args[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out var mz)
+                        || !double.TryParse(args[i + 2], NumberStyles.Float, CultureInfo.InvariantCulture, out var tolerance)) {
                         return argsError();
                     }
-                }
-                else if (args[i] == "-tolerance" && i + 1 < args.Length) {
-                    if (!double.TryParse(args[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out mzTolerance)) {
-                        return argsError();
-                    }
+                    targets.Add(new TargetQuery(mz, tolerance));
+                    i += 2;
                 }
             }
 
-            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull() || double.IsNaN(targetMz)) {
+            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull() || targets.Count == 0) {
                 return argsError();
             }
 
@@ -67,13 +65,20 @@ namespace CompMs.App.MsdialConsole.Process
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
             using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
-            writer.WriteLine("ScanId,RT,Intensity");
+            writer.WriteLine("ScanId,RT,TargetMz,Tolerance,Intensity");
 
             foreach (var spectrum in spectra.Where(n => n.MsLevel == 1)) {
-                var intensity = spectrum.Spectrum
-                    .Where(peak => Math.Abs(peak.Mz - targetMz) <= mzTolerance)
-                    .Sum(peak => peak.Intensity);
-                writer.WriteLine(string.Join(",", spectrum.ScanNumber, spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture), intensity.ToString(CultureInfo.InvariantCulture)));
+                foreach (var target in targets) {
+                    var intensity = spectrum.Spectrum
+                        .Where(peak => Math.Abs(peak.Mz - target.Mz) <= target.Tolerance)
+                        .Sum(peak => peak.Intensity);
+                    writer.WriteLine(string.Join(",",
+                        spectrum.ScanNumber,
+                        spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
+                        target.Mz.ToString(CultureInfo.InvariantCulture),
+                        target.Tolerance.ToString(CultureInfo.InvariantCulture),
+                        intensity.ToString(CultureInfo.InvariantCulture)));
+                }
             }
 
             return 0;
@@ -81,29 +86,36 @@ namespace CompMs.App.MsdialConsole.Process
 
         private int RunProject(string[] args) {
             var inputFile = string.Empty;
+            var rawFile = string.Empty;
             var outputFile = string.Empty;
-            var maxPoints = 20;
+            var outputFormat = "json";
 
             for (var i = 2; i < args.Length; i++) {
                 if (args[i] == "-i" && i + 1 < args.Length) {
                     inputFile = args[i + 1];
                 }
+                else if (args[i] == "-raw" && i + 1 < args.Length) {
+                    rawFile = args[i + 1];
+                }
                 else if (args[i] == "-o" && i + 1 < args.Length) {
                     outputFile = args[i + 1];
                 }
-                else if (args[i] == "-maxPoints" && i + 1 < args.Length) {
-                    if (!int.TryParse(args[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out maxPoints) || maxPoints <= 0) {
-                        return argsError();
-                    }
+                else if (args[i] == "-format" && i + 1 < args.Length) {
+                    outputFormat = args[i + 1];
                 }
             }
 
-            if (inputFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
+            if (inputFile.IsEmptyOrNull() || rawFile.IsEmptyOrNull() || outputFile.IsEmptyOrNull()) {
                 return argsError();
             }
 
             if (!File.Exists(inputFile)) {
                 Console.Error.WriteLine($"Project peak file was not found: {inputFile}");
+                return -1;
+            }
+
+            if (!File.Exists(rawFile)) {
+                Console.Error.WriteLine($"Raw data file was not found: {rawFile}");
                 return -1;
             }
 
@@ -113,19 +125,57 @@ namespace CompMs.App.MsdialConsole.Process
                 return -1;
             }
 
+            var measurement = LoadMeasurement(rawFile);
+            if (measurement == null || measurement.Count == 0) {
+                Console.Error.WriteLine("No raw spectra were found for project export.");
+                return -1;
+            }
+
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
-            var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, maxPoints);
+            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase)) {
+                WriteProjectCsv(outputFile, peaks, measurement);
+                return 0;
+            }
+
+            var json = BuildProjectJson(Path.GetFullPath(inputFile), peaks, measurement);
             File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             return 0;
         }
 
-        private static string BuildProjectJson(string source, IReadOnlyList<CompMs.MsdialCore.DataObj.ChromatogramPeakFeature> peaks, int maxPoints) {
+        private static void WriteProjectCsv(string outputFile, IReadOnlyList<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement) {
+            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
+            writer.WriteLine("PeakId,MasterPeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
+            foreach (var peak in peaks) {
+                WriteProjectRawCsvRows(writer, peak, measurement);
+            }
+        }
+
+        private static void WriteProjectRawCsvRows(StreamWriter writer, ChromatogramPeakFeature peak, IReadOnlyList<RawSpectrum> measurement) {
+            var targetMz = peak.PeakFeature.Mass;
+            var tolerance = EstimateTolerance(peak);
+            foreach (var spectrum in measurement.Where(n => n.MsLevel == 1)) {
+                var intensity = spectrum.Spectrum
+                    .Where(point => Math.Abs(point.Mz - targetMz) <= tolerance)
+                    .Sum(point => point.Intensity);
+                writer.WriteLine(string.Join(",",
+                    peak.PeakID,
+                    peak.MasterPeakID,
+                    CsvEscape(peak.Name),
+                    spectrum.ScanNumber,
+                    spectrum.ScanStartTime.ToString(CultureInfo.InvariantCulture),
+                    targetMz.ToString(CultureInfo.InvariantCulture),
+                    tolerance.ToString(CultureInfo.InvariantCulture),
+                    intensity.ToString(CultureInfo.InvariantCulture)));
+            }
+        }
+
+        private static string BuildProjectJson(string source, IReadOnlyList<ChromatogramPeakFeature> peaks, IReadOnlyList<RawSpectrum> measurement) {
             var sb = new StringBuilder();
             sb.AppendLine("{");
             sb.AppendLine($"  \"source\": \"{EscapeJson(source)}\",");
             sb.AppendLine("  \"peaks\": [");
             for (var i = 0; i < peaks.Count; i++) {
-                sb.Append(BuildProjectPeakJson(peaks[i], maxPoints));
+                sb.Append(BuildProjectPeakJson(peaks[i], measurement));
                 if (i < peaks.Count - 1) {
                     sb.AppendLine(",");
                 }
@@ -138,8 +188,8 @@ namespace CompMs.App.MsdialConsole.Process
             return sb.ToString();
         }
 
-        private static string BuildProjectPeakJson(CompMs.MsdialCore.DataObj.ChromatogramPeakFeature peak, int maxPoints) {
-            var points = BuildPeakPoints(peak).Take(maxPoints).ToList();
+        private static string BuildProjectPeakJson(ChromatogramPeakFeature peak, IReadOnlyList<RawSpectrum> measurement) {
+            var chromatogram = ExtractPeakChromatogram(peak, measurement);
             var sb = new StringBuilder();
             sb.AppendLine("    {");
             sb.AppendLine($"      \"id\": {peak.PeakID},");
@@ -151,25 +201,40 @@ namespace CompMs.App.MsdialConsole.Process
             sb.AppendLine($"        \"top\": {GetChromValue(peak.PeakFeature.ChromXsTop).ToString(CultureInfo.InvariantCulture)},");
             sb.AppendLine($"        \"right\": {GetChromValue(peak.PeakFeature.ChromXsRight).ToString(CultureInfo.InvariantCulture)}");
             sb.AppendLine("      },");
-            sb.AppendLine("      \"points\": [");
-            for (var i = 0; i < points.Count; i++) {
-                sb.Append($"        {{ \"rt\": {points[i].Rt.ToString(CultureInfo.InvariantCulture)}, \"intensity\": {points[i].Intensity.ToString(CultureInfo.InvariantCulture)} }}");
-                if (i < points.Count - 1) {
-                    sb.AppendLine(",");
-                }
-                else {
-                    sb.AppendLine();
-                }
-            }
-            sb.AppendLine("      ]");
+            sb.AppendLine("      \"chromatogram\": {");
+            sb.AppendLine($"        \"rts\": [{string.Join(", ", chromatogram.Rts.Select(v => v.ToString(CultureInfo.InvariantCulture)))}],");
+            sb.AppendLine($"        \"intensities\": [{string.Join(", ", chromatogram.Intensities.Select(v => v.ToString(CultureInfo.InvariantCulture)))}]");
+            sb.AppendLine("      }");
             sb.Append("    }");
             return sb.ToString();
         }
 
-        private static IEnumerable<ProjectPoint> BuildPeakPoints(CompMs.MsdialCore.DataObj.ChromatogramPeakFeature peak) {
-            yield return new ProjectPoint(GetChromValue(peak.PeakFeature.ChromXsLeft), peak.PeakFeature.PeakHeightLeft);
-            yield return new ProjectPoint(GetChromValue(peak.PeakFeature.ChromXsTop), peak.PeakFeature.PeakHeightTop);
-            yield return new ProjectPoint(GetChromValue(peak.PeakFeature.ChromXsRight), peak.PeakFeature.PeakHeightRight);
+        private static ProjectChromatogram ExtractPeakChromatogram(ChromatogramPeakFeature peak, IReadOnlyList<RawSpectrum> measurement) {
+            var rts = new List<double>();
+            var intensities = new List<double>();
+            var targetMz = peak.PeakFeature.Mass;
+            var tolerance = EstimateTolerance(peak);
+            foreach (var spectrum in measurement.Where(n => n.MsLevel == 1)) {
+                var intensity = spectrum.Spectrum
+                    .Where(point => Math.Abs(point.Mz - targetMz) <= tolerance)
+                    .Sum(point => point.Intensity);
+                rts.Add(spectrum.ScanStartTime);
+                intensities.Add(intensity);
+            }
+            if (rts.Count == 0) {
+                AddChromPoint(rts, intensities, peak.PeakFeature.ChromXsLeft, peak.PeakFeature.PeakHeightLeft);
+                AddChromPoint(rts, intensities, peak.PeakFeature.ChromXsTop, peak.PeakFeature.PeakHeightTop);
+                AddChromPoint(rts, intensities, peak.PeakFeature.ChromXsRight, peak.PeakFeature.PeakHeightRight);
+            }
+            return new ProjectChromatogram(rts, intensities);
+        }
+
+        private static void AddChromPoint(List<double> rts, List<double> intensities, CompMs.Common.Components.ChromXs chromXs, double intensity) {
+            if (chromXs == null) {
+                return;
+            }
+            rts.Add(chromXs.Value);
+            intensities.Add(intensity);
         }
 
         private static string EscapeJson(string value) {
@@ -180,18 +245,28 @@ namespace CompMs.App.MsdialConsole.Process
                 .Replace("\n", "\\n");
         }
 
+        private static string CsvEscape(string value) {
+            if (value == null) {
+                return string.Empty;
+            }
+            return value.Contains(",") || value.Contains("\"")
+                ? $"\"{value.Replace("\"", "\"\"")}\""
+                : value;
+        }
+
         private static double GetChromValue(CompMs.Common.Components.ChromXs chromXs) {
             return chromXs?.Value ?? 0d;
         }
 
-        private readonly struct ProjectPoint {
-            public ProjectPoint(double rt, double intensity) {
-                Rt = rt;
-                Intensity = intensity;
+        private static double EstimateTolerance(ChromatogramPeakFeature peak) {
+            var left = GetChromValue(peak.PeakFeature.ChromXsLeft);
+            var top = GetChromValue(peak.PeakFeature.ChromXsTop);
+            var right = GetChromValue(peak.PeakFeature.ChromXsRight);
+            var width = Math.Max(0d, right - left);
+            if (width > 0d) {
+                return width / 2d;
             }
-
-            public double Rt { get; }
-            public double Intensity { get; }
+            return Math.Max(0.01d, Math.Abs(top - left));
         }
 
         private static IReadOnlyList<RawSpectrum> LoadMeasurement(string inputFile) {
@@ -201,9 +276,30 @@ namespace CompMs.App.MsdialConsole.Process
         }
 
         private static int argsError() {
-            Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -mz <target m/z> [-tolerance <mz tolerance>]");
-            Console.Error.WriteLine("MsdialConsoleApp.exe eic project -i <peak file> -o <output json> [-maxPoints <count>]");
+            Console.Error.WriteLine("MsdialConsoleApp.exe eic raw -i <input file> -o <output csv> -target <mz> <tolerance> [-target <mz> <tolerance> ...]");
+            Console.Error.WriteLine("MsdialConsoleApp.exe eic project -i <peak file> -raw <raw file> -o <output file> [-format csv|json]");
             return -1;
+        }
+
+        private readonly struct TargetQuery {
+            public TargetQuery(double mz, double tolerance) {
+                Mz = mz;
+                Tolerance = tolerance;
+            }
+
+            public double Mz { get; }
+            public double Tolerance { get; }
+        }
+
+        private readonly struct ProjectChromatogram {
+            public ProjectChromatogram(List<double> rts, List<double> intensities) {
+                Rts = rts;
+                Intensities = intensities;
+            }
+
+            public List<double> Rts { get; }
+            public List<double> Intensities { get; }
+            public int PointCount => Math.Min(Rts.Count, Intensities.Count);
         }
     }
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -83,20 +83,21 @@ namespace CompMs.App.MsdialConsole.Process
                 return -1;
             }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
+            Directory.CreateDirectory(Path.GetFullPath(outputFile));
             WriteRawCsv(outputFile, targets, spectra, acquisitionType);
 
             return 0;
         }
 
-        private static void WriteRawCsv(string outputFile, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra, AcquisitionType acquisitionType)
+        private static void WriteRawCsv(string outputPath, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra, AcquisitionType acquisitionType)
         {
             var rawSpectra = new RawSpectra(spectra, IonMode.Positive, acquisitionType);
-            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
-            writer.WriteLine( "ScanId,RT,TargetMz,Tolerance,Intensity");
             var chromatogramRange = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
             foreach (var target in targets)
             {
+                var targetFile = CreateSplitOutputPath(outputPath, $"mz-{SanitizeFileName(target.Mz.ToString(CultureInfo.InvariantCulture))}_tol-{SanitizeFileName(target.Tolerance.ToString(CultureInfo.InvariantCulture))}", ".csv");
+                using var writer = new StreamWriter(targetFile, false, Encoding.ASCII);
+                writer.WriteLine("ScanId,RT,TargetMz,Tolerance,Intensity");
                 using var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(target.Mz, target.Tolerance), chromatogramRange);
                 for (var i = 0; i < chromatogram.Length; i++)
                 {
@@ -136,7 +137,6 @@ namespace CompMs.App.MsdialConsole.Process
                 return -1;
             }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
             var project = LoadProject(inputFile);
             var files = project.AnalysisFiles.Where(file => file.AnalysisFileIncluded).ToList();
             if (files.Count == 0) {
@@ -151,16 +151,13 @@ namespace CompMs.App.MsdialConsole.Process
             }
             else
             {
-                var json = BuildProjectJson(Path.GetFullPath(inputFile), project);
-                File.WriteAllText(outputFile, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                WriteProjectJson(outputFile, Path.GetFullPath(inputFile), project);
                 return 0;
             }
         }
 
-        private static void WriteProjectCsv(string outputFile, IMsdialDataStorage<ParameterBase> project)
+        private static void WriteProjectCsv(string outputPath, IMsdialDataStorage<ParameterBase> project)
         {
-            using var writer = new StreamWriter(outputFile, false, Encoding.ASCII);
-            writer.WriteLine("FileId,FileName,PeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
             var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
             foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded))
             {
@@ -177,6 +174,9 @@ namespace CompMs.App.MsdialConsole.Process
                 var parameter = project.Parameter;
                 var rawSpectra = new RawSpectra(measurement, parameter.IonMode, file.AcquisitionType);
                 var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), parameter.CentroidMs1Tolerance, range);
+                var fileOutput = CreateSplitOutputPath(outputPath, SanitizeFileName(file.AnalysisFileName), ".csv");
+                using var writer = new StreamWriter(fileOutput, false, Encoding.ASCII);
+                writer.WriteLine("FileId,FileName,PeakId,Name,ScanId,RT,TargetMz,Tolerance,Intensity");
                 foreach (var (chromatogram, peak) in chromatograms.Zip(peaks, (c, p) => (c, p)))
                 {
                     for (var i = 0; i < chromatogram.Length; i++)
@@ -196,21 +196,23 @@ namespace CompMs.App.MsdialConsole.Process
             }
         }
 
-        private static string BuildProjectJson(string source, IMsdialDataStorage<ParameterBase> project) {
+        private static void WriteProjectJson(string outputPath, string source, IMsdialDataStorage<ParameterBase> project) {
+            var rootOutput = Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? ".";
+            Directory.CreateDirectory(rootOutput);
+            foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded)) {
+                var fileOutput = CreateSplitOutputPath(outputPath, SanitizeFileName(file.AnalysisFileName), ".json");
+                var json = BuildProjectJson(source, project, file);
+                File.WriteAllText(fileOutput, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+        }
+
+        private static string BuildProjectJson(string source, IMsdialDataStorage<ParameterBase> project, AnalysisFileBean file) {
             var sb = new StringBuilder();
             sb.AppendLine("{");
             sb.AppendLine($"  \"source\": \"{EscapeJson(source)}\",");
             sb.AppendLine("  \"peaks\": [");
-            var files = project.AnalysisFiles.Where(file => file.AnalysisFileIncluded).ToList();
-            for (var i = 0; i < files.Count; i++) {
-                sb.Append(BuildProjectPeakJson(project, files[i]));
-                if (i < files.Count - 1) {
-                    sb.AppendLine(",");
-                }
-                else {
-                    sb.AppendLine();
-                }
-            }
+            sb.Append(BuildProjectPeakJson(project, file));
+            sb.AppendLine();
             sb.AppendLine("  ]");
             sb.AppendLine("}");
             return sb.ToString();
@@ -276,6 +278,21 @@ namespace CompMs.App.MsdialConsole.Process
             return value.Contains(",") || value.Contains("\"")
                 ? $"\"{value.Replace("\"", "\"\"")}\""
                 : value;
+        }
+
+        private static string CreateSplitOutputPath(string outputPath, string suffix, string extension) {
+            var fullPath = Path.GetFullPath(outputPath);
+            var directory = Path.GetDirectoryName(fullPath) ?? ".";
+            var fileName = Path.GetFileNameWithoutExtension(fullPath);
+            return Path.Combine(directory, $"{fileName}_{suffix}{extension}");
+        }
+
+        private static string SanitizeFileName(string value) {
+            var sanitized = value ?? string.Empty;
+            foreach (var invalid in Path.GetInvalidFileNameChars()) {
+                sanitized = sanitized.Replace(invalid, '_');
+            }
+            return sanitized.IsEmptyOrNull() ? "output" : sanitized;
         }
 
         private static double GetChromValue(Common.Components.ChromXs chromXs) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -144,16 +144,17 @@ namespace CompMs.App.MsdialConsole.Process
                 return -1;
             }
 
-            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase))
-            {
+            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase)) {
                 WriteProjectCsv(outputFile, project);
                 return 0;
             }
-            else
-            {
+            if (string.Equals(outputFormat, "json", StringComparison.OrdinalIgnoreCase)) {
                 WriteProjectJson(outputFile, project);
                 return 0;
             }
+
+            Console.Error.WriteLine($"Invalid output format: {outputFormat}. Valid options are: csv, json.");
+            return -1;
         }
 
         private static void WriteProjectCsv(string outputPath, IMsdialDataStorage<ParameterBase> project)

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -163,13 +163,20 @@ namespace CompMs.App.MsdialConsole.Process
             Directory.CreateDirectory(rootOutput);
             var range = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
             foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded))
-                if (file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()) {
+            {
+                if (file.PeakAreaBeanInformationFilePath.IsEmptyOrNull() || !File.Exists(file.PeakAreaBeanInformationFilePath)) {
+                     Console.Error.WriteLine($"Peak feature file was not found: {file.PeakAreaBeanInformationFilePath}");
+                     continue;
+                 }
+                 if (file.AnalysisFilePath.IsEmptyOrNull() || !File.Exists(file.AnalysisFilePath)) {
+                     Console.Error.WriteLine($"Raw file was not found: {file.AnalysisFilePath}");
                     continue;
                 }
 
                 var peaks = MsdialPeakSerializer.LoadChromatogramPeakFeatures(file.PeakAreaBeanInformationFilePath);
                 var measurement = LoadMeasurement(file.AnalysisFilePath);
                 if (measurement.Count == 0) {
+                    Console.Error.WriteLine($"No raw spectra were found in: {file.AnalysisFilePath}");
                     continue;
                 }
 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -202,6 +202,15 @@ namespace CompMs.App.MsdialConsole.Process
             var rootOutput = Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? ".";
             Directory.CreateDirectory(rootOutput);
             foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded)) {
+                if (file.AnalysisFilePath.IsEmptyOrNull() || !File.Exists(file.AnalysisFilePath)) {
+                    Console.Error.WriteLine($"Raw file was not found: {file.AnalysisFilePath}");
+                    continue;
+                }
+                if (!file.PeakAreaBeanInformationFilePath.IsEmptyOrNull() && !File.Exists(file.PeakAreaBeanInformationFilePath)) {
+                    Console.Error.WriteLine($"Peak feature file was not found: {file.PeakAreaBeanInformationFilePath}");
+                    continue;
+                }
+
                 var fileOutput = CreateSplitOutputPath(outputPath, SanitizeFileName(file.AnalysisFileName), ".json");
                 var json = BuildProjectJson(project, file);
                 File.WriteAllText(fileOutput, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -83,7 +83,7 @@ namespace CompMs.App.MsdialConsole.Process
                 return -1;
             }
 
-            Directory.CreateDirectory(Path.GetFullPath(outputFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
             WriteRawCsv(outputFile, targets, spectra, acquisitionType);
 
             return 0;
@@ -93,11 +93,10 @@ namespace CompMs.App.MsdialConsole.Process
         {
             var rawSpectra = new RawSpectra(spectra, IonMode.Positive, acquisitionType);
             var chromatogramRange = new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
+            using var writer = new StreamWriter(outputPath, false, Encoding.ASCII);
+            writer.WriteLine("ScanId,RT,TargetMz,Tolerance,Intensity");
             foreach (var target in targets)
             {
-                var targetFile = CreateSplitOutputPath(outputPath, $"mz-{SanitizeFileName(target.Mz.ToString(CultureInfo.InvariantCulture))}_tol-{SanitizeFileName(target.Tolerance.ToString(CultureInfo.InvariantCulture))}", ".csv");
-                using var writer = new StreamWriter(targetFile, false, Encoding.ASCII);
-                writer.WriteLine("ScanId,RT,TargetMz,Tolerance,Intensity");
                 using var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(target.Mz, target.Tolerance), chromatogramRange);
                 for (var i = 0; i < chromatogram.Length; i++)
                 {
@@ -151,7 +150,7 @@ namespace CompMs.App.MsdialConsole.Process
             }
             else
             {
-                WriteProjectJson(outputFile, Path.GetFullPath(inputFile), project);
+                WriteProjectJson(outputFile, project);
                 return 0;
             }
         }
@@ -196,71 +195,77 @@ namespace CompMs.App.MsdialConsole.Process
             }
         }
 
-        private static void WriteProjectJson(string outputPath, string source, IMsdialDataStorage<ParameterBase> project) {
+        private static void WriteProjectJson(string outputPath, IMsdialDataStorage<ParameterBase> project) {
             var rootOutput = Path.GetDirectoryName(Path.GetFullPath(outputPath)) ?? ".";
             Directory.CreateDirectory(rootOutput);
             foreach (var file in project.AnalysisFiles.Where(file => file.AnalysisFileIncluded)) {
                 var fileOutput = CreateSplitOutputPath(outputPath, SanitizeFileName(file.AnalysisFileName), ".json");
-                var json = BuildProjectJson(source, project, file);
+                var json = BuildProjectJson(project, file);
                 File.WriteAllText(fileOutput, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             }
         }
 
-        private static string BuildProjectJson(string source, IMsdialDataStorage<ParameterBase> project, AnalysisFileBean file) {
+        private static string BuildProjectJson(IMsdialDataStorage<ParameterBase> project, AnalysisFileBean file) {
+            var peaks = file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()
+                ? []
+                : MsdialPeakSerializer.LoadChromatogramPeakFeatures(file.PeakAreaBeanInformationFilePath) ?? [];
+            ChromatogramRange chromatogramRange = new(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
+            IReadOnlyList<RawSpectrum> measurement = LoadMeasurement(file.AnalysisFilePath);
+            RawSpectra rawSpectra = new(measurement, project.Parameter.IonMode, file.AcquisitionType);
             var sb = new StringBuilder();
             sb.AppendLine("{");
-            sb.AppendLine($"  \"source\": \"{EscapeJson(source)}\",");
+            sb.AppendLine($"  \"raw file\": \"{EscapeJson(file.AnalysisFilePath)}\",");
+            sb.AppendLine($"  \"peak file\": \"{EscapeJson(file.PeakAreaBeanInformationFilePath)}\",");
             sb.AppendLine("  \"peaks\": [");
-            sb.Append(BuildProjectPeakJson(project, file));
-            sb.AppendLine();
+
+            var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), project.Parameter.CentroidMs1Tolerance, chromatogramRange);
+            foreach (var (chromatogram, i) in chromatograms.Zip(Enumerable.Range(0, peaks.Count), (c, i) => (c, i))) {
+                BuildProjectPeakJson(sb, peaks[i], chromatogram);
+                if (i < peaks.Count - 1) {
+                    sb.AppendLine(",");
+                }
+                else {
+                    sb.AppendLine();
+                }
+            }
             sb.AppendLine("  ]");
             sb.AppendLine("}");
             return sb.ToString();
         }
 
-        private static string BuildProjectPeakJson(IMsdialDataStorage<ParameterBase> project, AnalysisFileBean file) {
-            var measurement = LoadMeasurement(file.AnalysisFilePath);
-            var peaks = file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()
-                ? []
-                : MsdialPeakSerializer.LoadChromatogramPeakFeatures(file.PeakAreaBeanInformationFilePath) ?? [];
-            var rawSpectra = new RawSpectra(measurement, project.Parameter.IonMode, (CompMs.Common.Enum.AcquisitionType)file.AcquisitionType);
-            var chromatogram = peaks.Count > 0
-                ? ExtractPeakChromatogram(rawSpectra, project.Parameter, peaks[0].PrecursorMz)
-                : new ProjectChromatogram([], []);
-            var sb = new StringBuilder();
+        private static void BuildProjectPeakJson(StringBuilder sb, ChromatogramPeakFeature peak, ExtractedIonChromatogram chromatogram1) {
+            var chromatogram = ConvertPeakChromatogram(chromatogram1);
             sb.AppendLine("    {");
-            sb.AppendLine($"      \"id\": {file.AnalysisFileId},");
-            sb.AppendLine($"      \"masterPeakId\": {file.AnalysisFileId},");
-            sb.AppendLine($"      \"name\": \"{EscapeJson(file.AnalysisFileName)}\",");
-            sb.AppendLine($"      \"mz\": {(peaks.Count > 0 ? peaks[0].PrecursorMz : 0d).ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"      \"id\": {peak.MasterPeakID},");
+            sb.AppendLine($"      \"name\": \"{EscapeJson(peak.Name)}\",");
+            sb.AppendLine($"      \"mz\": {peak.PrecursorMz.ToString(CultureInfo.InvariantCulture)},");
             sb.AppendLine("      \"rt\": {");
-            sb.AppendLine($"        \"left\": {0.ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine($"        \"top\": {0.ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine($"        \"right\": {0.ToString(CultureInfo.InvariantCulture)}");
+            sb.AppendLine($"        \"left\": {peak.PeakFeature.ChromXsLeft.RT.Value.ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"        \"top\": {peak.PeakFeature.ChromXsTop.RT.Value.ToString(CultureInfo.InvariantCulture)},");
+            sb.AppendLine($"        \"right\": {peak.PeakFeature.ChromXsRight.RT.Value.ToString(CultureInfo.InvariantCulture)}");
             sb.AppendLine("      },");
             sb.AppendLine("      \"chromatogram\": {");
-            sb.AppendLine($"        \"rts\": [{string.Join(", ", chromatogram.Rts.Select(v => v.ToString(CultureInfo.InvariantCulture)))}],");
-            sb.AppendLine($"        \"intensities\": [{string.Join(", ", chromatogram.Intensities.Select(v => v.ToString(CultureInfo.InvariantCulture)))}]");
+            sb.AppendLine($"        \"rts\": [{string.Join(",", chromatogram.Rts.Select(v => v.ToString(CultureInfo.InvariantCulture)))}],");
+            sb.AppendLine($"        \"intensities\": [{string.Join(",", chromatogram.Intensities.Select(v => v.ToString(CultureInfo.InvariantCulture)))}]");
             sb.AppendLine("      }");
             sb.Append("    }");
-            return sb.ToString();
         }
 
-        private static ProjectChromatogram ExtractPeakChromatogram(RawSpectra rawSpectra, ParameterBase parameter, double targetMz) {
-            var rts = new List<double>();
-            var intensities = new List<double>();
-            var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(targetMz, parameter.CentroidMs1Tolerance), new ChromatogramRange(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min));
-            foreach (var dataPoint in chromatogram.AsPeakArray()) {
-                rts.Add(dataPoint.Time);
-                intensities.Add(dataPoint.Intensity);
+        private static ProjectChromatogram ConvertPeakChromatogram(ExtractedIonChromatogram chromatogram) {
+            var rts = new List<double>(chromatogram.Length);
+            var intensities = new List<double>(chromatogram.Length);
+            for (var i = 0; i < chromatogram.Length; i++) {
+                rts.Add(chromatogram.Time(i));
+                intensities.Add(chromatogram.Intensity(i));
             }
             return new ProjectChromatogram(rts, intensities);
         }
 
         private static IMsdialDataStorage<ParameterBase> LoadProject(string projectFile) {
             using var stream = new FileStream(projectFile, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return Common.MessagePack.MessagePackDefaultHandler.LoadFromStream<MsdialDataStorage>(stream);
             using var manager = ZipStreamManager.OpenGet(stream);
-            return MsdialDataStorage.Serializer.LoadAsync(manager, Path.GetFileName(projectFile), Path.GetDirectoryName(Path.GetFullPath(projectFile)) ?? string.Empty, string.Empty).GetAwaiter().GetResult();
+            return MsdialDataStorage.Serializer.LoadAsync(manager, Path.GetFileName(projectFile), "", /*Path.GetDirectoryName(Path.GetFullPath(projectFile)) ?? string.Empty,*/ string.Empty).GetAwaiter().GetResult();
         }
 
         private static string EscapeJson(string value) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -209,7 +209,6 @@ namespace CompMs.App.MsdialConsole.Process
             var peaks = file.PeakAreaBeanInformationFilePath.IsEmptyOrNull()
                 ? []
                 : MsdialPeakSerializer.LoadChromatogramPeakFeatures(file.PeakAreaBeanInformationFilePath) ?? [];
-            ChromatogramRange chromatogramRange = new(0d, double.MaxValue, ChromXType.RT, ChromXUnit.Min);
             IReadOnlyList<RawSpectrum> measurement = LoadMeasurement(file.AnalysisFilePath);
             RawSpectra rawSpectra = new(measurement, project.Parameter.IonMode, file.AcquisitionType);
             var sb = new StringBuilder();
@@ -218,8 +217,10 @@ namespace CompMs.App.MsdialConsole.Process
             sb.AppendLine($"  \"peak file\": \"{EscapeJson(file.PeakAreaBeanInformationFilePath)}\",");
             sb.AppendLine("  \"peaks\": [");
 
-            var chromatograms = rawSpectra.GetMS1ExtractedChromatograms(peaks.Select(p => p.PrecursorMz), project.Parameter.CentroidMs1Tolerance, chromatogramRange);
-            foreach (var (chromatogram, i) in chromatograms.Zip(Enumerable.Range(0, peaks.Count), (c, i) => (c, i))) {
+            for (int i = 0; i < peaks.Count; i++) {
+                var peak = peaks[i];
+                var chromatogramRange = ChromatogramRange.FromPeakFeature(peak).ExtendRelative(1d);
+                var chromatogram = rawSpectra.GetMS1ExtractedChromatogram(new MzRange(peaks[i].PrecursorMz, project.Parameter.CentroidMs1Tolerance), chromatogramRange);
                 BuildProjectPeakJson(sb, peaks[i], chromatogram);
                 if (i < peaks.Count - 1) {
                     sb.AppendLine(",");
@@ -239,33 +240,42 @@ namespace CompMs.App.MsdialConsole.Process
             sb.AppendLine($"      \"id\": {peak.MasterPeakID},");
             sb.AppendLine($"      \"name\": \"{EscapeJson(peak.Name)}\",");
             sb.AppendLine($"      \"mz\": {peak.PrecursorMz.ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine("      \"rt\": {");
-            sb.AppendLine($"        \"left\": {peak.PeakFeature.ChromXsLeft.RT.Value.ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine($"        \"top\": {peak.PeakFeature.ChromXsTop.RT.Value.ToString(CultureInfo.InvariantCulture)},");
-            sb.AppendLine($"        \"right\": {peak.PeakFeature.ChromXsRight.RT.Value.ToString(CultureInfo.InvariantCulture)}");
-            sb.AppendLine("      },");
+            switch (peak.ChromXs.GetRepresentativeXAxis().Type)
+            {
+                case ChromXType.RT:
+                    sb.AppendLine("      \"retention time\": {");
+                    sb.AppendLine($"        \"left\": {peak.PeakFeature.ChromXsLeft.RT.Value.ToString(CultureInfo.InvariantCulture)},");
+                    sb.AppendLine($"        \"top\": {peak.PeakFeature.ChromXsTop.RT.Value.ToString(CultureInfo.InvariantCulture)},");
+                    sb.AppendLine($"        \"right\": {peak.PeakFeature.ChromXsRight.RT.Value.ToString(CultureInfo.InvariantCulture)}");
+                    sb.AppendLine("      },");
+                    break;
+                case ChromXType.Drift:
+                    sb.AppendLine("      \"drift time\": {");
+                    sb.AppendLine($"        \"left\": {peak.PeakFeature.ChromXsLeft.Drift.Value.ToString(CultureInfo.InvariantCulture)},");
+                    sb.AppendLine($"        \"top\": {peak.PeakFeature.ChromXsTop.Drift.Value.ToString(CultureInfo.InvariantCulture)},");
+                    sb.AppendLine($"        \"right\": {peak.PeakFeature.ChromXsRight.Drift.Value.ToString(CultureInfo.InvariantCulture)}");
+                    sb.AppendLine("      },");
+                    break;
+            }
             sb.AppendLine("      \"chromatogram\": {");
-            sb.AppendLine($"        \"rts\": [{string.Join(",", chromatogram.Rts.Select(v => v.ToString(CultureInfo.InvariantCulture)))}],");
+            sb.AppendLine($"        \"times\": [{string.Join(",", chromatogram.Times.Select(v => v.ToString(CultureInfo.InvariantCulture)))}],");
             sb.AppendLine($"        \"intensities\": [{string.Join(",", chromatogram.Intensities.Select(v => v.ToString(CultureInfo.InvariantCulture)))}]");
             sb.AppendLine("      }");
             sb.Append("    }");
         }
 
         private static ProjectChromatogram ConvertPeakChromatogram(ExtractedIonChromatogram chromatogram) {
-            var rts = new List<double>(chromatogram.Length);
+            var times = new List<double>(chromatogram.Length);
             var intensities = new List<double>(chromatogram.Length);
             for (var i = 0; i < chromatogram.Length; i++) {
-                rts.Add(chromatogram.Time(i));
+                times.Add(chromatogram.Time(i));
                 intensities.Add(chromatogram.Intensity(i));
             }
-            return new ProjectChromatogram(rts, intensities);
+            return new ProjectChromatogram(times, intensities);
         }
 
         private static IMsdialDataStorage<ParameterBase> LoadProject(string projectFile) {
-            using var stream = new FileStream(projectFile, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return Common.MessagePack.MessagePackDefaultHandler.LoadFromStream<MsdialDataStorage>(stream);
-            using var manager = ZipStreamManager.OpenGet(stream);
-            return MsdialDataStorage.Serializer.LoadAsync(manager, Path.GetFileName(projectFile), "", /*Path.GetDirectoryName(Path.GetFullPath(projectFile)) ?? string.Empty,*/ string.Empty).GetAwaiter().GetResult();
+            return Common.MessagePack.MessagePackDefaultHandler.LoadFromFile<MsdialDataStorage>(projectFile);
         }
 
         private static string EscapeJson(string value) {
@@ -322,11 +332,11 @@ namespace CompMs.App.MsdialConsole.Process
             public double Tolerance { get; } = tolerance;
         }
 
-        private readonly struct ProjectChromatogram(List<double> rts, List<double> intensities)
+        private readonly struct ProjectChromatogram(List<double> times, List<double> intensities)
         {
-            public List<double> Rts { get; } = rts;
+            public List<double> Times { get; } = times;
             public List<double> Intensities { get; } = intensities;
-            public int PointCount => Math.Min(Rts.Count, Intensities.Count);
+            public int PointCount => Math.Min(Times.Count, Intensities.Count);
         }
     }
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -93,7 +93,7 @@ namespace CompMs.App.MsdialConsole.Process
                     case "eic":
                         return new EicProcess().Run(args);
                     default:
-                        Console.WriteLine("Invalid analysis type. Valid options are: 'gcms', 'lcmsdda', 'lcmsdia', 'dims', 'imms', 'eic'");
+                        Console.WriteLine("Invalid analysis type. Valid options are: 'gcms', 'lcms', 'lcimms', 'dims', 'imms', 'msn', 'eic'");
                         return -1;
                 }
             } 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -17,6 +17,11 @@ namespace CompMs.App.MsdialConsole.Process
 
         public static int Run(string[] args) {
             if (args.Length == 0) return argsError();
+
+            if (args[0] == "eic") {
+                return new EicProcess().Run(args);
+            }
+
             if (args.Length < 7) return argsError();
 
             var inputFolder = string.Empty;
@@ -85,8 +90,10 @@ namespace CompMs.App.MsdialConsole.Process
                                 return new MoleculerNetworkProcess().Run4Onefile(inputFolder, outputFolder, methodFile, ionmode);
                             }
                         }
+                    case "eic":
+                        return new EicProcess().Run(args);
                     default:
-                        Console.WriteLine("Invalid analysis type. Valid options are: 'gcms', 'lcmsdda', 'lcmsdia', 'dims', 'imms'");
+                        Console.WriteLine("Invalid analysis type. Valid options are: 'gcms', 'lcmsdda', 'lcmsdia', 'dims', 'imms', 'eic'");
                         return -1;
                 }
             } 
@@ -106,7 +113,7 @@ namespace CompMs.App.MsdialConsole.Process
 
                         Msdial Console App requires the following args:
 						MsdialConsoleApp.exe <analysisType> -i <input folder> -o <output folder> -m <method file> -p (option)
-						Where: <analysisType>	is one of gcms, lcms	(required)
+						Where: <analysisType>	is one of gcms, lcms, eic	(required)
 							   <input folder>	is the folder containing the files to be processed	(required)
 							   <output folder>	is the folder to save results	(required)
 							   <method file>	is a file holding processing properties	(required)


### PR DESCRIPTION
## Why

Add console support for exporting extracted ion chromatograms from raw measurements and analyzed MS-DIAL projects.

## What changed

- Add the `eic raw` and `eic project` command paths to `MsdialCoreTestApp`.
- Export raw-data EICs as CSV with repeated m/z/tolerance targets and configurable acquisition type.
- Export project chromatograms as CSV or JSON, grouped by `AnalysisFileBean`.
- Generate project chromatograms from raw measurement spectra and peak metadata rather than peak-point placeholders.
- Emit all detected peak chromatograms for each analysis file, with RT/DriftTime metadata when available.
- Add partial DriftTime-aware chromatogram range and JSON output support.

## Notes

- JSON stores chromatogram coordinates and intensities as separate arrays.
- User-specific `.vscode` files are intentionally excluded from the branch.

## Validation

- `dotnet build tests\MSDIAL5\MsdialCoreTestApp\MsdialCoreTestApp.csproj -nologo`