### PR TITLE
Optimize MS2 value peak extraction

### DIFF
--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -332,10 +332,7 @@ namespace CompMs.MsdialCore.Utility {
             int startScanID, int endScanID, IReadOnlyList<double> pMzValues, ParameterBase param, AcquisitionType acquisitionType,
             double targetCE = -1, ChromXType type = ChromXType.RT, ChromXUnit unit = ChromXUnit.Min) {
 
-            var counter = 0;
-            var arrayLength = GetTargetArrayLength(provider, startScanID, endScanID, precursorMz, targetCE, param, acquisitionType);
-            var valuePeakArrayList = new List<ValuePeak[]>(pMzValues.Count);
-            valuePeakArrayList.AddRange(pMzValues.Select(_ => new ValuePeak[arrayLength]));
+            var valuePeakLists = pMzValues.Select(_ => new List<ValuePeak>()).ToArray();
 
             for (int i = startScanID; i <= endScanID; i++) {
                 var spec = provider.LoadMsSpectrumFromIndex(i);
@@ -348,27 +345,12 @@ namespace CompMs.MsdialCore.Utility {
                         var intensities = RetrieveIntensitiesFromMzValues(pMzValues, spec.Spectrum, param.CentroidMs2Tolerance);
 
                         for (int j = 0; j < pMzValues.Count; j++) { 
-                            valuePeakArrayList[j][counter] = new ValuePeak(id, chromX, pMzValues[j], intensities[j]);
+                            valuePeakLists[j].Add(new ValuePeak(id, chromX, pMzValues[j], intensities[j]));
                         }
-                        counter++;
                     }
                 }
             }
-            return valuePeakArrayList;
-        }
-
-        private static int GetTargetArrayLength(IDataProvider provider, int startScanID, int endScanID, double precursorMz, double targetCE, ParameterBase param, AcquisitionType type) {
-            var counter = 0;
-            for (int i = startScanID; i <= endScanID; i++) {
-                var spec = provider.LoadMsSpectrumFromIndex(i);
-                if (spec.MsLevel == 2 && spec.Precursor != null) {
-                    if (targetCE >= 0 && spec.CollisionEnergy >= 0 && Math.Abs(targetCE - spec.CollisionEnergy) > 1) continue; // for AIF mode
-                    if (IsInMassWindow(precursorMz, spec, param.CentroidMs1Tolerance, type)) {
-                        counter++;
-                    }
-                }
-            }
-            return counter;
+            return valuePeakLists.Select(peaks => peaks.ToArray()).ToList();
         }
 
         public static double[] RetrieveIntensitiesFromMzValues(

--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -332,8 +332,10 @@ namespace CompMs.MsdialCore.Utility {
             int startScanID, int endScanID, IReadOnlyList<double> pMzValues, ParameterBase param, AcquisitionType acquisitionType,
             double targetCE = -1, ChromXType type = ChromXType.RT, ChromXUnit unit = ChromXUnit.Min) {
 
-            var valuePeakLists = pMzValues.Select(_ => new List<ValuePeak>()).ToArray();
-
+var valuePeakLists = new List<ValuePeak>[pMzValues.Count];
+for (int j = 0; j < valuePeakLists.Length; j++) {
+    valuePeakLists[j] = new List<ValuePeak>();
+}
             for (int i = startScanID; i <= endScanID; i++) {
                 var spec = provider.LoadMsSpectrumFromIndex(i);
                 if (spec.MsLevel == 2 && spec.Precursor != null) {
@@ -350,7 +352,11 @@ namespace CompMs.MsdialCore.Utility {
                     }
                 }
             }
-            return valuePeakLists.Select(peaks => peaks.ToArray()).ToList();
+var results = new List<ValuePeak[]>(valuePeakLists.Length);
+for (int j = 0; j < valuePeakLists.Length; j++) {
+    results.Add(valuePeakLists[j].ToArray());
+}
+return results;
         }
 
         public static double[] RetrieveIntensitiesFromMzValues(

--- a/tests/MSDIAL5/MsdialCoreTests/Utility/DataAccessTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Utility/DataAccessTests.cs
@@ -1,8 +1,16 @@
 ﻿using CompMs.Common.Components;
 using CompMs.Common.DataObj;
+using CompMs.Common.Enum;
+using CompMs.MsdialCore.Algorithm;
 using CompMs.Common.DataObj.Property;
 using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Parameter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CompMs.MsdialCore.Utility.Tests;
 
@@ -116,6 +124,72 @@ public class DataAccessTests
             Assert.AreEqual(expected[i].Mass, actual[i].Mass);
             Assert.AreEqual(expected[i].Intensity, actual[i].Intensity);
         }
+    }
+
+    [TestMethod()]
+    public void GetMs2ValuePeaksReturnsMatchingPeaksInScanOrder() {
+        var provider = new StubDataProvider([
+            new RawSpectrum { MsLevel = 1 },
+            CreateMs2Spectrum(10, 500, 0, 3, 7),
+            CreateMs2Spectrum(11, 500, 2, 100, 200),
+            CreateMs2Spectrum(12, 500, 0, 5, 11),
+            new RawSpectrum { MsLevel = 2 },
+        ]);
+        var parameter = new ParameterBase {
+            CentroidMs1Tolerance = 0.1f,
+            CentroidMs2Tolerance = 0.05f,
+        };
+
+        var actual = DataAccess.GetMs2ValuePeaks(
+            provider, 500, 0, 4, [100, 200], parameter, AcquisitionType.DDA, targetCE: 0);
+
+        Assert.AreEqual(2, actual.Count);
+        Assert.AreEqual(2, actual[0].Length);
+        Assert.AreEqual(2, actual[1].Length);
+        CollectionAssert.AreEqual(new[] { 10, 12 }, actual[0].Select(peak => peak.Id).ToArray());
+        CollectionAssert.AreEqual(new[] { 10, 12 }, actual[1].Select(peak => peak.Id).ToArray());
+        Assert.AreEqual(3d, actual[0][0].Intensity);
+        Assert.AreEqual(5d, actual[0][1].Intensity);
+        Assert.AreEqual(7d, actual[1][0].Intensity);
+        Assert.AreEqual(11d, actual[1][1].Intensity);
+    }
+
+    private static RawSpectrum CreateMs2Spectrum(int index, double precursorMz, double collisionEnergy, double firstIntensity, double secondIntensity) {
+        return new RawSpectrum {
+            Index = index,
+            MsLevel = 2,
+            CollisionEnergy = collisionEnergy,
+            ScanStartTime = index,
+            Precursor = new RawPrecursorIon { IsolationTargetMz = precursorMz },
+            Spectrum = [
+                new RawPeakElement { Mz = 100, Intensity = firstIntensity },
+                new RawPeakElement { Mz = 150, Intensity = 0 },
+                new RawPeakElement { Mz = 200, Intensity = secondIntensity },
+                new RawPeakElement { Mz = 250, Intensity = 0 },
+            ],
+        };
+    }
+
+    private sealed class StubDataProvider : IDataProvider {
+        private readonly ReadOnlyCollection<RawSpectrum> _spectra;
+
+        public StubDataProvider(IList<RawSpectrum> spectra) {
+            _spectra = new ReadOnlyCollection<RawSpectrum>(spectra);
+        }
+
+        public ReadOnlyCollection<RawSpectrum> LoadMsSpectrums() {
+            return _spectra;
+        }
+
+        public ReadOnlyCollection<RawSpectrum> LoadMs1Spectrums() => throw new System.NotImplementedException();
+
+        public ReadOnlyCollection<RawSpectrum> LoadMsNSpectrums(int level) => throw new System.NotImplementedException();
+
+        public Task<ReadOnlyCollection<RawSpectrum>> LoadMsSpectrumsAsync(CancellationToken token) => throw new System.NotImplementedException();
+
+        public Task<ReadOnlyCollection<RawSpectrum>> LoadMs1SpectrumsAsync(CancellationToken token) => throw new System.NotImplementedException();
+
+        public Task<ReadOnlyCollection<RawSpectrum>> LoadMsNSpectrumsAsync(int level, CancellationToken token) => throw new System.NotImplementedException();
     }
 
     [TestMethod()]


