### PR TITLE
Optimize retention-time scan lookup

### DIFF
--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -237,22 +237,11 @@ namespace CompMs.MsdialCore.Utility {
 
         // index access
         public static int GetScanStartIndexByRt(float focusedRt, float rtTol, IReadOnlyList<RawSpectrum> spectrumList) {
-
             var targetRt = focusedRt - rtTol;
-            int startIndex = 0, endIndex = spectrumList.Count - 1;
-
-            int counter = 0;
-            int limit = spectrumList.Count > 50000 ? 20 : 10;
-            while (counter < limit) {
-                if (spectrumList[startIndex].ScanStartTime <= targetRt && targetRt < spectrumList[(startIndex + endIndex) / 2].ScanStartTime) {
-                    endIndex = (startIndex + endIndex) / 2;
-                }
-                else if (spectrumList[(startIndex + endIndex) / 2].ScanStartTime <= targetRt && targetRt < spectrumList[endIndex].ScanStartTime) {
-                    startIndex = (startIndex + endIndex) / 2;
-                }
-                counter++;
-            }
-            return startIndex;
+            return SearchCollection.LowerBound(
+                spectrumList,
+                targetRt,
+                (spectrum, rt) => spectrum.ScanStartTime.CompareTo(rt));
         }
 
         public static int GetTargetCEIndexForMS2RawSpectrum(ChromatogramPeakFeature chromPeakFeature, double targetCE) {

--- a/tests/MSDIAL5/MsdialCoreTests/Utility/DataAccessTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Utility/DataAccessTests.cs
@@ -57,6 +57,21 @@ public class DataAccessTests
     }
 
     [TestMethod()]
+    public void GetScanStartIndexByRtReturnsLowerBound() {
+        var spectra = new[]
+        {
+            new RawSpectrum { ScanStartTime = 1f },
+            new RawSpectrum { ScanStartTime = 2f },
+            new RawSpectrum { ScanStartTime = 3f },
+            new RawSpectrum { ScanStartTime = 4f },
+        };
+
+        Assert.AreEqual(2, DataAccess.GetScanStartIndexByRt(3.5f, .5f, spectra));
+        Assert.AreEqual(0, DataAccess.GetScanStartIndexByRt(.5f, .5f, spectra));
+        Assert.AreEqual(spectra.Length, DataAccess.GetScanStartIndexByRt(5f, .5f, spectra));
+    }
+
+    [TestMethod()]
     public void GetAverageSpectrumPassIndexTest() {
         var spectra = new[]
         {


### PR DESCRIPTION
## Summary
- replace the fixed-iteration retention-time scan search with the shared exact lower-bound binary search
- add boundary coverage for before-range, in-range, and after-range retention times

## Performance improvements identified
1. Replace approximate fixed-iteration `GetScanStartIndexByRt` search with exact O(log n) lower-bound lookup (implemented here).
2. Avoid the two-pass scan in `GetMs2ValuePeaks` by growing result buffers or collecting matching scans once.
3. Add a lower-bound start index to `GetIonAbundanceOfMzInSpectrum` callers that repeatedly query the same spectrum.
4. Replace repeated `ContainsKey` plus indexer access in drift chromatogram aggregation with `TryGetValue`.
5. Replace `OrderBy(...).ToList()` on drift-bin values with a collection strategy that preserves sorted output without intermediate allocations.
6. Optimize `RetrieveIntensitiesFromMzValues` to use an upper bound and avoid rescanning boundary peaks.
7. Replace nested all-pairs peak matching in `SearchMatchedPeaks` with a mass-window sweep for sorted spectra.
8. Cache processed spectra in repeated molecular-network scoring paths.
9. Reuse pooled buffers for the matrix and temporary arrays in `Ms2ScanMatching.GetMatchedSpectraMatrix`.
10. Replace repeated LINQ materialization in average-spectrum accumulation with pre-sized mutable buffers.

## Validation
- `dotnet test .\tests\MSDIAL5\MsdialCoreTests\MsdialCoreTests.csproj --no-restore --filter FullyQualifiedName~GetScanStartIndexByRt`