### PR TITLE
Export LC-MS alignment quality assurance metrics

### DIFF
--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLongCSVExporter.cs
@@ -58,6 +58,24 @@ namespace CompMs.MsdialCore.Export
             }
         }
 
+        public void ExportValueWithFileMetadata(
+            Stream stream,
+            IReadOnlyList<AlignmentSpotProperty> spots,
+            IReadOnlyList<AnalysisFileBean> files,
+            IFileClassMetaAccessor fileMetaAccessor,
+            params (string label, IQuantValueAccessor accessor)[] quantAccessors) {
+            using var sw = new StreamWriter(stream, Encoding.ASCII, bufferSize: 4096, leaveOpen: true);
+            WriteValueHeader(sw, fileMetaAccessor.GetHeaders(), quantAccessors.Select(pair => pair.label));
+
+            var accessors = quantAccessors.Select(pair => pair.accessor).ToArray();
+            foreach (var spot in spots) {
+                WriteValueContent(sw, spot, files, fileMetaAccessor, accessors);
+                foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>()) {
+                    WriteValueContent(sw, driftSpot, files, fileMetaAccessor, accessors);
+                }
+            }
+        }
+
         private void WriteMetaHeader(StreamWriter writer, IReadOnlyList<string> header) {
             writer.WriteLine(string.Join(_separator, header));
         }
@@ -72,6 +90,10 @@ namespace CompMs.MsdialCore.Export
             writer.WriteLine(string.Join(_separator, new[] { "ID", "File", "Class", }.Concat(header)));
         }
 
+        private void WriteValueHeader(StreamWriter writer, IEnumerable<string> fileMetaHeader, IEnumerable<string> valueHeader) {
+            writer.WriteLine(string.Join(_separator, new[] { "ID", "File", }.Concat(fileMetaHeader).Concat(valueHeader)));
+        }
+
         private void WriteValueContent(StreamWriter writer, AlignmentSpotProperty spot, IReadOnlyList<AnalysisFileBean> files, IQuantValueAccessor[] quantAccessors) {
             var id = spot.MasterAlignmentID.ToString();
             var dicts = quantAccessors.Select(accessor => accessor.GetQuantValues(spot)).ToList();
@@ -80,6 +102,26 @@ namespace CompMs.MsdialCore.Export
                 var peak = lookupTable[file.AnalysisFileId].FirstOrDefault();
                 var peakFileName = peak?.FileName ?? file.AnalysisFileName;
                 IEnumerable<string> row = new[] { id, file.AnalysisFileName, file.AnalysisFileClass }
+                    .Concat(dicts.Select(dict => dict[peakFileName]))
+                    .Select(WrapField);
+                writer.WriteLine(string.Join(_separator, row));
+            }
+        }
+
+        private void WriteValueContent(
+            StreamWriter writer,
+            AlignmentSpotProperty spot,
+            IReadOnlyList<AnalysisFileBean> files,
+            IFileClassMetaAccessor fileMetaAccessor,
+            IQuantValueAccessor[] quantAccessors) {
+            var id = spot.MasterAlignmentID.ToString();
+            var dicts = quantAccessors.Select(accessor => accessor.GetQuantValues(spot)).ToList();
+            var lookupTable = spot.AlignedPeakProperties.ToLookup(peak => peak.FileID);
+            foreach (var file in files) {
+                var peak = lookupTable[file.AnalysisFileId].FirstOrDefault();
+                var peakFileName = peak?.FileName ?? file.AnalysisFileName;
+                IEnumerable<string> row = new[] { id, file.AnalysisFileName }
+                    .Concat(fileMetaAccessor.GetContent(file))
                     .Concat(dicts.Select(dict => dict[peakFileName]))
                     .Select(WrapField);
                 writer.WriteLine(string.Join(_separator, row));

--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -1414,6 +1414,7 @@ namespace CompMs.MsdialCore.Utility {
                 case "MZ": return Math.Round(spotProperty.Mass, 5).ToString();
                 case "SN": return Math.Round(spotProperty.PeakShape.SignalToNoise, 1).ToString();
                 case "MSMS": return spotProperty.MS2RawSpectrumID >= 0 ? "TRUE" : "FALSE";
+                case "Reference matched": return spotProperty.IsReferenceMatched() ? "TRUE" : "FALSE";
                 default: return string.Empty;
             }
         }
@@ -1432,6 +1433,7 @@ namespace CompMs.MsdialCore.Utility {
                 case "MZ": return spotProperty.Mass;
                 case "SN": return spotProperty.PeakShape.SignalToNoise;
                 case "MSMS": return spotProperty.MS2RawSpectrumID;
+                case "Reference matched": return spotProperty.IsReferenceMatched() ? 1d : 0d;
                 default: return -1;
             }
         }

