### PR TITLE
Fix console blank filtering threshold parsing

### DIFF
--- a/MsdialWorkbench.sln
+++ b/MsdialWorkbench.sln
@@ -115,6 +115,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsdialLcMsApi", "src\MSDIAL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsdialCoreTestApp", "tests\MSDIAL5\MsdialCoreTestApp\MsdialCoreTestApp.csproj", "{AA61D298-CAC4-4CFA-8F20-00CDB5ACA5BC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsdialCoreTestAppTests", "tests\MSDIAL5\MsdialCoreTestAppTests\MsdialCoreTestAppTests.csproj", "{0258C2E6-6496-431C-B87A-E81DA4895825}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsdialLcImMsApi", "src\MSDIAL5\MsdialLcImMsApi\MsdialLcImMsApi.csproj", "{0750647B-1DFC-49DC-ADFB-16235E22AA88}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsdialDimsCoreTests", "tests\MSDIAL5\MsdialDimsCoreTests\MsdialDimsCoreTests.csproj", "{98544BC7-3111-4A2B-B33D-72154A7CBC81}"
@@ -1322,6 +1324,26 @@ Global
 		{AA61D298-CAC4-4CFA-8F20-00CDB5ACA5BC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AA61D298-CAC4-4CFA-8F20-00CDB5ACA5BC}.Release|x64.ActiveCfg = Release|Any CPU
 		{AA61D298-CAC4-4CFA-8F20-00CDB5ACA5BC}.Release|x64.Build.0 = Release|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug vendor unsupported|Any CPU.ActiveCfg = Debug vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug vendor unsupported|Any CPU.Build.0 = Debug vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug vendor unsupported|x64.ActiveCfg = Debug vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug vendor unsupported|x64.Build.0 = Debug vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug with args|Any CPU.ActiveCfg = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug with args|Any CPU.Build.0 = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug with args|x64.ActiveCfg = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug with args|x64.Build.0 = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Debug|x64.Build.0 = Debug|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release vendor unsupported|Any CPU.ActiveCfg = Release vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release vendor unsupported|Any CPU.Build.0 = Release vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release vendor unsupported|x64.ActiveCfg = Release vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release vendor unsupported|x64.Build.0 = Release vendor unsupported|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release|x64.ActiveCfg = Release|Any CPU
+		{0258C2E6-6496-431C-B87A-E81DA4895825}.Release|x64.Build.0 = Release|Any CPU
 		{0750647B-1DFC-49DC-ADFB-16235E22AA88}.Debug vendor unsupported|Any CPU.ActiveCfg = Debug|Any CPU
 		{0750647B-1DFC-49DC-ADFB-16235E22AA88}.Debug vendor unsupported|Any CPU.Build.0 = Debug|Any CPU
 		{0750647B-1DFC-49DC-ADFB-16235E22AA88}.Debug vendor unsupported|x64.ActiveCfg = Debug vendor unsupported|Any CPU
@@ -1851,6 +1873,7 @@ Global
 		{1DC75792-8CC8-4274-B29C-B1023127356D} = {765ED28C-F085-4C96-8E81-683BBAE67B01}
 		{BE80842B-9747-4BFC-A5B4-1845051AA1D0} = {765ED28C-F085-4C96-8E81-683BBAE67B01}
 		{629337F8-F6E7-41F2-8DF7-FEBA23AF1222} = {765ED28C-F085-4C96-8E81-683BBAE67B01}
+		{0258C2E6-6496-431C-B87A-E81DA4895825} = {765ED28C-F085-4C96-8E81-683BBAE67B01}
 		{98544BC7-3111-4A2B-B33D-72154A7CBC81} = {765ED28C-F085-4C96-8E81-683BBAE67B01}
 		{B21FC8DB-0C0D-4313-AE05-53F328B5B827} = {765ED28C-F085-4C96-8E81-683BBAE67B01}
 		{2773E213-04B6-47E2-8277-F86D1D3DA50B} = {765ED28C-F085-4C96-8E81-683BBAE67B01}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -763,7 +763,12 @@ namespace CompMs.App.MsdialConsole.Parser
                     if (valueLower.ToLower() == "samplemaxoverblankave")
                         param.BlankFiltering = (BlankFiltering)Enum.Parse(typeof(BlankFiltering), valueLower, true);
                     return true;
-                case "sample max / blank average": if (float.TryParse(valueLower, out float sampleMaxOverBlankAverage)) param.SampleMaxOverBlankAverage = sampleMaxOverBlankAverage; return true;
+                case "sample max / blank average":
+                    if (float.TryParse(valueLower, out float sampleMaxOverBlankAverage)) {
+                        param.SampleMaxOverBlankAverage = sampleMaxOverBlankAverage;
+                        param.FoldChangeForBlankFiltering = sampleMaxOverBlankAverage;
+                    }
+                    return true;
                 case "sample average / blank average": if (float.TryParse(valueLower, out float sampleAverageOverBlankAverage)) param.SampleAverageOverBlankAverage = sampleAverageOverBlankAverage; return true;
                 case "keep reference matched metabolites": if (valueLower == "true" || valueLower == "false") param.IsKeepRefMatchedMetaboliteFeatures = bool.Parse(valueLower); return true;
                 case "keep suggested metabolites": if (valueLower == "true" || valueLower == "false") param.IsKeepSuggestedMetaboliteFeatures = bool.Parse(valueLower); return true;

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/ConfigParserTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/ConfigParserTests.cs
@@ -1,0 +1,21 @@
+using CompMs.App.MsdialConsole.Parser;
+using CompMs.MsdialLcmsApi.Parameter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MsdialCoreTestAppTests.Parser;
+
+[TestClass]
+public sealed class ConfigParserTests
+{
+    [TestMethod]
+    public void ReadCommonParameter_UpdatesActiveBlankFilteringFoldChange()
+    {
+        var parameter = new MsdialLcmsParameter();
+
+        var result = ConfigParser.ReadCommonParameter(parameter, "sample max / blank average", "7");
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(7f, parameter.SampleMaxOverBlankAverage);
+        Assert.AreEqual(7f, parameter.FoldChangeForBlankFiltering);
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the legacy `SampleMaxOverBlankAverage` value
- also apply the console value to `FoldChangeForBlankFiltering`, which the blank filter reads
- add a regression test for custom sample-max/blank-average thresholds
- include the existing console test project in the solution so CI runs the regression test

## Root cause

The console parser stored `Sample max / blank average` only in the legacy property, while alignment filtering reads `FoldChangeForBlankFiltering`. Both default to 5, hiding the mismatch until a custom threshold is configured.

## Validation

- `dotnet test tests/MSDIAL5/MsdialCoreTestAppTests/MsdialCoreTestAppTests.csproj --configuration "Debug vendor unsupported"` (5 tests passed)
