### PR TITLE
Fix null RT correction selection path

### DIFF
--- a/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
+++ b/src/MSDIAL5/MsdialCore/Parameter/ParameterBase.cs
@@ -107,8 +107,6 @@ namespace CompMs.MsdialCore.Parameter
         [IgnoreMember]
         public string CompoundListForRtCorrectionPath { get => ReferenceFileParam.CompoundListForRtCorrectionPath; set => ReferenceFileParam.CompoundListForRtCorrectionPath = value; }
         [IgnoreMember]
-        public string RtCorrectionPeakSelectionFilePath { get => ReferenceFileParam.RtCorrectionPeakSelectionFilePath; set => ReferenceFileParam.RtCorrectionPeakSelectionFilePath = value; }
-        [IgnoreMember]
         public List<AdductIon> SearchedAdductIons { get => ReferenceFileParam.SearchedAdductIons; set => ReferenceFileParam.SearchedAdductIons = value; }
 
         // Export
@@ -538,7 +536,7 @@ namespace CompMs.MsdialCore.Parameter
             pStrings.Add(String.Join(": ", new string[] { "Isotope text DB file path", IsotopeTextDBFilePath.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Compounds library file path for target detection", CompoundListInTargetModePath.ToString() }));
             pStrings.Add(String.Join(": ", new string[] { "Compounds library file path for RT correction", CompoundListForRtCorrectionPath.ToString() }));
-            pStrings.Add(String.Join(": ", new string[] { "RT correction peak selection file path", RtCorrectionPeakSelectionFilePath.ToString() }));
+            pStrings.Add(String.Join(": ", new string[] { "RT correction peak selection file path", ReferenceFileParam.RtCorrectionPeakSelectionFilePath?.ToString() ?? string.Empty }));
             pStrings.Add(String.Join(": ", new string[] { "Searched adduct ions", String.Join(",", SearchedAdductIons.Select(n => n.AdductIonName).ToArray()) }));
 
             pStrings.Add("\r\n");

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -617,7 +617,7 @@ namespace CompMs.App.MsdialConsole.Parser
                         }
                     }
                     return true;
-                case "rt correction peak selection file path": param.RtCorrectionPeakSelectionFilePath = value; return true;
+                case "rt correction peak selection file path": param.ReferenceFileParam.RtCorrectionPeakSelectionFilePath = value; return true;
 
                 // Private version
                 case "is private version of tada":

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/EicProcess.cs
@@ -131,7 +131,7 @@ namespace CompMs.App.MsdialConsole.Process
             parameter.IonMode = ionMode;
             parameter.CompoundListForRtCorrectionPath = libraryFile.FullName;
             parameter.RetentionTimeCorrectionCommon.RetentionTimeCorrectionParam.ExcuteRtCorrection = true;
-            parameter.RtCorrectionPeakSelectionFilePath = selectionFile?.FullName ?? string.Empty;
+            parameter.ReferenceFileParam.RtCorrectionPeakSelectionFilePath = selectionFile?.FullName ?? string.Empty;
             var analysisFiles = CreateRtCorrectionAnalysisFiles(rawFiles, acquisitionType, outputFile.FullName);
             RetentionTimeCorrectionProcess.Prepare(
                 analysisFiles,

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/RetentionTimeCorrectionProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/RetentionTimeCorrectionProcess.cs
@@ -53,9 +53,9 @@ internal static class RetentionTimeCorrectionProcess {
         }
 
         Directory.CreateDirectory(outputFolder);
-        var selectionInput = parameter.RtCorrectionPeakSelectionFilePath;
+        var selectionInput = parameter.ReferenceFileParam.RtCorrectionPeakSelectionFilePath;
         var detectedRts = SnapshotDetectedRetentionTimes(analysisFiles);
-        if (!selectionInput.IsEmptyOrNull()) {
+        if (!string.IsNullOrEmpty(selectionInput)) {
             ApplySelectionFile(selectionInput, analysisFiles, parameter.RetentionTimeCorrectionCommon);
         }
         else {


### PR DESCRIPTION
RT correction can fail when the optional peak selection file path is null while `ParameterBase.ParametersAsText()` serializes parameters. This change makes parameter output null-safe and keeps the path owned by `ReferenceBaseParameter` instead of exposing another forwarding property on `ParameterBase`.

The console configuration parser and RT correction process now read and write the path through `ReferenceFileParam`, preserving the existing behavior for configured selection files.

Validation: `dotnet build tests\MSDIAL5\MsdialCoreTestApp\MsdialCoreTestApp.csproj --no-restore --verbosity minimal`