### PR TITLE
Refactor console app CLI to System.CommandLine

### DIFF
--- a/tests/MSDIAL5/MsdialCoreTestApp/MsdialCoreTestApp.csproj
+++ b/tests/MSDIAL5/MsdialCoreTestApp/MsdialCoreTestApp.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -35,6 +35,31 @@ namespace CompMs.App.MsdialConsole.Process
             return -1;
         }
 
+        public int RunRaw(FileInfo inputFile, FileInfo outputFile, IReadOnlyList<double> targetValues, AcquisitionType acquisitionType) {
+            if (targetValues.Count == 0 || targetValues.Count % 2 != 0) {
+                return ArgsError();
+            }
+
+            var targets = new List<TargetQuery>(targetValues.Count / 2);
+            for (var i = 0; i < targetValues.Count; i += 2) {
+                targets.Add(new TargetQuery(targetValues[i], targetValues[i + 1]));
+            }
+
+            var spectra = LoadMeasurement(inputFile.FullName);
+            if (spectra.Count == 0) {
+                Console.Error.WriteLine("No raw spectra were found.");
+                return -1;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputFile.FullName) ?? ".");
+            WriteRawCsv(outputFile.FullName, targets, spectra, acquisitionType);
+            return 0;
+        }
+
+        public int RunProject(FileInfo inputFile, FileInfo outputFile, string outputFormat) {
+            return RunProject(new[] { "eic", "project", "-i", inputFile.FullName, "-o", outputFile.FullName, "-format", outputFormat });
+        }
+
         private int RunRaw(string[] args)
         {
             var inputFile = string.Empty;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -44,7 +44,10 @@ namespace CompMs.App.MsdialConsole.Process
             for (var i = 0; i < targetValues.Count; i += 2) {
                 targets.Add(new TargetQuery(targetValues[i], targetValues[i + 1]));
             }
+            return RunRaw(inputFile, outputFile, targets, acquisitionType);
+        }
 
+        private int RunRaw(FileInfo inputFile, FileInfo outputFile, IReadOnlyList<TargetQuery> targets, AcquisitionType acquisitionType) {
             var spectra = LoadMeasurement(inputFile.FullName);
             if (spectra.Count == 0) {
                 Console.Error.WriteLine("No raw spectra were found.");
@@ -57,7 +60,29 @@ namespace CompMs.App.MsdialConsole.Process
         }
 
         public int RunProject(FileInfo inputFile, FileInfo outputFile, string outputFormat) {
-            return RunProject(new[] { "eic", "project", "-i", inputFile.FullName, "-o", outputFile.FullName, "-format", outputFormat });
+            if (!File.Exists(inputFile.FullName)) {
+                Console.Error.WriteLine($"Project file was not found: {inputFile.FullName}");
+                return -1;
+            }
+
+            var project = LoadProject(inputFile.FullName);
+            var files = project.AnalysisFiles.Where(file => file.AnalysisFileIncluded).ToList();
+            if (files.Count == 0) {
+                Console.Error.WriteLine("No included analysis files were found in the project.");
+                return -1;
+            }
+
+            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase)) {
+                WriteProjectCsv(outputFile.FullName, project);
+                return 0;
+            }
+            if (string.Equals(outputFormat, "json", StringComparison.OrdinalIgnoreCase)) {
+                WriteProjectJson(outputFile.FullName, project);
+                return 0;
+            }
+
+            Console.Error.WriteLine($"Invalid output format: {outputFormat}. Valid options are: csv, json.");
+            return -1;
         }
 
         private int RunRaw(string[] args)
@@ -101,20 +126,10 @@ namespace CompMs.App.MsdialConsole.Process
                 return ArgsError();
             }
 
-            var spectra = LoadMeasurement(inputFile);
-            if (spectra.Count == 0)
-            {
-                Console.Error.WriteLine("No raw spectra were found.");
-                return -1;
-            }
-
-            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputFile)) ?? ".");
-            WriteRawCsv(outputFile, targets, spectra, acquisitionType);
-
-            return 0;
+            return RunRaw(new FileInfo(inputFile), new FileInfo(outputFile), targets, acquisitionType);
         }
 
-        private static void WriteRawCsv(string outputPath, List<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra, AcquisitionType acquisitionType)
+        private static void WriteRawCsv(string outputPath, IReadOnlyList<TargetQuery> targets, IReadOnlyList<RawSpectrum> spectra, AcquisitionType acquisitionType)
         {
             var ionMode = spectra.FirstOrDefault(s => s.MsLevel == 1)?.ScanPolarity == ScanPolarity.Negative ? IonMode.Negative : IonMode.Positive;
             var rawSpectra = new RawSpectra(spectra, ionMode, acquisitionType);
@@ -157,29 +172,7 @@ namespace CompMs.App.MsdialConsole.Process
                 return ArgsError();
             }
 
-            if (!File.Exists(inputFile)) {
-                Console.Error.WriteLine($"Project file was not found: {inputFile}");
-                return -1;
-            }
-
-            var project = LoadProject(inputFile);
-            var files = project.AnalysisFiles.Where(file => file.AnalysisFileIncluded).ToList();
-            if (files.Count == 0) {
-                Console.Error.WriteLine("No included analysis files were found in the project.");
-                return -1;
-            }
-
-            if (string.Equals(outputFormat, "csv", StringComparison.OrdinalIgnoreCase)) {
-                WriteProjectCsv(outputFile, project);
-                return 0;
-            }
-            if (string.Equals(outputFormat, "json", StringComparison.OrdinalIgnoreCase)) {
-                WriteProjectJson(outputFile, project);
-                return 0;
-            }
-
-            Console.Error.WriteLine($"Invalid output format: {outputFormat}. Valid options are: csv, json.");
-            return -1;
+            return RunProject(new FileInfo(inputFile), new FileInfo(outputFile), outputFormat);
         }
 
         private static void WriteProjectCsv(string outputPath, IMsdialDataStorage<ParameterBase> project)

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -2,143 +2,470 @@
 using CompMs.App.MsdialConsole.Properties;
 using CompMs.Common.Extension;
 using System;
+using System.CommandLine;
 using System.IO;
 