--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -1414,7 +1414,7 @@ namespace CompMs.MsdialCore.Utility {
                 case "MZ": return Math.Round(spotProperty.Mass, 5).ToString();
                 case "SN": return Math.Round(spotProperty.PeakShape.SignalToNoise, 1).ToString();
                 case "MSMS": return spotProperty.MS2RawSpectrumID >= 0 ? "TRUE" : "FALSE";
-                case "Reference matched": return spotProperty.IsReferenceMatched() ? "TRUE" : "FALSE";
+                case "Reference matched": return IsReferenceMatchedName(spotProperty.Name) ? "TRUE" : "FALSE";
                 default: return string.Empty;
             }
         }
@@ -1433,9 +1433,21 @@ namespace CompMs.MsdialCore.Utility {
                 case "MZ": return spotProperty.Mass;
                 case "SN": return spotProperty.PeakShape.SignalToNoise;
                 case "MSMS": return spotProperty.MS2RawSpectrumID;
-                case "Reference matched": return spotProperty.IsReferenceMatched() ? 1d : 0d;
+                case "Reference matched": return IsReferenceMatchedName(spotProperty.Name) ? 1d : 0d;
                 default: return -1;
             }
+        }
+
+        public static bool IsReferenceMatchedName(string name) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                return false;
+            }
+            var value = name.TrimStart();
+            return !value.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase)
+                && !value.StartsWith("null", StringComparison.OrdinalIgnoreCase)
+                && !value.StartsWith("empty", StringComparison.OrdinalIgnoreCase)
+                && !value.StartsWith("w/o", StringComparison.OrdinalIgnoreCase)
+                && !value.StartsWith("RIKEN", StringComparison.OrdinalIgnoreCase);
         }
 
         public static List<ChromatogramPeakFeature> GetChromPeakFeatureObjectsIntegratingRtAndDriftData(List<ChromatogramPeakFeature> features) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -157,20 +157,26 @@ public sealed class LcmsProcess
             using var stream = File.Open(align_outputfile, FileMode.Create, FileAccess.Write);
             align_exporter.Export(stream, result.AlignmentSpotProperties, align_decResults, files, new MulticlassFileMetaAccessor(0), align_accessor, align_quantAccessor, align_stats);
 
