### PR TITLE
Optimize batch dot-product state reset

### DIFF
--- a/src/Common/CommonStandard/Algorithm/Scoring/MsScanMatching.cs
+++ b/src/Common/CommonStandard/Algorithm/Scoring/MsScanMatching.cs
@@ -4506,15 +4506,17 @@ namespace CompMs.Common.Algorithm.Scoring {
                     if (!isExists[ID]) {
                         isExists[ID] = true;
                         summed[ID] = 0d;
+                        existsID[existsIDIdx++] = ID;
                     }
                     summed[ID] += intensity;
                 }
 
+                for (int l = 0; l < existsIDIdx; l++) {
+                    isExists[existsID[l]] = false;
+                }
+
                 p = k;
                 existsIDIdx = 0;
-                for (int l = 0; l < isExists.Length; l++) {
-                    isExists[l] = false;
-                }
                 while (p < mergedPeaks.Length && mergedPeaks[p].Mz < focus.Mz + bin) {
                     var (_, _, ID) = mergedPeaks[p++];
                     if (!isExists[ID]) {


### PR DESCRIPTION
## Summary
- optimize GetBatchSimpleDotProduct by tracking only spectrum IDs observed in the current mass window
- remove the full isExists array scan from the hot loop while preserving result semantics
- reuse the existing pooled ID buffer without adding allocations

## Performance opportunities identified
1. Replace the per-window full isExists clear in GetBatchSimpleDotProduct with sparse reset (implemented).
2. Add precursor-mass bucketing before pairwise molecular-network scoring.
3. Replace repeated OrderByDescending top-edge selection with bounded heaps.
4. Cache processed spectra across networking queries.
5. Avoid repeated Min/Max enumeration in node construction.
6. Use sorted/two-pointer mass windows for matching.
7. Reduce progress callback frequency in O(n²) edge generation.
8. Use buffered formatting for network exports.
9. Reuse temporary isotope-profile buffers.
10. Use hash-based membership for graph filtering.

## Validation
Focused MsScanMatchingTests: 16 passed.