-namespace CompMs.App.MsdialConsole.Process
+namespace CompMs.App.MsdialConsole.Process;
+
+public static class MainProcess
 {
-    public sealed class MainProcess
-    {
-        private MainProcess() { }
+    public static int CreateMsp4Model(string inputMspFile, string inputEdgeFile, string outputMspFile) {
+        new MoleculerNetworkProcess().GetMsp4Model(inputMspFile, inputEdgeFile, outputMspFile);
+        return 1;
+    }
 
-        public static int CreateMsp4Model(string inputMspFile, string inputEdgeFile, string outputMspFile) {
-            new MoleculerNetworkProcess().GetMsp4Model(inputMspFile, inputEdgeFile, outputMspFile);
-            return 1;
-        }
-
-        public static int Run(string[] args) {
-            if (args.Length == 0) return argsError();
-
-            if (args[0] == "eic") {
-                return new EicProcess().Run(args);
+    public static void SetGcmsCommand(Command root) {
+        var cmd = new Command("gcms", "Run GC-MS data processing");
+        var inputOpt = new Option<FileSystemInfo>("--input", "-i") {
+            Description = "Input folder containing the files to be processed",
+            Required = true,
+        };
+        var outputOpt = new Option<DirectoryInfo>("--output", "-o")
+        {
+            Description = "Output folder to save results",
+            Required = true,
+        };
+        var methodOpt = new Option<FileInfo>("--method", "-m")
+        {
+            Description = "Method file holding processing properties",
+            Required = true,
+        };
+        var projectOpt = new Option<bool>("--project", "-p") {
+            Description = "Option to generate .mdproject file to be loaded in MSDIAL5 GUI application"
+        };
+        cmd.Options.Add(inputOpt);
+        cmd.Options.Add(outputOpt);
+        cmd.Options.Add(methodOpt);
+        cmd.Options.Add(projectOpt);
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileSystemInfo>();
+            if (!input.Exists) {
+                result.AddError("Input path does not exist.");
             }
-
-            if (args.Length < 7) return argsError();
-
-            var inputFolder = string.Empty;
-            var targetFolder = string.Empty;
-            var methodFile = string.Empty;
-            var outputFolder = string.Empty;
-            var isProjectStore = false;
-            var isAif = false;
-            var targetMz = -1.0f;
-            var ionmode = "Positive";
-            var overwrite = false;
-            var isAllEdgeExport = false;
-
-            for (int i = 1; i < args.Length; i++) {
-                if (args[i] == "-i" && i + 1 < args.Length) inputFolder = args[i + 1];
-                else if (args[i] == "-m" && i + 1 < args.Length) methodFile = args[i + 1];
-                else if (args[i] == "-t" && i + 1 < args.Length) targetFolder = args[i + 1];
-                else if (args[i] == "-o" && i + 1 < args.Length) outputFolder = args[i + 1];
-                else if (args[i] == "-p") isProjectStore = true;
-                else if (args[i] == "-target" && i + 1 < args.Length) {
-                    if (!float.TryParse(args[i + 1], out targetMz)) {
-                        return argsError2();
-                    }
-                }
-                else if (args[i] == "-ionmode" && i + 1 < args.Length) ionmode = args[i + 1];
-                else if (args[i] == "-overwrite" && i + 1 < args.Length) {
-                    var booleanstring = args[i + 1];
-                    if (bool.TryParse(booleanstring, out bool isoverwirte)) {
-                        overwrite = isoverwirte;
-                    }
-                }
-                else if (args[i] == "-a") isAllEdgeExport = true;
+        });
+        outputOpt.Validators.Add(result => {
+            var output = result.GetValueOrDefault<DirectoryInfo>();
+            if (File.Exists(output.FullName)) {
+                result.AddError("Output path cannot be a file.");
             }
-            inputFolder = Path.GetFullPath(inputFolder);
-            methodFile = Path.GetFullPath(methodFile);
-            outputFolder = Path.GetFullPath(outputFolder);
-
-            if (inputFolder == string.Empty || methodFile == string.Empty || outputFolder == string.Empty) return argsError();
-            var analysisType = args[0];
+        });
+        methodOpt.Validators.Add(result => {
+            var methodFile = result.GetValueOrDefault<FileInfo>();
+            if (!methodFile.Exists) {
+                result.AddError("Method file does not exist.");
+            }
+        });
+        cmd.SetAction(parseResult => {
             try {
-                switch (analysisType) {
-                    case "gcms":
-                        return new GcmsProcess().Run(inputFolder, outputFolder, methodFile, isProjectStore);
-                    case "lcms":
-                        return new LcmsProcess().Run(inputFolder, outputFolder, methodFile, isProjectStore, targetMz);
-                    case "lcimms":
-                        return new LcimmsProcess().Run(inputFolder, outputFolder, methodFile, isProjectStore, targetMz);
-                    case "dims":
-                        return new DimsProcess().Run(inputFolder, outputFolder, methodFile, isProjectStore, targetMz);
-                    case "imms":
-                        return new ImmsProcess().Run(inputFolder, outputFolder, methodFile, isProjectStore, targetMz);
-                    case "msn":
-
-                        if (Directory.Exists(inputFolder)) {
-                            if (isAllEdgeExport){
-                                return new MoleculerNetworkProcess().Run4AllEdgeGeneration(inputFolder, outputFolder, methodFile, ionmode, overwrite);
-                            }
-                            else
-                                return new MoleculerNetworkProcess().Run(inputFolder, outputFolder, methodFile, ionmode, overwrite);
-                        }
-                        else {
-                            if (!targetFolder.IsEmptyOrNull()) {
-                                return new MoleculerNetworkProcess().Map2TargetFile(targetFolder, inputFolder, methodFile, outputFolder, ionmode);
-                            }
-                            else {
-                                return new MoleculerNetworkProcess().Run4Onefile(inputFolder, outputFolder, methodFile, ionmode);
-                            }
-                        }
-                    case "eic":
-                        return new EicProcess().Run(args);
-                    default:
-                        Console.WriteLine("Invalid analysis type. Valid options are: 'gcms', 'lcms', 'lcimms', 'dims', 'imms', 'msn', 'eic'");
-                        return -1;
-                }
-            } 
+                var input = parseResult.GetRequiredValue(inputOpt);
+                var outputFolder = parseResult.GetRequiredValue(outputOpt);
+                var methodFile = parseResult.GetRequiredValue(methodOpt);
+                var isProjectStore = parseResult.GetValue(projectOpt);
+                return new GcmsProcess().Run(input.FullName, outputFolder.FullName, methodFile.FullName, isProjectStore);
+            }
             catch (Exception ex) {
                 var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
                 Console.WriteLine(msg);
-                return ex.GetHashCode(); 
+                return 1;
             }
-        }
+        });
+        root.Add(cmd);
+    }
 
-        /// <summary>
-        /// Shows console application usage help
-        /// </summary>
-        /// <returns>error code -1</returns>
-        private static int argsError() {
-            var error = @$"Msdial Console App Version {Resources.VERSION}
+    public static void SetLcmsCommand(Command root) {
+        var cmd = new Command("lcms", "Run LC-MS data processing");
+        var inputOpt = new Option<FileSystemInfo>("--input", "-i") {
+            Description = "Input folder containing the files to be processed",
+            Required = true,
+        };
+        var outputOpt = new Option<DirectoryInfo>("--output", "-o")
+        {
+            Description = "Output folder to save results",
+            Required = true,
+        };
+        var methodOpt = new Option<FileInfo>("--method", "-m")
+        {
+            Description = "Method file holding processing properties",
+            Required = true,
+        };
+        var projectOpt = new Option<bool>("--project", "-p") {
+            Description = "Option to generate .mdproject file to be loaded in MSDIAL5 GUI application"
+        };
+        var targetOpt = new Option<float>("--target", "-target", "-t")
+        {
+            Description = "Option to run as target mode. please set m/z",
+        };
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileSystemInfo>();
+            if (!input.Exists) {
+                result.AddError("Input path does not exist.");
+            }
+        });
+        outputOpt.Validators.Add(result => {
+            var output = result.GetValueOrDefault<DirectoryInfo>();
+            if (File.Exists(output.FullName)) {
+                result.AddError("Output path cannot be a file.");
+            }
+        });
+        methodOpt.Validators.Add(result => {
+            var methodFile = result.GetValueOrDefault<FileInfo>();
+            if (!methodFile.Exists) {
+                result.AddError("Method file does not exist.");
+            }
+        });
+        cmd.Options.Add(inputOpt);
+        cmd.Options.Add(outputOpt);
+        cmd.Options.Add(methodOpt);
+        cmd.Options.Add(projectOpt);
+        cmd.Options.Add(targetOpt);
+        cmd.SetAction(parseResult => {
+            try {
+                var inputFolder = parseResult.GetRequiredValue(inputOpt);
+                var outputFolder = parseResult.GetRequiredValue(outputOpt);
+                var methodFile = parseResult.GetRequiredValue(methodOpt);
+                var isProjectStore = parseResult.GetValue(projectOpt);
+                var targetMz = parseResult.GetResult(targetOpt)?.GetValueOrDefault<float>() ?? -1f;
+                return new LcmsProcess().Run(inputFolder.FullName, outputFolder.FullName, methodFile.FullName, isProjectStore, targetMz);
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
+        });
+        root.Add(cmd);
+    }
 
-                        Msdial Console App requires the following args:
-						MsdialConsoleApp.exe <analysisType> -i <input folder> -o <output folder> -m <method file> -p (option)
-						Where: <analysisType>	is one of gcms, lcms, eic	(required)
-							   <input folder>	is the folder containing the files to be processed	(required)
-							   <output folder>	is the folder to save results	(required)
-							   <method file>	is a file holding processing properties	(required)
-                               <option -p>           is an option to generate .mdproject file to be loaded in MSDIAL5 GUI application.";
 
-            Console.Error.WriteLine(error);
+    public static void SetLcimmsCommand(Command root) {
+        var cmd = new Command("lcimms", "Run LC-IM-MS data processing");
+        var inputOpt = new Option<FileSystemInfo>("--input", "-i") {
+            Description = "Input folder containing the files to be processed",
+            Required = true,
+        };
+        var outputOpt = new Option<DirectoryInfo>("--output", "-o")
+        {
+            Description = "Output folder to save results",
+            Required = true,
+        };
+        var methodOpt = new Option<FileInfo>("--method", "-m")
+        {
+            Description = "Method file holding processing properties",
+            Required = true,
+        };
+        var projectOpt = new Option<bool>("--project", "-p") {
+            Description = "Option to generate .mdproject file to be loaded in MSDIAL5 GUI application"
+        };
+        var targetOpt = new Option<float>("--target", "-target", "-t")
+        {
+            Description = "Option to run as target mode. please set m/z",
+        };
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileSystemInfo>();
+            if (!input.Exists) {
+                result.AddError("Input path does not exist.");
+            }
+        });
+        outputOpt.Validators.Add(result => {
+            var output = result.GetValueOrDefault<DirectoryInfo>();
+            if (File.Exists(output.FullName)) {
+                result.AddError("Output path cannot be a file.");
+            }
+        });
+        methodOpt.Validators.Add(result => {
+            var methodFile = result.GetValueOrDefault<FileInfo>();
+            if (!methodFile.Exists) {
+                result.AddError("Method file does not exist.");
+            }
+        });
+        cmd.Options.Add(inputOpt);
+        cmd.Options.Add(outputOpt);
+        cmd.Options.Add(methodOpt);
+        cmd.Options.Add(projectOpt);
+        cmd.Options.Add(targetOpt);
+        cmd.SetAction(parseResult => {
+            try {
+                var inputFolder = parseResult.GetRequiredValue(inputOpt);
+                var outputFolder = parseResult.GetRequiredValue(outputOpt);
+                var methodFile = parseResult.GetRequiredValue(methodOpt);
+                var isProjectStore = parseResult.GetValue(projectOpt);
+                var targetMz = parseResult.GetResult(targetOpt)?.GetValueOrDefault<float>() ?? -1f;
+                return new LcimmsProcess().Run(inputFolder.FullName, outputFolder.FullName, methodFile.FullName, isProjectStore, targetMz);
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
+        });
+        root.Add(cmd);
+    }
 