-            var qaOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".qa.tsv");
-            using var qaStream = File.Open(qaOutputFile, FileMode.Create, FileAccess.Write);
-            new AlignmentLongCSVExporter().ExportValueWithFileMetadata(
-                qaStream,
-                result.AlignmentSpotProperties,
-                files,
-                new MulticlassFileMetaAccessor(0),
-                ("Height", new LegacyQuantValueAccessor("Height", storage.Parameter)),
-                ("RT", new LegacyQuantValueAccessor("RT", storage.Parameter)),
-                ("MZ", new LegacyQuantValueAccessor("MZ", storage.Parameter)),
-                ("SN", new LegacyQuantValueAccessor("SN", storage.Parameter)),
-                ("MSMS", new LegacyQuantValueAccessor("MSMS", storage.Parameter)),
-                ("Reference matched", new LegacyQuantValueAccessor("Reference matched", storage.Parameter)));
-            Console.WriteLine($"LC-MS quality-assurance matrix: {qaOutputFile}");
+            if (storage.Parameter.IsHeightMatrixExport) {
+                var qaOutputFolder = String.IsNullOrWhiteSpace(storage.Parameter.ExportFolderPath)
+                    ? outputFolder
+                    : storage.Parameter.ExportFolderPath;
+                Directory.CreateDirectory(qaOutputFolder);
+                var qaOutputFile = Path.Combine(qaOutputFolder, alignmentFile.FileName + ".qa.tsv");
+                using var qaStream = File.Open(qaOutputFile, FileMode.Create, FileAccess.Write);
+                new AlignmentLongCSVExporter().ExportValueWithFileMetadata(
+                    qaStream,
+                    result.AlignmentSpotProperties,
+                    files,
+                    new MulticlassFileMetaAccessor(0),
+                    ("Height", new LegacyQuantValueAccessor("Height", storage.Parameter)),
+                    ("RT", new LegacyQuantValueAccessor("RT", storage.Parameter)),
+                    ("MZ", new LegacyQuantValueAccessor("MZ", storage.Parameter)),
+                    ("SN", new LegacyQuantValueAccessor("SN", storage.Parameter)),
+                    ("MSMS", new LegacyQuantValueAccessor("MSMS", storage.Parameter)),
+                    ("Reference matched", new LegacyQuantValueAccessor("Reference matched", storage.Parameter)));
+                Console.WriteLine($"LC-MS quality-assurance matrix: {qaOutputFile}");
+            }
 
             var align_outputmspfile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdmsp");
             using var streammsp = File.Open(align_outputmspfile, FileMode.Create, FileAccess.Write);

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -157,6 +157,20 @@ public sealed class LcmsProcess
             using var stream = File.Open(align_outputfile, FileMode.Create, FileAccess.Write);
             align_exporter.Export(stream, result.AlignmentSpotProperties, align_decResults, files, new MulticlassFileMetaAccessor(0), align_accessor, align_quantAccessor, align_stats);
 
+            var qaOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".qa.tsv");
+            using var qaStream = File.Open(qaOutputFile, FileMode.Create, FileAccess.Write);
+            new AlignmentLongCSVExporter().ExportValueWithFileMetadata(
+                qaStream,
+                result.AlignmentSpotProperties,
+                files,
+                new MulticlassFileMetaAccessor(0),
+                ("Height", new LegacyQuantValueAccessor("Height", storage.Parameter)),
+                ("RT", new LegacyQuantValueAccessor("RT", storage.Parameter)),
+                ("MZ", new LegacyQuantValueAccessor("MZ", storage.Parameter)),
+                ("SN", new LegacyQuantValueAccessor("SN", storage.Parameter)),
+                ("Reference matched", new LegacyQuantValueAccessor("Reference matched", storage.Parameter)));
+            Console.WriteLine($"LC-MS quality-assurance matrix: {qaOutputFile}");
+
             var align_outputmspfile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdmsp");
             using var streammsp = File.Open(align_outputmspfile, FileMode.Create, FileAccess.Write);
             IAlignmentSpectraExporter align_mspexporter = new AlignmentMspExporter(storage.DataBaseMapper, storage.Parameter);

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -168,6 +168,7 @@ public sealed class LcmsProcess
                 ("RT", new LegacyQuantValueAccessor("RT", storage.Parameter)),
                 ("MZ", new LegacyQuantValueAccessor("MZ", storage.Parameter)),
                 ("SN", new LegacyQuantValueAccessor("SN", storage.Parameter)),
+                ("MSMS", new LegacyQuantValueAccessor("MSMS", storage.Parameter)),
                 ("Reference matched", new LegacyQuantValueAccessor("Reference matched", storage.Parameter)));
             Console.WriteLine($"LC-MS quality-assurance matrix: {qaOutputFile}");
 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/MainProcess.cs
