### PR TITLE
Optimize MS2 spectrum peak shrinking hot path

### DIFF
--- a/src/Common/CommonStandard/Algorithm/Scoring/Ms2ScanMatching.cs
+++ b/src/Common/CommonStandard/Algorithm/Scoring/Ms2ScanMatching.cs
@@ -44,7 +44,7 @@ namespace CompMs.Common.Algorithm.Scoring
         private List<SpectrumPeak> ShrinkPeaks(List<SpectrumPeak> reference) {
             var result = new List<SpectrumPeak>(reference.Count);
             foreach (var peak in reference) {
-                if (result.Any() && peak.Mass - result[result.Count - 1].Mass <= _searchParameter.Ms2Tolerance) {
+                if (result.Count > 0 && peak.Mass - result[result.Count - 1].Mass <= _searchParameter.Ms2Tolerance) {
                     result[result.Count - 1].Intensity += peak.Intensity;
                     result[result.Count - 1].SpectrumComment |= peak.SpectrumComment;
                     if (string.IsNullOrEmpty(result[result.Count - 1].Comment)) {


### PR DESCRIPTION
## Summary
- replace `result.Any()` with constant-time `result.Count > 0` in `Ms2ScanMatching.ShrinkPeaks`
- preserve peak merging behavior while avoiding repeated LINQ enumeration in the MS2 matching hot path

## Ten performance improvement candidates
1. Optimize `Ms2ScanMatching.ShrinkPeaks` empty-result check — high impact/trivial effort; implemented here.
2. Cache SpectrumViewer mass/intensity ranges — medium-high impact/low effort; avoid repeated Min/Max traversals.
3. Use a HashSet for SpectrumViewer duplicate-drop checks — medium impact/low effort.
4. Avoid sorting every MolecularNetworking edge before degree filtering — high impact for large networks/low-medium effort.
5. Index chemical ontology membership checks — medium-high impact/medium effort.
6. Reduce intermediate allocations in spectrum normalization — medium impact/low effort.
7. Improve MsScanMatching candidate availability indexing — high impact for large peak sets/medium effort.
8. Reuse isotope-profile ordering — medium impact/medium effort.
9. Replace repeated enumerable Count calls — low-medium impact/low effort.
10. Batch SpectrumViewer axis recalculation notifications — medium UI impact/medium effort.

## Validation
- `dotnet restore tests\Common\CommonStandardTests\CommonStandardTests.csproj`
- `dotnet test tests\Common\CommonStandardTests\CommonStandardTests.csproj --no-restore --verbosity minimal`