-            return -1;
-        }
-        private static int argsError2() {
-            var error = @$"Msdial Console App Version {Resources.VERSION}
+    public static void SetDimsCommand(Command root) {
+        var cmd = new Command("dims", "Run DI-MS data processing");
+        var inputOpt = new Option<FileSystemInfo>("--input", "-i") {
+            Description = "Input folder containing the files to be processed",
+            Required = true,
+        };
+        var outputOpt = new Option<DirectoryInfo>("--output", "-o")
+        {
+            Description = "Output folder to save results",
+            Required = true,
+        };
+        var methodOpt = new Option<FileInfo>("--method", "-m")
+        {
+            Description = "Method file holding processing properties",
+            Required = true,
+        };
+        var projectOpt = new Option<bool>("--project", "-p") {
+            Description = "Option to generate .mdproject file to be loaded in MSDIAL5 GUI application"
+        };
+        var targetOpt = new Option<float>("--target", "-target", "-t")
+        {
+            Description = "Option to run as target mode. please set m/z",
+        };
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileSystemInfo>();
+            if (!input.Exists) {
+                result.AddError("Input path does not exist.");
+            }
+        });
+        outputOpt.Validators.Add(result => {
+            var output = result.GetValueOrDefault<DirectoryInfo>();
+            if (File.Exists(output.FullName)) {
+                result.AddError("Output path cannot be a file.");
+            }
+        });
+        methodOpt.Validators.Add(result => {
+            var methodFile = result.GetValueOrDefault<FileInfo>();
+            if (!methodFile.Exists) {
+                result.AddError("Method file does not exist.");
+            }
+        });
+        cmd.Options.Add(inputOpt);
+        cmd.Options.Add(outputOpt);
+        cmd.Options.Add(methodOpt);
+        cmd.Options.Add(projectOpt);
+        cmd.Options.Add(targetOpt);
+        cmd.SetAction(parseResult => {
+            try {
+                var inputFolder = parseResult.GetRequiredValue(inputOpt);
+                var outputFolder = parseResult.GetRequiredValue(outputOpt);
+                var methodFile = parseResult.GetRequiredValue(methodOpt);
+                var isProjectStore = parseResult.GetValue(projectOpt);
+                var targetMz = parseResult.GetResult(targetOpt)?.GetValueOrDefault<float>() ?? -1f;
+                return new DimsProcess().Run(inputFolder.FullName, outputFolder.FullName, methodFile.FullName, isProjectStore, targetMz);
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
+        });
+        root.Add(cmd);
+    }
 
-                        Msdial Console App requires the following args:
-						MsdialConsoleApp.exe <analysisType> -i <input folder> -o <output folder> -m <method file> -p (option) -mCE (option) -target <target m/z>
-						Where: <analysisType>	is one of gcms, lcms	(required)
-							   <input folder>	is the folder containing the files to be processed	(required)
-							   <output folder>	is the folder to save results	(required)
-							   <method file>	is a file holding processing properties	(required)
-                               <option -p>           is an option to generate .mdproject file to be loaded in MSDIAL5 GUI application.
-                               <option -target> is an option to run as target mode. please set m/z";
+    public static void SetImmsCommand(Command root) {
+        var cmd = new Command("imms", "Run IC-MS data processing");
+        var inputOpt = new Option<FileSystemInfo>("--input", "-i") {
+            Description = "Input folder containing the files to be processed",
+            Required = true,
+        };
+        var outputOpt = new Option<DirectoryInfo>("--output", "-o")
+        {
+            Description = "Output folder to save results",
+            Required = true,
+        };
+        var methodOpt = new Option<FileInfo>("--method", "-m")
+        {
+            Description = "Method file holding processing properties",
+            Required = true,
+        };
+        var projectOpt = new Option<bool>("--project", "-p") {
+            Description = "Option to generate .mdproject file to be loaded in MSDIAL5 GUI application"
+        };
+        var targetOpt = new Option<float>("--target", "-target", "-t")
+        {
+            Description = "Option to run as target mode. please set m/z",
+        };
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileSystemInfo>();
+            if (!input.Exists) {
+                result.AddError("Input path does not exist.");
+            }
+        });
+        outputOpt.Validators.Add(result => {
+            var output = result.GetValueOrDefault<DirectoryInfo>();
+            if (File.Exists(output.FullName)) {
+                result.AddError("Output path cannot be a file.");
+            }
+        });
+        methodOpt.Validators.Add(result => {
+            var methodFile = result.GetValueOrDefault<FileInfo>();
+            if (!methodFile.Exists) {
+                result.AddError("Method file does not exist.");
+            }
+        });
+        cmd.Options.Add(inputOpt);
+        cmd.Options.Add(outputOpt);
+        cmd.Options.Add(methodOpt);
+        cmd.Options.Add(projectOpt);
+        cmd.Options.Add(targetOpt);
+        cmd.SetAction(parseResult => {
+            try {
+                var inputFolder = parseResult.GetRequiredValue(inputOpt);
+                var outputFolder = parseResult.GetRequiredValue(outputOpt);
+                var methodFile = parseResult.GetRequiredValue(methodOpt);
+                var isProjectStore = parseResult.GetValue(projectOpt);
+                var targetMz = parseResult.GetResult(targetOpt)?.GetValueOrDefault<float>() ?? -1f;
+                return new ImmsProcess().Run(inputFolder.FullName, outputFolder.FullName, methodFile.FullName, isProjectStore, targetMz);
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
+        });
+        root.Add(cmd);
+    }
 