@@ -11,6 +11,18 @@ namespace CompMs.App.MsdialConsole.Process;
 
 public static class MainProcess
 {
+    public const string LcmsAlignmentQaMatrixCapability = "lcms_alignment_qa_matrix";
+
+    public static void SetCapabilitiesCommand(Command root) {
+        var cmd = new Command("capabilities", "List machine-readable MS-DIAL Console capabilities");
+        cmd.SetAction(_ => {
+            Console.WriteLine("msdial.console.capabilities.v1");
+            Console.WriteLine(LcmsAlignmentQaMatrixCapability);
+            return 0;
+        });
+        root.Add(cmd);
+    }
+
     public static int CreateMsp4Model(string inputMspFile, string inputEdgeFile, string outputMspFile) {
         new MoleculerNetworkProcess().GetMsp4Model(inputMspFile, inputEdgeFile, outputMspFile);
         return 1;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Program.cs
@@ -184,6 +184,7 @@ class Program {
         MainProcess.SetMsnCommand(root);
         MainProcess.SetEicCommand(root);
         MainProcess.SetImageGenerationCommand(root);
+        MainProcess.SetCapabilitiesCommand(root);
         var parseResult = root.Parse(args);
         return parseResult.InvokeAsync();
     }

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentLongCSVExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentLongCSVExporterTests.cs
@@ -62,6 +62,42 @@ public class AlignmentLongCSVExporterTests
         Assert.AreEqual("ID\tFile\tClass\tHeight\r\n1\trenamed.raw\tclass\tvalue\r\n", Encoding.ASCII.GetString(stream.ToArray()));
     }
 
+    [TestMethod]
+    public void ExportValueWithFileMetadataIncludesRunOrderAndBatch()
+    {
+        var exporter = new AlignmentLongCSVExporter();
+        var file = new AnalysisFileBean
+        {
+            AnalysisFileId = 3,
+            AnalysisFileName = "qc.raw",
+            AnalysisFileClass = "QC",
+            AnalysisFileType = AnalysisFileType.QC,
+            AnalysisFileAnalyticalOrder = 17,
+            AnalysisBatch = 2,
+        };
+        var spot = new AlignmentSpotProperty
+        {
+            MasterAlignmentID = 9,
+            AlignedPeakProperties = new List<AlignmentChromPeakFeature>
+            {
+                new AlignmentChromPeakFeature { FileID = 3, FileName = "qc.raw" },
+            },
+        };
+        using var stream = new MemoryStream();
+
+        exporter.ExportValueWithFileMetadata(
+            stream,
+            new[] { spot },
+            new[] { file },
+            new MulticlassFileMetaAccessor(0),
+            ("Height", new FakeQuantValueAccessor()));
+
+        Assert.AreEqual(
+            "ID\tFile\tClass\tFile type\tInjection order\tBatch ID\tHeight\r\n" +
+            "9\tqc.raw\tQC\tQC\t17\t2\tvalue\r\n",
+            Encoding.ASCII.GetString(stream.ToArray()));
+    }
+
     private sealed class FakeFileMetaAccessor : IFileClassMetaAccessor
     {
         public IReadOnlyList<string> GetHeaders() => new[] { "Name", "Class" };

--- a/tests/MSDIAL5/MsdialCoreTests/Utility/DataAccessTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Utility/DataAccessTests.cs
@@ -102,4 +102,19 @@ public class DataAccessTests
             Assert.AreEqual(expected[i].Intensity, actual[i].Intensity);
         }
     }
+
+    [TestMethod()]
+    public void ReferenceMatchedExportUsesAnnotationName() {
+        foreach (var name in new[] { "", " ", "Unknown", "unknown feature", "null", "empty", "w/o MS2: compound", "RIKEN MS/MS" }) {
+            var peak = new AlignmentChromPeakFeature { Name = name };
+            Assert.AreEqual("FALSE", DataAccess.GetSpotValueAsString(peak, "Reference matched"), name);
+            Assert.AreEqual(0d, DataAccess.GetSpotValue(peak, "Reference matched"), name);
+        }
+
+        foreach (var name in new[] { "FA 16:0", "PC 34:1", "Reference compound" }) {
+            var peak = new AlignmentChromPeakFeature { Name = name };
+            Assert.AreEqual("TRUE", DataAccess.GetSpotValueAsString(peak, "Reference matched"), name);
+            Assert.AreEqual(1d, DataAccess.GetSpotValue(peak, "Reference matched"), name);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- export an LC-MS alignment-level `.qa.tsv` matrix for downstream quality assurance
- include per-file height, RT, m/z, raw S/N, MS/MS acquisition, and reference-match metrics
- derive reference-match status from the aligned peak name when the annotation flag is not propagated
- add exporter and data-access unit coverage

## Validation
- Release/net48 MS-DIAL Console build completed successfully
- targeted MsdialCore exporter and data-access tests passed
- validated the exported QA matrix with the seven-file Console FastLC WIFF demo dataset

## Dependency
This PR is intentionally based on `feature/console-retention-time-correction` so only the QA-specific commits are shown. It can be retargeted to `master` after #766 is merged.