### PR TITLE
Suppress redundant raw-read logs during LC-MS alignment

### DIFF
--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/ConsoleLineFilter.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/ConsoleLineFilter.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace CompMs.App.MsdialConsole.Process;
+
+public static class ConsoleLineFilter
+{
+    private static readonly object SyncRoot = new object();
+
+    public static IDisposable SuppressExact(params string[] lines) {
+        return new SuppressionScope(lines);
+    }
+
+    private sealed class SuppressionScope : IDisposable
+    {
+        private readonly TextWriter _original;
+        private bool _disposed;
+
+        public SuppressionScope(IEnumerable<string> lines) {
+            Monitor.Enter(SyncRoot);
+            try {
+                _original = Console.Out;
+                Console.SetOut(new ExactLineSuppressingTextWriter(_original, lines));
+            }
+            catch {
+                Monitor.Exit(SyncRoot);
+                throw;
+            }
+        }
+
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+            Console.SetOut(_original);
+            _disposed = true;
+            Monitor.Exit(SyncRoot);
+        }
+    }
+}
+
+internal sealed class ExactLineSuppressingTextWriter : TextWriter
+{
+    private readonly TextWriter _inner;
+    private readonly HashSet<string> _suppressed;
+
+    public ExactLineSuppressingTextWriter(TextWriter inner, IEnumerable<string> suppressed) {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _suppressed = new HashSet<string>(suppressed ?? throw new ArgumentNullException(nameof(suppressed)), StringComparer.Ordinal);
+    }
+
+    public override Encoding Encoding => _inner.Encoding;
+    public override IFormatProvider FormatProvider => _inner.FormatProvider;
+
+    public override void Flush() => _inner.Flush();
+    public override void Write(char value) => _inner.Write(value);
+    public override void Write(string? value) => _inner.Write(value);
+    public override void WriteLine() => _inner.WriteLine();
+
+    public override void WriteLine(string? value) {
+        if (!_suppressed.Contains(value ?? string.Empty)) {
+            _inner.WriteLine(value);
+        }
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -147,7 +147,10 @@ public sealed class LcmsProcess
                 Console.WriteLine("Alignment light mode: streaming peak matrix, file-backed alignment deconvolution access, GUI chromatogram serialization, GUI alignment object serialization, and ion-abundance correlation links are disabled; text exports remain enabled.");
                 Console.WriteLine("Alignment started.");
                 var lightRunner = new LcmsAlignmentLightRunner(storage, evaluator, providerFactory, CreateConsoleProgressReporter("Alignment"));
-                var lightResult = lightRunner.Run(files, alignmentFile, alignmentLightPeakStore!);
+                LcmsAlignmentLightResult lightResult;
+                using (ConsoleLineFilter.SuppressExact("Reading data...")) {
+                    lightResult = lightRunner.Run(files, alignmentFile, alignmentLightPeakStore!);
+                }
                 result = lightResult.Container;
                 align_decResults = lightResult.MsdecResults;
                 alignmentLightMsdecResults = lightResult.MsdecResults as IDisposable;
@@ -159,7 +162,9 @@ public sealed class LcmsProcess
                 factory.Progress = CreateConsoleProgressReporter("Alignment");
                 var aligner = factory.CreatePeakAligner();
                 Console.WriteLine("Alignment started.");
-                result = aligner.Alignment(files, alignmentFile, serializer);
+                using (ConsoleLineFilter.SuppressExact("Reading data...")) {
+                    result = aligner.Alignment(files, alignmentFile, serializer);
+                }
                 Console.WriteLine("Alignment finished.");
                 result.Save(alignmentFile);
                 align_decResults = LoadRepresentativeDeconvolutions(storage, result.AlignmentSpotProperties).ToList();

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/Process/ConsoleLineFilterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/Process/ConsoleLineFilterTests.cs
@@ -1,0 +1,41 @@
+using CompMs.App.MsdialConsole.Process;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace MsdialCoreTestAppTests.Process;
+
+[TestClass]
+public sealed class ConsoleLineFilterTests
+{
+    [TestMethod]
+    public void SuppressExact_HidesOnlyTheRequestedLineWithinScope() {
+        var original = Console.Out;
+        var output = new StringWriter();
+        try {
+            Console.SetOut(output);
+            Console.WriteLine("Reading data...");
+            using (ConsoleLineFilter.SuppressExact("Reading data...")) {
+                Console.WriteLine("Reading data...");
+                Console.WriteLine("Alignment progress: 50%");
+                Console.WriteLine("Reading data... additional detail");
+            }
+            Console.WriteLine("Reading data...");
+        }
+        finally {
+            Console.SetOut(original);
+        }
+
+        var lines = output.ToString().Split(
+            new[] { Environment.NewLine },
+            StringSplitOptions.RemoveEmptyEntries);
+        CollectionAssert.AreEqual(
+            new[] {
+                "Reading data...",
+                "Alignment progress: 50%",
+                "Reading data... additional detail",
+                "Reading data...",
+            },
+            lines);
+    }
+}


### PR DESCRIPTION
## Summary
- suppress only the exact Reading data... line while LC-MS alignment is running
- preserve peak-picking raw-read messages, alignment progress, warnings, and detailed messages
- apply the same scoped behavior to standard and alignment-light paths
- add a focused Console output filter test

## Validation
- dotnet test tests/MSDIAL5/MsdialCoreTestAppTests/MsdialCoreTestAppTests.csproj -c Release --filter FullyQualifiedName~ConsoleLineFilterTests
- dotnet build tests/MSDIAL5/MsdialCoreTestApp/MsdialCoreTestApp.csproj -c Release -f net48 --no-restore
- FastLC WIFF demo (7 files): 14 Reading data... lines before alignment, 0 inside the alignment interval, and 11 alignment progress lines from 6% through 100%