-            Console.Error.WriteLine(error);
+    public static void SetMsnCommand(Command root) {
+        var cmd = new Command("msn", "Run molecular networking data processing");
+        var inputOpt = new Option<string>("--input", "-i")
+        {
+            Description = "Input folder containing the files to be processed or a single file",
+            Required = true,
+        };
+        var outputOpt = new Option<string>("--output", "-o")
+        {
+            Description = "Output folder to save results or a single result file",
+            Required = true,
+        };
+        var methodOpt = new Option<FileInfo>("--method", "-m")
+        {
+            Description = "Method file holding processing properties",
+            Required = true,
+        };
+        var targetFileOpt = new Option<FileInfo>("--targetFile", "-t")
+        {
+            Description = "Option",
+        };
+        var ionmodeOpt = new Option<string>("--ionmode", "-ionmode")
+        {
+            Description = "Ion mode for MS/MS data processing. Valid options are 'Positive' or 'Negative'",
+            DefaultValueFactory = _ => "Positive",
+        };
+        var overwriteOpt = new Option<bool>("--overwrite", "-overwrite")
+        {
+            Description = "Option to overwrite existing output files. Default is false.",
+            DefaultValueFactory = _ => false,
+        };
+        var allEdgeExportOpt = new Option<bool>("--all-edge-export", "-a")
+        {
+            Description = "Option to export all edges in the molecular network. Default is false.",
+            DefaultValueFactory = _ => false,
+        };
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileSystemInfo>();
+            if (!input.Exists) {
+                result.AddError("Input path does not exist.");
+            }
+        });
+        methodOpt.Validators.Add(result => {
+            var methodFile = result.GetValueOrDefault<FileInfo>();
+            if (!methodFile.Exists) {
+                result.AddError("Method file does not exist.");
+            }
+        });
+        cmd.Options.Add(inputOpt);
+        cmd.Options.Add(outputOpt);
+        cmd.Options.Add(methodOpt);
+        cmd.Options.Add(targetFileOpt);
+        cmd.Options.Add(ionmodeOpt);
+        cmd.Options.Add(overwriteOpt);
+        cmd.Options.Add(allEdgeExportOpt);
+        cmd.Validators.Add(result => {
+            string input = result.GetRequiredValue(inputOpt);
+            string output = result.GetRequiredValue(outputOpt);
 
-            return -1;
-        }
+            if (!Directory.Exists(input) && !File.Exists(input)) {
+                result.AddError("Input path does not exist.");
+            }
+            if (Directory.Exists(input) && File.Exists(output)) {
+                result.AddError("Output path cannot be a file when input is a directory.");
+            }
+            if (File.Exists(input) && Directory.Exists(output)) {
+                result.AddError("Output path cannot be a directory when input is a file.");
+            }
+        });
+        ionmodeOpt.Validators.Add(result => {
+            var value = result.GetValueOrDefault<string>();
+            if (value is not ("Positive" or "Negative")) {
+                result.AddError("Ion mode must be Positive or Negative.");
+            }
+        });
+        cmd.SetAction(parseResult => {
+            try {
+                var input = Path.GetFullPath(parseResult.GetRequiredValue(inputOpt));
+                var output = Path.GetFullPath(parseResult.GetRequiredValue(outputOpt));
+                var methodFile = parseResult.GetRequiredValue(methodOpt);
+                var targetFile = parseResult.GetValue(targetFileOpt);
+                var ionmode = parseResult.GetRequiredValue(ionmodeOpt);
+                var overwrite = parseResult.GetValue(overwriteOpt);
+                var allEdgeExport = parseResult.GetValue(allEdgeExportOpt);
 
+                if (Directory.Exists(input)) {
+                    if (allEdgeExport){
+                        return new MoleculerNetworkProcess().Run4AllEdgeGeneration(input, output, methodFile.FullName, ionmode, overwrite);
+                    }
+                    else
+                        return new MoleculerNetworkProcess().Run(input, output, methodFile.FullName, ionmode, overwrite);
+                }
+                else {
+                    if (targetFile != null && targetFile.Exists) {
+                        return new MoleculerNetworkProcess().Map2TargetFile(targetFile.FullName, input, methodFile.FullName, output, ionmode);
+                    }
+                    else {
+                        return new MoleculerNetworkProcess().Run4Onefile(input, output, methodFile.FullName, ionmode);
+                    }
+                }
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
+        });
+
+        root.Add(cmd);
+    }
+
+    public static void SetImageGenCommand(Command root) {
+        var cmd = new Command("imagegen", "Run image generation process for MALDI imaging data");
+        var inputOpt = new Option<FileInfo>("--input", "-i")
+        {
+            Description = "Input .mddata file containing the peak data to be processed",
+            Required = true,
+        };
+        inputOpt.Validators.Add(result => {
+            var input = result.GetValueOrDefault<FileInfo>();
+            if (!input.Exists) {
+                result.AddError("Input .mddata file does not exist.");
+            }
+        });
+        cmd.Options.Add(inputOpt);
+        cmd.SetAction(async parseResult => {
+            try {
+                var inputFile = parseResult.GetRequiredValue(inputOpt);
+                await new ImageGenerationProcess().RunAsync(inputFile.FullName);
+                return 0;
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
+        });
+        root.Add(cmd);
     }
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -440,32 +440,4 @@ public static class MainProcess
         root.Add(cmd);
     }
 
-    public static void SetImageGenCommand(Command root) {
-        var cmd = new Command("imagegen", "Run image generation process for MALDI imaging data");
-        var inputOpt = new Option<FileInfo>("--input", "-i")
-        {
-            Description = "Input .mddata file containing the peak data to be processed",
-            Required = true,
-        };
-        inputOpt.Validators.Add(result => {
-            var input = result.GetValueOrDefault<FileInfo>();
-            if (!input.Exists) {
-                result.AddError("Input .mddata file does not exist.");
-            }
-        });
-        cmd.Options.Add(inputOpt);
-        cmd.SetAction(async parseResult => {
-            try {
-                var inputFile = parseResult.GetRequiredValue(inputOpt);
-                await new ImageGenerationProcess().RunAsync(inputFile.FullName);
-                return 0;
-            }
-            catch (Exception ex) {
-                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
-                Console.WriteLine(msg);
-                return 1;
-            }
-        });
-        root.Add(cmd);
-    }
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -1,5 +1,6 @@
 ﻿using CompMs.App.MsdialConsole.Process.MoleculerNetworking;
 using CompMs.App.MsdialConsole.Properties;
+using CompMs.Common.Enum;
 using CompMs.Common.Extension;
 using System;
 using System.Collections.Generic;
@@ -446,28 +447,19 @@ public static class MainProcess
         var raw = new Command("raw", "Export EICs from a raw data file");
         var rawInput = new Option<FileInfo>("--input", "-i") { Required = true };
         var rawOutput = new Option<FileInfo>("--output", "-o") { Required = true };
-        var targets = new Option<string[]>("--target", "-target") { Required = true };
+        var targets = new Option<double[]>("--target", "-target") { Required = true };
         targets.Arity = ArgumentArity.OneOrMore;
-        var acquisitionType = new Option<string>("--acquisitiontype") { DefaultValueFactory = _ => "DDA" };
+        var acquisitionType = new Option<AcquisitionType>("--acquisitiontype") { DefaultValueFactory = _ => AcquisitionType.DDA };
         raw.Options.Add(rawInput);
         raw.Options.Add(rawOutput);
         raw.Options.Add(targets);
         raw.Options.Add(acquisitionType);
         raw.SetAction(parseResult => {
-            var args = new List<string> { "eic", "raw", "-i", parseResult.GetRequiredValue(rawInput).FullName, "-o", parseResult.GetRequiredValue(rawOutput).FullName };
-            args.Add("-acquisitiontype");
-            args.Add(parseResult.GetValue(acquisitionType));
-            var targetValues = parseResult.GetValue(targets);
-            if (targetValues.Length % 2 != 0) {
-                Console.Error.WriteLine("Each -target value requires an m/z and tolerance.");
-                return 1;
-            }
-            for (var i = 0; i < targetValues.Length; i += 2) {
-                args.Add("-target");
-                args.Add(targetValues[i]);
-                args.Add(targetValues[i + 1]);
-            }
-            return new EicProcess().Run(args.ToArray());
+            return new EicProcess().RunRaw(
+                parseResult.GetRequiredValue(rawInput),
+                parseResult.GetRequiredValue(rawOutput),
+                parseResult.GetValue(targets),
+                parseResult.GetValue(acquisitionType));
         });
 
         var project = new Command("project", "Export EICs from an MS-DIAL project");
@@ -477,11 +469,10 @@ public static class MainProcess
         project.Options.Add(projectInput);
         project.Options.Add(projectOutput);
         project.Options.Add(format);