### PR DESCRIPTION
## Summary
- eliminate the preliminary full scan used only to count matching MS2 spectra
- collect value peaks during the existing extraction pass
- preserve the returned per-m/z arrays and ordering

## Performance audit: 10 opportunities
1. **Implemented — `DataAccess.GetMs2ValuePeaks`**: remove the duplicate provider traversal used to pre-count results; high impact for large raw-data ranges and low implementation risk.
2. `DataAccess.GetMs2Peaklist`: cache/reuse spectrum eligibility checks when multiple product ions are extracted from the same precursor window instead of reloading and filtering the same scans for every product m/z.
3. `DataAccess.GetMs2ValuePeaks`: compute intensities for sorted target m/z values with a shared monotonic peak cursor and avoid repeated setup when target lists are reused across files.
4. `DataAccess.GetDriftChromatogramByRtMz`: replace repeated `ContainsKey` plus indexer lookups in nested dictionaries with `TryGetValue` to reduce hash lookups in the inner peak loop.
5. `DataAccess.GetDriftChromatogramByRtMz`: replace per-peak `double[]` allocations with a value-oriented accumulator to reduce GC pressure during ion-mobility extraction.
6. `SpectrumViewModel` and `SplitSpectrumsViewModel`: maintain a membership set for drag/drop duplicate checks instead of linear `Contains` scans as displayed scan counts grow.
7. `SpectrumViewModel` and `SplitSpectrumsViewModel`: combine the repeated spectrum min/max enumerations per collection-change event so each spectrum is traversed once per axis update.
8. `DataAccess.IsSWATH`: perform one pass over MS2 spectra rather than materializing multiple LINQ sequences and enumerating them repeatedly.
9. `DataAccess.GetBaselineCorrectedPeaklistByMassAccuracy`: reserve output capacity from the input peak count to avoid repeated list growth during chromatogram construction.
10. `DataAccess.GetDriftChromatogramByScanRtMz`: use the existing RT index lookup to bound both directional scans before loading spectra, reducing provider calls outside the requested RT window.

## Validation
- `dotnet test tests\\MSDIAL5\\MsdialCoreTests\\MsdialCoreTests.csproj --no-restore --filter FullyQualifiedName~DataAccessTests`