### PR TITLE
Add imaging output command to console app

### DIFF
--- a/src/MSDIAL5/MsdialGuiApp/Model/Core/ProjectModel.cs
+++ b/src/MSDIAL5/MsdialGuiApp/Model/Core/ProjectModel.cs
@@ -161,7 +161,7 @@ namespace CompMs.App.Msdial.Model.Core
 
         private static async Task<ProjectModel> LoadMddatasetAsync(string  mddata, IMessageBroker broker) {
             var folder = Path.GetDirectoryName(mddata);
-            var title = Path.GetFileNameWithoutExtension(mddata);
+            var title = Path.GetFileName(mddata);
             var storage = new ProjectDataStorage(new ProjectParameter(DateTime.Now, folder, title + ".mdproject"));
             var deserializer = new MsdialIntegrateSerializer();
 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/ImageGenerationProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/ImageGenerationProcess.cs
@@ -1,0 +1,45 @@
+using CompMs.Common.DataObj;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Parameter;
+using CompMs.MsdialCore.Parser;
+using CompMs.MsdialIntegrate.Parser;
+using CompMs.RawDataHandler.Core;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CompMs.App.MsdialConsole.Process;
+
+internal sealed class ImageGenerationProcess
+{
+    public async Task RunAsync(string inputFile, CancellationToken token = default) {
+        var folder = Path.GetDirectoryName(inputFile);
+        var title = Path.GetFileName(inputFile);
+        var deserializer = new MsdialIntegrateSerializer();
+
+        IMsdialDataStorage<ParameterBase> storage;
+        using (IStreamManager manager = new DirectoryTreeStreamManager(folder!)) {
+            storage = await deserializer.LoadAsync(manager, title, folder, string.Empty).ConfigureAwait(false);
+            manager.Complete();
+        }
+
+        foreach (var analysis in storage.AnalysisFiles) {
+            var peaks = MsdialPeakSerializer.LoadChromatogramPeakFeatures(analysis.PeakAreaBeanInformationFilePath);
+
+            using RawDataAccess rawDataAccess = new(analysis.AnalysisFilePath, 0, getProfileData: true, isImagingMsData: true, isGuiProcess: false) {
+                DriftToleranceForPixelData = .1d
+            };
+            var frames = rawDataAccess.GetMaldiFrames();
+
+            if (frames is not null) {
+                var csvPath = Path.Combine(Path.GetDirectoryName(analysis.AnalysisFilePath) ?? folder!, Path.GetFileNameWithoutExtension(analysis.AnalysisFilePath) + "_frames.csv");
+                var lines = new[] { "PixelIndex,XIndex,YIndex" }.Concat(frames.Select((f, i) => $"{i},{f.XIndexPos},{f.YIndexPos}"));
+                File.WriteAllLines(csvPath, lines);
+            }
+
+            var raw2DElements = peaks.Select(peak => new Raw2DElement { Mz = peak.PrecursorMz, Drift = peak.PeakFeature.ChromXsTop.Drift.Value, }).ToList();
+            await rawDataAccess.SaveRawPixelFeaturesAsync(raw2DElements, frames, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/ImageGenerationProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/ImageGenerationProcess.cs
@@ -15,11 +15,14 @@ internal sealed class ImageGenerationProcess
 {
     public async Task RunAsync(string inputFile, CancellationToken token = default) {
         var folder = Path.GetDirectoryName(inputFile);
+        if (string.IsNullOrEmpty(folder)) {
+            folder = Directory.GetCurrentDirectory();
+        }
         var title = Path.GetFileName(inputFile);
         var deserializer = new MsdialIntegrateSerializer();
 
         IMsdialDataStorage<ParameterBase> storage;
-        using (IStreamManager manager = new DirectoryTreeStreamManager(folder!)) {
+        using (IStreamManager manager = new DirectoryTreeStreamManager(folder)) {
             storage = await deserializer.LoadAsync(manager, title, folder, string.Empty).ConfigureAwait(false);
             manager.Complete();
         }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -479,4 +479,18 @@ public static class MainProcess
         root.Subcommands.Add(eic);
     }
 
+    public static void SetImageGenerationCommand(Command root) {
+        var imagegen = new Command("imagegen", "Generate imaging output from an MS-DIAL project");
+        var input = new Option<FileInfo>("--input", "-i") {
+            Description = "MS-DIAL project file containing imaging analysis results",
+            Required = true,
+        };
+        imagegen.Options.Add(input);
+        imagegen.SetAction(parseResult => {
+            new ImageGenerationProcess().RunAsync(parseResult.GetRequiredValue(input).FullName).GetAwaiter().GetResult();
+            return 0;
+        });
+        root.Subcommands.Add(imagegen);
+    }
+
 }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -487,8 +487,19 @@ public static class MainProcess
         };
         imagegen.Options.Add(input);
         imagegen.SetAction(async (parseResult, token) => {
-            await new ImageGenerationProcess().RunAsync(parseResult.GetRequiredValue(input).FullName, token).ConfigureAwait(false);
-            return 0;
+            try {
+                await new ImageGenerationProcess().RunAsync(parseResult.GetRequiredValue(input).FullName, token).ConfigureAwait(false);
+                return 0;
+            }
+            catch (OperationCanceledException) {
+                Console.WriteLine("Cancelled.");
+                return 1;
+            }
+            catch (Exception ex) {
+                var msg = String.Format("{0} -- {1} -- {2}", ex.InnerException, ex.Message, ex.StackTrace);
+                Console.WriteLine(msg);
+                return 1;
+            }
         });
         root.Subcommands.Add(imagegen);
     }

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -486,8 +486,8 @@ public static class MainProcess
             Required = true,
         };
         imagegen.Options.Add(input);
-        imagegen.SetAction(parseResult => {
-            new ImageGenerationProcess().RunAsync(parseResult.GetRequiredValue(input).FullName).GetAwaiter().GetResult();
+        imagegen.SetAction(async (parseResult, token) => {
+            await new ImageGenerationProcess().RunAsync(parseResult.GetRequiredValue(input).FullName, token).ConfigureAwait(false);
             return 0;
         });
         root.Subcommands.Add(imagegen);

--- a/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
@@ -183,6 +183,7 @@ class Program {
         MainProcess.SetImmsCommand(root);
         MainProcess.SetMsnCommand(root);
         MainProcess.SetEicCommand(root);
+        MainProcess.SetImageGenerationCommand(root);
         var parseResult = root.Parse(args);
         return parseResult.InvokeAsync();
     }


### PR DESCRIPTION
## Why

Add the console-side imaging output workflow so imaging projects can be processed from the System.CommandLine-based CLI introduced in PR1.

## What changed

- Added `imagegen --input/-i` as an asynchronous CLI command.
- Added `ImageGenerationProcess` to load project analysis data, export MALDI frame coordinates, and save raw pixel features.
- Preserved cancellation through the command action into the imaging process.
- Updated project loading to retain the project file extension in its title.

## Validation

- `dotnet build tests\\MSDIAL5\\MsdialCoreTestApp\\MsdialCoreTestApp.csproj --framework net8 --no-restore`

The build completes successfully with existing package compatibility/security warnings.