-        project.SetAction(parseResult => new EicProcess().Run(new[] {
-            "eic", "project", "-i", parseResult.GetRequiredValue(projectInput).FullName,
-            "-o", parseResult.GetRequiredValue(projectOutput).FullName,
-            "-format", parseResult.GetValue(format),
-        }));
+        project.SetAction(parseResult => new EicProcess().RunProject(
+            parseResult.GetRequiredValue(projectInput),
+            parseResult.GetRequiredValue(projectOutput),
+            parseResult.GetValue(format)));
 
         eic.Subcommands.Add(raw);
         eic.Subcommands.Add(project);

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -47,13 +47,13 @@ public static class MainProcess
         });
         outputOpt.Validators.Add(result => {
             var output = result.GetValueOrDefault<DirectoryInfo>();
-            if (File.Exists(output.FullName)) {
+            if (output is null || File.Exists(output.FullName)) {
                 result.AddError("Output path cannot be a file.");
             }
         });
         methodOpt.Validators.Add(result => {
             var methodFile = result.GetValueOrDefault<FileInfo>();
-            if (!methodFile.Exists) {
+            if (methodFile is null || !methodFile.Exists) {
                 result.AddError("Method file does not exist.");
             }
         });
@@ -99,19 +99,19 @@ public static class MainProcess
         };
         inputOpt.Validators.Add(result => {
             var input = result.GetValueOrDefault<FileSystemInfo>();
-            if (!input.Exists) {
+            if (input is null || !input.Exists) {
                 result.AddError("Input path does not exist.");
             }
         });
         outputOpt.Validators.Add(result => {
             var output = result.GetValueOrDefault<DirectoryInfo>();
-            if (File.Exists(output.FullName)) {
+            if (output is null || File.Exists(output.FullName)) {
                 result.AddError("Output path cannot be a file.");
             }
         });
         methodOpt.Validators.Add(result => {
             var methodFile = result.GetValueOrDefault<FileInfo>();
-            if (!methodFile.Exists) {
+            if (methodFile is null || !methodFile.Exists) {
                 result.AddError("Method file does not exist.");
             }
         });
@@ -164,19 +164,19 @@ public static class MainProcess
         };
         inputOpt.Validators.Add(result => {
             var input = result.GetValueOrDefault<FileSystemInfo>();
-            if (!input.Exists) {
+            if (input is null || !input.Exists) {
                 result.AddError("Input path does not exist.");
             }
         });
         outputOpt.Validators.Add(result => {
             var output = result.GetValueOrDefault<DirectoryInfo>();
-            if (File.Exists(output.FullName)) {
+            if (output is null || File.Exists(output.FullName)) {
                 result.AddError("Output path cannot be a file.");
             }
         });
         methodOpt.Validators.Add(result => {
             var methodFile = result.GetValueOrDefault<FileInfo>();
-            if (!methodFile.Exists) {
+            if (methodFile is null || !methodFile.Exists) {
                 result.AddError("Method file does not exist.");
             }
         });
@@ -228,19 +228,19 @@ public static class MainProcess
         };
         inputOpt.Validators.Add(result => {
             var input = result.GetValueOrDefault<FileSystemInfo>();
-            if (!input.Exists) {
+            if (input is null || !input.Exists) {
                 result.AddError("Input path does not exist.");
             }
         });
         outputOpt.Validators.Add(result => {
             var output = result.GetValueOrDefault<DirectoryInfo>();
-            if (File.Exists(output.FullName)) {
+            if (output is null || File.Exists(output.FullName)) {
                 result.AddError("Output path cannot be a file.");
             }
         });
         methodOpt.Validators.Add(result => {
             var methodFile = result.GetValueOrDefault<FileInfo>();
-            if (!methodFile.Exists) {
+            if (methodFile is null || !methodFile.Exists) {
                 result.AddError("Method file does not exist.");
             }
         });
@@ -292,19 +292,19 @@ public static class MainProcess
         };
         inputOpt.Validators.Add(result => {
             var input = result.GetValueOrDefault<FileSystemInfo>();
-            if (!input.Exists) {
+            if (input is null || !input.Exists) {
                 result.AddError("Input path does not exist.");
             }
         });
         outputOpt.Validators.Add(result => {
             var output = result.GetValueOrDefault<DirectoryInfo>();
-            if (File.Exists(output.FullName)) {
+            if (output is null || File.Exists(output.FullName)) {
                 result.AddError("Output path cannot be a file.");
             }
         });
         methodOpt.Validators.Add(result => {
             var methodFile = result.GetValueOrDefault<FileInfo>();
-            if (!methodFile.Exists) {
+            if (methodFile is null || !methodFile.Exists) {
                 result.AddError("Method file does not exist.");
             }
         });
@@ -369,13 +369,13 @@ public static class MainProcess
         };
         inputOpt.Validators.Add(result => {
             var input = result.GetValueOrDefault<FileSystemInfo>();
-            if (!input.Exists) {
+            if (input is null || !input.Exists) {
                 result.AddError("Input path does not exist.");
             }
         });
         methodOpt.Validators.Add(result => {
             var methodFile = result.GetValueOrDefault<FileInfo>();
-            if (!methodFile.Exists) {
+            if (methodFile is null || !methodFile.Exists) {
                 result.AddError("Method file does not exist.");
             }
         });

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -2,6 +2,7 @@
 using CompMs.App.MsdialConsole.Properties;
 using CompMs.Common.Extension;
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
 
@@ -438,6 +439,53 @@ public static class MainProcess
         });
 
         root.Add(cmd);
+    }
+
+    public static void SetEicCommand(Command root) {
+        var eic = new Command("eic", "Export extracted ion chromatograms");
+        var raw = new Command("raw", "Export EICs from a raw data file");
+        var rawInput = new Option<FileInfo>("--input", "-i") { Required = true };
+        var rawOutput = new Option<FileInfo>("--output", "-o") { Required = true };
+        var targets = new Option<string[]>("--target", "-target") { Required = true };
+        targets.Arity = ArgumentArity.OneOrMore;
+        var acquisitionType = new Option<string>("--acquisitiontype") { DefaultValueFactory = _ => "DDA" };
+        raw.Options.Add(rawInput);
+        raw.Options.Add(rawOutput);
+        raw.Options.Add(targets);
+        raw.Options.Add(acquisitionType);
+        raw.SetAction(parseResult => {
+            var args = new List<string> { "eic", "raw", "-i", parseResult.GetRequiredValue(rawInput).FullName, "-o", parseResult.GetRequiredValue(rawOutput).FullName };
+            args.Add("-acquisitiontype");
+            args.Add(parseResult.GetValue(acquisitionType));
+            var targetValues = parseResult.GetValue(targets);
+            if (targetValues.Length % 2 != 0) {
+                Console.Error.WriteLine("Each -target value requires an m/z and tolerance.");
+                return 1;
+            }
+            for (var i = 0; i < targetValues.Length; i += 2) {
+                args.Add("-target");
+                args.Add(targetValues[i]);
+                args.Add(targetValues[i + 1]);
+            }
+            return new EicProcess().Run(args.ToArray());
+        });
+
+        var project = new Command("project", "Export EICs from an MS-DIAL project");
+        var projectInput = new Option<FileInfo>("--input", "-i") { Required = true };
+        var projectOutput = new Option<FileInfo>("--output", "-o") { Required = true };
+        var format = new Option<string>("--format") { DefaultValueFactory = _ => "json" };
+        project.Options.Add(projectInput);
+        project.Options.Add(projectOutput);
+        project.Options.Add(format);
+        project.SetAction(parseResult => new EicProcess().Run(new[] {
+            "eic", "project", "-i", parseResult.GetRequiredValue(projectInput).FullName,
+            "-o", parseResult.GetRequiredValue(projectOutput).FullName,
+            "-format", parseResult.GetValue(format),
+        }));
+
+        eic.Subcommands.Add(raw);
+        eic.Subcommands.Add(project);
+        root.Subcommands.Add(eic);
     }
 
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -41,7 +41,7 @@ public static class MainProcess
         cmd.Options.Add(projectOpt);
         inputOpt.Validators.Add(result => {
             var input = result.GetValueOrDefault<FileSystemInfo>();
-            if (!input.Exists) {
+            if (input is null || !input.Exists) {
                 result.AddError("Input path does not exist.");
             }
         });

--- a/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
@@ -182,6 +182,7 @@ class Program {
         MainProcess.SetDimsCommand(root);
         MainProcess.SetImmsCommand(root);
         MainProcess.SetMsnCommand(root);
+        MainProcess.SetEicCommand(root);
         var parseResult = root.Parse(args);
         return parseResult.InvokeAsync();
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
@@ -182,8 +182,6 @@ class Program {
         MainProcess.SetDimsCommand(root);
         MainProcess.SetImmsCommand(root);
         MainProcess.SetMsnCommand(root);
-        MainProcess.SetImageGenCommand(root);
-
         var parseResult = root.Parse(args);
         return parseResult.InvokeAsync();
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
@@ -1,11 +1,13 @@
 ﻿using CompMs.App.MsdialConsole.Process;
-using System;
-using System.Collections.Generic;
+using CompMs.App.MsdialConsole.Properties;
 using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace CompMs.App.MsdialConsole;
 class Program {
-    public static int Main(string[] args) {
+    public static Task<int> Main(string[] args) {
         // gcms
         // args = new string[] {
         //     "gcms"
@@ -169,84 +171,28 @@ class Program {
         //    @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_filtered.edge",
         //     @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_for_model.msp");
 
-        var analysisArg = new Argument<string>("analysisType") {
-            Description = "gcms | lcms | lcimms | dims | imms | msn | imagegen"
-        };
+        var root = new RootCommand($"MSDIAL Console Application {Resources.VERSION}");
+        if (root.Options.OfType<VersionOption>().SingleOrDefault() is { } versionOption) {
+            versionOption.Action = new VersionAction();
+        }
 
-        var inputOpt = new Option<string>("--input", "-i") {
-            Description = "input folder or file",
-            Required = true,
-        };
-        var outputOpt = new Option<string>("--output", "-o") {
-            Description = "output folder",
-            Required = true,
-        };
-        var methodOpt = new Option<string>("--method", "-m") {
-            Description = "method file",
-            Required = true,
-        };
-        var projectOpt = new Option<bool>("--project", "-p") {
-            Description = "generate .mdproject file",
-        };
-        var targetFolderOpt = new Option<string?>("--targetFolder", "-t") {
-            Description = "target folder or file",
-        };
-        var targetMzOpt = new Option<string?>("--target") {
-            Description = "target m/z",
-        };
-        var ionmodeOpt = new Option<string>("--ionmode") {
-            Description = "ion mode",
-            Arity = ArgumentArity.ZeroOrOne,
-            DefaultValueFactory = _ => "Positive",
-        };
-        var overwriteOpt = new Option<bool>("--overwrite") {
-            Description = "overwrite",
-            Arity = ArgumentArity.ExactlyOne,
-            DefaultValueFactory = _ => false,
-        };
-        var allEdgeOpt = new Option<bool>("--allEdgeExport", "-a") {
-            Description = "export all edges",
-        };
+        MainProcess.SetGcmsCommand(root);
+        MainProcess.SetLcmsCommand(root);
+        MainProcess.SetLcimmsCommand(root);
+        MainProcess.SetDimsCommand(root);
+        MainProcess.SetImmsCommand(root);
+        MainProcess.SetMsnCommand(root);
+        MainProcess.SetImageGenCommand(root);
 
-        var root = new RootCommand("MSDIAL Console Application");
-        root.Arguments.Add(analysisArg);
-        root.Options.Add(inputOpt);
-        root.Options.Add(outputOpt);
-        root.Options.Add(methodOpt);
-        root.Options.Add(projectOpt);
-        root.Options.Add(targetFolderOpt);
-        root.Options.Add(targetMzOpt);
-        root.Options.Add(ionmodeOpt);
-        root.Options.Add(overwriteOpt);
-        root.Options.Add(allEdgeOpt);
+        var parseResult = root.Parse(args);
+        return parseResult.InvokeAsync();
+    }
 
-        root.SetAction(parseResult => {
-            var analysisType = parseResult.GetRequiredValue(analysisArg);
-            var input = parseResult.GetResult(inputOpt);
-            var output = parseResult.GetResult(outputOpt);
-            var method = parseResult.GetResult(methodOpt);
-            var project = parseResult.GetResult(projectOpt);
-            var targetFolder = parseResult.GetResult(targetFolderOpt);
-            var targetMz = parseResult.GetResult(targetMzOpt);
-            var ionmode = parseResult.GetResult(ionmodeOpt);
-            var overwrite = parseResult.GetResult(overwriteOpt);
-            var allEdge = parseResult.GetResult(allEdgeOpt);
-
-            var argList = new List<string> { analysisType };
-            if (input?.GetValueOrDefault<string>() is { Length: > 0 } inputStr) { argList.Add("-i"); argList.Add(inputStr); }
-            if (method?.GetValueOrDefault<string>() is { Length: > 0 } methodStr) { argList.Add("-m"); argList.Add(methodStr); }
-            if (targetFolder?.GetValueOrDefault<string>() is { Length: > 0 } targetFolderStr) { argList.Add("-t"); argList.Add(targetFolderStr); }
-            if (output?.GetValueOrDefault<string>() is { Length: > 0 } outputStr) { argList.Add("-o"); argList.Add(outputStr); }
-            if (project?.GetValueOrDefault<bool>() ?? false) argList.Add("-p");
-            if (targetMz?.GetValueOrDefault<string>() is { Length: > 0 } targetMzStr) { argList.Add("-target"); argList.Add(targetMzStr); }
-            if (ionmode?.GetValueOrDefault<string>() is { Length: > 0 } ionmodeStr) { argList.Add("-ionmode"); argList.Add(ionmodeStr); }
-            if (overwrite?.GetValueOrDefault<bool>() ?? false) argList.Add("-overwrite");
-            if (allEdge?.GetValueOrDefault<bool>() ?? false) argList.Add("-a");
-
-            var rc = MainProcess.Run(argList.ToArray());
-            Environment.Exit(rc);
-        });
-
-        return root.Parse(args).Invoke();
+    internal class VersionAction : SynchronousCommandLineAction
+    {
+        public override int Invoke(ParseResult parseResult) {
+            System.Console.WriteLine(Resources.VERSION);
+            return 0;
+        }
     }
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
@@ -1,191 +1,252 @@
-﻿using CompMs.App.MsdialConsole.Casmi;
-using CompMs.App.MsdialConsole.DataObjTest;
-using CompMs.App.MsdialConsole.EadSpectraAnalysis;
-using CompMs.App.MsdialConsole.Export;
-using CompMs.App.MsdialConsole.MolecularNetwork;
-using CompMs.App.MsdialConsole.MspCuration;
-using CompMs.App.MsdialConsole.Parser;
-using CompMs.App.MsdialConsole.Process;
-using CompMs.App.MsdialConsole.ProteomicsTest;
-using CompMs.Common.FormulaGenerator.Parser;
-using CompMs.Common.Lipidomics;
-using CompMs.Common.Proteomics.Parser;
-using CompMs.MsdialCore.Utility;
-using CompMs.MsdialLcMsApi.Algorithm.PostCuration;
+﻿using CompMs.App.MsdialConsole.Process;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Text;
+using System.CommandLine;
 
-namespace CompMs.App.MsdialConsole {
-    class Program {
-        static void Main(string[] args) {
-            // gcms
-            // args = new string[] {
-            //     "gcms"
-            //     , "-i"
-            //     , @"D:\msdial_test\Msdial\out\GCMS"
-            //     , "-o"
-            //     , @"D:\msdial_test\Msdial\out\GCMS"
-            //     , "-m"
-            //     , @"D:\msdial_test\Msdial\out\GCMS\Msdial-GCMS-Param.txt"
-            //     , "-p"
-            // };
+namespace CompMs.App.MsdialConsole;
+class Program {
+    public static int Main(string[] args) {
+        // gcms
+        // args = new string[] {
+        //     "gcms"
+        //     , "-i"
+        //     , @"D:\msdial_test\Msdial\out\GCMS"
+        //     , "-o"
+        //     , @"D:\msdial_test\Msdial\out\GCMS"
+        //     , "-m"
+        //     , @"D:\msdial_test\Msdial\out\GCMS\Msdial-GCMS-Param.txt"
+        //     , "-p"
+        // };
 
-            // lcms
-            //args = new string[]
-            //{
-            //    "lcms"
-            //    , "-i"
-            //    , @"E:\0_SourceCode\MsdialWorkbenchDemo\console_fastlc_demo"
-            //    , "-o"
-            //    , @"E:\0_SourceCode\MsdialWorkbenchDemo\console_fastlc_demo"
-            //    , "-m"
-            //    , @"E:\0_SourceCode\MsdialWorkbenchDemo\console_fastlc_demo\lib\msdial_console_param4lipidomics.txt"
-            //    , "-p"
-            //};
+        // lcms
+        //args = new string[]
+        //{
+        //    "lcms"
+        //    , "-i"
+        //    , @"E:\0_SourceCode\MsdialWorkbenchDemo\console_fastlc_demo"
+        //    , "-o"
+        //    , @"E:\0_SourceCode\MsdialWorkbenchDemo\console_fastlc_demo"
+        //    , "-m"
+        //    , @"E:\0_SourceCode\MsdialWorkbenchDemo\console_fastlc_demo\lib\msdial_console_param4lipidomics.txt"
+        //    , "-p"
+        //};
 
-            // lcms csv file import
-            //args = new string[]
-            //{
-            //    "lcms"
-            //    , "-i"
-            //    , @"D:\0_SourceCode\MsdialWorkbenchDemo\mzml_gnps\consoleapp_demo_csvimportfiles.csv"
-            //    , "-o"
-            //    , @"D:\0_SourceCode\MsdialWorkbenchDemo\mzml_gnps"
-            //    , "-m"
-            //    , @"D:\0_SourceCode\MsdialWorkbenchDemo\mzml_gnps\msdial_console_param4metabolomics.txt"
-            //    , "-p"
-            //};
+        // lcms csv file import
+        //args = new string[]
+        //{
+        //    "lcms"
+        //    , "-i"
+        //    , @"D:\0_SourceCode\MsdialWorkbenchDemo\mzml_gnps\consoleapp_demo_csvimportfiles.csv"
+        //    , "-o"
+        //    , @"D:\0_SourceCode\MsdialWorkbenchDemo\mzml_gnps"
+        //    , "-m"
+        //    , @"D:\0_SourceCode\MsdialWorkbenchDemo\mzml_gnps\msdial_console_param4metabolomics.txt"
+        //    , "-p"
+        //};
 
-            // dims
-            // args = new string[]
-            // {
-            //     "dims"
-            //     , "-i"
-            //     , @"\\mtbdt\Mtb_info\data\msdial_test\MSMSALL_Positive"
-            //     , "-o"
-            //     , @"\\mtbdt\Mtb_info\data\msdial_test\MSMSALL_Positive"
-            //     , "-m"
-            //     , @"\\mtbdt\Mtb_info\data\msdial_test\MSMSALL_Positive\dims_param.txt"
-            //     , "-p"
-            // };
+        // dims
+        // args = new string[]
+        // {
+        //     "dims"
+        //     , "-i"
+        //     , @"\\mtbdt\Mtb_info\data\msdial_test\MSMSALL_Positive"
+        //     , "-o"
+        //     , @"\\mtbdt\Mtb_info\data\msdial_test\MSMSALL_Positive"
+        //     , "-m"
+        //     , @"\\mtbdt\Mtb_info\data\msdial_test\MSMSALL_Positive\dims_param.txt"
+        //     , "-p"
+        // };
 
-            // imms
-            // args = new string[]
-            // {
-            //     "imms"
-            //     , "-i"
-            //     , @"D:\msdial_test\Msdial\out\infusion_neg_timsON_pasef_ibf"
-            //     , "-o"
-            //     , @"D:\msdial_test\Msdial\out\infusion_neg_timsON_pasef_ibf"
-            //     , "-m"
-            //     , @"D:\msdial_test\Msdial\out\infusion_neg_timsON_pasef_ibf\Msdial-imms-Param.txt"
-            //     , "-p"
-            // };
+        // imms
+        // args = new string[]
+        // {
+        //     "imms"
+        //     , "-i"
+        //     , @"D:\msdial_test\Msdial\out\infusion_neg_timsON_pasef_ibf"
+        //     , "-o"
+        //     , @"D:\msdial_test\Msdial\out\infusion_neg_timsON_pasef_ibf"
+        //     , "-m"
+        //     , @"D:\msdial_test\Msdial\out\infusion_neg_timsON_pasef_ibf\Msdial-imms-Param.txt"
+        //     , "-p"
+        // };
 
-            // lcimms
-            //args = new string[] {
-            //    "lcimms"
-            //    , "-i"
-            //    , @"D:\msdial_test\Msdial\out\IonMobilityDemoFiles\IonMobilityDemoFiles\IBF"
-            //    , "-o"
-            //    , @"D:\msdial_test\Msdial\out\IonMobilityDemoFiles\IonMobilityDemoFiles\IBF"
-            //    , "-m"
-            //    , @"D:\msdial_test\Msdial\out\IonMobilityDemoFiles\IonMobilityDemoFiles\IBF\lcimms_param.txt"
-            //    , "-p"
-            //};
+        // lcimms
+        //args = new string[] {
+        //    "lcimms"
+        //    , "-i"
+        //    , @"D:\msdial_test\Msdial\out\IonMobilityDemoFiles\IonMobilityDemoFiles\IBF"
+        //    , "-o"
+        //    , @"D:\msdial_test\Msdial\out\IonMobilityDemoFiles\IonMobilityDemoFiles\IBF"
+        //    , "-m"
+        //    , @"D:\msdial_test\Msdial\out\IonMobilityDemoFiles\IonMobilityDemoFiles\IBF\lcimms_param.txt"
+        //    , "-p"
+        //};
 
-            // moleculer networking
-            //args = new string[] {
-            //    "msn"
-            //    , "-i"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\data\ogawa_20240123\input_msn_neg"
-            //    , "-o"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\data\ogawa_20240123\output_msn_neg"
-            //    , "-m"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\data\ogawa_20240123\msn_param_20240127.txt"
-            //    , "-ionmode"
-            //    , "Negative"
-            //    , "-overwrite"
-            //    , "false"
-            //};
+        // moleculer networking
+        //args = new string[] {
+        //    "msn"
+        //    , "-i"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\data\ogawa_20240123\input_msn_neg"
+        //    , "-o"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\data\ogawa_20240123\output_msn_neg"
+        //    , "-m"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\data\ogawa_20240123\msn_param_20240127.txt"
+        //    , "-ionmode"
+        //    , "Negative"
+        //    , "-overwrite"
+        //    , "false"
+        //};
 
 
-            //args = new string[] {
-            //    "msn"
-            //    , "-i"
-            //    , @"\\165.93.102.222\Public\MetaboBankPeakPick\ogawa_20240123\msn_msp_neg\MSMS-Public_experimentspectra-neg-VS19.msp"
-            //    , "-o"
-            //    , @"\\165.93.102.222\Public\MetaboBankPeakPick\ogawa_20240123\msn_msp_neg\MSMS-Public_experimentspectra-neg-VS19_v2.edge"
-            //    , "-m"
-            //    , @"\\165.93.102.222\Public\MetaboBankPeakPick\ogawa_20240123\msn_param_20240401.txt"
-            //    , "-ionmode"
-            //    , "Negative"
-            //};
+        //args = new string[] {
+        //    "msn"
+        //    , "-i"
+        //    , @"\\165.93.102.222\Public\MetaboBankPeakPick\ogawa_20240123\msn_msp_neg\MSMS-Public_experimentspectra-neg-VS19.msp"
+        //    , "-o"
+        //    , @"\\165.93.102.222\Public\MetaboBankPeakPick\ogawa_20240123\msn_msp_neg\MSMS-Public_experimentspectra-neg-VS19_v2.edge"
+        //    , "-m"
+        //    , @"\\165.93.102.222\Public\MetaboBankPeakPick\ogawa_20240123\msn_param_20240401.txt"
+        //    , "-ionmode"
+        //    , "Negative"
+        //};
 
-            //args = new string[] {
-            //    "msn"
-            //    , "-i"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\brain_test_neg.msp"
-            //    , "-t"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_for_model.msp"
-            //    , "-o"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\brain2model.edge"
-            //    , "-m"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\msn_param_for_mapping.txt"
-            //    , "-ionmode"
-            //    , "Negative"
-            //};
+        //args = new string[] {
+        //    "msn"
+        //    , "-i"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\brain_test_neg.msp"
+        //    , "-t"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_for_model.msp"
+        //    , "-o"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\brain2model.edge"
+        //    , "-m"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\msn_param_for_mapping.txt"
+        //    , "-ionmode"
+        //    , "Negative"
+        //};
 
-            //args = new string[] {
-            //    "msn"
-            //    , "-i"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\casmi2022_neg.msp"
-            //    , "-t"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\MSMS-Public_experimentspectra-neg-VS19-curated.msp"
-            //    , "-o"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\casmi2model.edge"
-            //    , "-m"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\msn_param_for_mapping.txt"
-            //    , "-ionmode"
-            //    , "Negative"
-            //};
+        //args = new string[] {
+        //    "msn"
+        //    , "-i"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\casmi2022_neg.msp"
+        //    , "-t"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\MSMS-Public_experimentspectra-neg-VS19-curated.msp"
+        //    , "-o"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\casmi2model.edge"
+        //    , "-m"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\msp\neg\msn_param_for_mapping.txt"
+        //    , "-ionmode"
+        //    , "Negative"
+        //};
 
-            //args = new string[] {
-            //    "msn"
-            //    , "-i"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg.msp"
-            //    , "-o"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg.edge"
-            //    , "-m"
-            //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\msn_param_20240403.txt"
-            //    , "-ionmode"
-            //    , "Negative"
-            //};
+        //args = new string[] {
+        //    "msn"
+        //    , "-i"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg.msp"
+        //    , "-o"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg.edge"
+        //    , "-m"
+        //    , @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\msn_param_20240403.txt"
+        //    , "-ionmode"
+        //    , "Negative"
+        //};
 
-            //MoleculerSpectrumNetworkingTest.MergeNodeFiles(@"E:\6_Projects\PROJECT_MsMachineLearning\data\MTBKS157\peakpick\neg", @"E:\6_Projects\PROJECT_MsMachineLearning\msn\cytoscape_test\node.txt");
-            //MoleculerSpectrumNetworkingTest.MergeEdgeFiles(@"E:\6_Projects\PROJECT_MsMachineLearning\msn\result-2309271138", @"E:\6_Projects\PROJECT_MsMachineLearning\msn\cytoscape_test\edge.txt");
-            //EadAnnotationTest.Run(
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\pairfile.txt",
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\annofile.txt",
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\peaknamefile.txt",
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\resultexport.txt");
+        //MoleculerSpectrumNetworkingTest.MergeNodeFiles(@"E:\6_Projects\PROJECT_MsMachineLearning\data\MTBKS157\peakpick\neg", @"E:\6_Projects\PROJECT_MsMachineLearning\msn\cytoscape_test\node.txt");
+        //MoleculerSpectrumNetworkingTest.MergeEdgeFiles(@"E:\6_Projects\PROJECT_MsMachineLearning\msn\result-2309271138", @"E:\6_Projects\PROJECT_MsMachineLearning\msn\cytoscape_test\edge.txt");
+        //EadAnnotationTest.Run(
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\pairfile.txt",
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\annofile.txt",
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\peaknamefile.txt",
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\LightSplash\result\annotation\resultexport.txt");
 
-            //EadAnnotationTest.Run(
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\pairfile.txt",
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\annofile.txt",
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\peaknamefile.txt",
-            //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\resultexport.txt");
+        //EadAnnotationTest.Run(
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\pairfile.txt",
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\annofile.txt",
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\peaknamefile.txt",
+        //    @"E:\6_Projects\PAPERWORK_MSDIAL5\04_MSDIAL5_validation_eieio\StandardMix\KE14_output\resultexport.txt");
 
-            //MainProcess.CreateMsp4Model(
-            //    @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg.msp",
-            //    @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_filtered.edge",
-            //     @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_for_model.msp");
+        //MainProcess.CreateMsp4Model(
+        //    @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg.msp",
+        //    @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_filtered.edge",
+        //     @"E:\6_Projects\PROJECT_MsMachineLearning\msn\aging_lipidome\data\aging_lipidome_neg_for_model.msp");
 
-            MainProcess.Run(args);
-        }
+        var analysisArg = new Argument<string>("analysisType") {
+            Description = "gcms | lcms | lcimms | dims | imms | msn | imagegen"
+        };
+
+        var inputOpt = new Option<string>("--input", "-i") {
+            Description = "input folder or file",
+            Required = true,
+        };
+        var outputOpt = new Option<string>("--output", "-o") {
+            Description = "output folder",
+            Required = true,
+        };
+        var methodOpt = new Option<string>("--method", "-m") {
+            Description = "method file",
+            Required = true,
+        };
+        var projectOpt = new Option<bool>("--project", "-p") {
+            Description = "generate .mdproject file",
+        };
+        var targetFolderOpt = new Option<string?>("--targetFolder", "-t") {
+            Description = "target folder or file",
+        };
+        var targetMzOpt = new Option<string?>("--target") {
+            Description = "target m/z",
+        };
+        var ionmodeOpt = new Option<string>("--ionmode") {
+            Description = "ion mode",
+            Arity = ArgumentArity.ZeroOrOne,
+            DefaultValueFactory = _ => "Positive",
+        };
+        var overwriteOpt = new Option<bool>("--overwrite") {
+            Description = "overwrite",
+            Arity = ArgumentArity.ExactlyOne,
+            DefaultValueFactory = _ => false,
+        };
+        var allEdgeOpt = new Option<bool>("--allEdgeExport", "-a") {
+            Description = "export all edges",
+        };
+
+        var root = new RootCommand("MSDIAL Console Application");
+        root.Arguments.Add(analysisArg);
+        root.Options.Add(inputOpt);
+        root.Options.Add(outputOpt);
+        root.Options.Add(methodOpt);
+        root.Options.Add(projectOpt);
+        root.Options.Add(targetFolderOpt);
+        root.Options.Add(targetMzOpt);
+        root.Options.Add(ionmodeOpt);
+        root.Options.Add(overwriteOpt);
+        root.Options.Add(allEdgeOpt);
+
+        root.SetAction(parseResult => {
+            var analysisType = parseResult.GetRequiredValue(analysisArg);
+            var input = parseResult.GetResult(inputOpt);
+            var output = parseResult.GetResult(outputOpt);
+            var method = parseResult.GetResult(methodOpt);
+            var project = parseResult.GetResult(projectOpt);
+            var targetFolder = parseResult.GetResult(targetFolderOpt);
+            var targetMz = parseResult.GetResult(targetMzOpt);
+            var ionmode = parseResult.GetResult(ionmodeOpt);
+            var overwrite = parseResult.GetResult(overwriteOpt);
+            var allEdge = parseResult.GetResult(allEdgeOpt);
+
+            var argList = new List<string> { analysisType };
+            if (input?.GetValueOrDefault<string>() is { Length: > 0 } inputStr) { argList.Add("-i"); argList.Add(inputStr); }
+            if (method?.GetValueOrDefault<string>() is { Length: > 0 } methodStr) { argList.Add("-m"); argList.Add(methodStr); }
+            if (targetFolder?.GetValueOrDefault<string>() is { Length: > 0 } targetFolderStr) { argList.Add("-t"); argList.Add(targetFolderStr); }
+            if (output?.GetValueOrDefault<string>() is { Length: > 0 } outputStr) { argList.Add("-o"); argList.Add(outputStr); }
+            if (project?.GetValueOrDefault<bool>() ?? false) argList.Add("-p");
+            if (targetMz?.GetValueOrDefault<string>() is { Length: > 0 } targetMzStr) { argList.Add("-target"); argList.Add(targetMzStr); }
+            if (ionmode?.GetValueOrDefault<string>() is { Length: > 0 } ionmodeStr) { argList.Add("-ionmode"); argList.Add(ionmodeStr); }
+            if (overwrite?.GetValueOrDefault<bool>() ?? false) argList.Add("-overwrite");
+            if (allEdge?.GetValueOrDefault<bool>() ?? false) argList.Add("-a");
+
+            var rc = MainProcess.Run(argList.ToArray());
+            Environment.Exit(rc);
+        });
+
+        return root.Parse(args).Invoke();
     }
 }


### PR DESCRIPTION
## Why

The console application needs a structured command-line foundation so its processing modes can be invoked consistently and extended without maintaining ad hoc argument parsing.

## What changed

- Added the `System.CommandLine` package to the console test application.
- Migrated the entry point to a `RootCommand` with version handling.
- Registered GCMS, LCMS, LC-IM-MS, DIMS, IMMS, MSN, and EIC commands.
- Added EIC `raw` and `project` subcommands while preserving the existing `EicProcess` behavior.
- Kept Imaging image-generation functionality out of this PR for the follow-up Imaging work.

## Validation

- `dotnet build tests\MSDIAL5\MsdialCoreTestApp\MsdialCoreTestApp.csproj --framework net8 --no-restore`