### PR TITLE
Make library downloads opt-in during builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ However, if the discussion is something that cannot be done openly by any means,
 8. Select `MsdialGuiApp` from the `Startup Projects` pull-down menu.
 9. Click `▶ MsdialGuiApp` button on the right side of 8.
 
+By default, building the project does not download the large library files. To download missing library files during a build, pass the MSBuild property explicitly:
+
+```powershell
+dotnet build .\src\MSDIAL5\MsdialGuiApp\MsdialGuiApp.csproj -p:DownloadLibraries=true
+```
+
 ### Important Note
 The 'Debug/Release vendor unsupported' version is a special configuration designed for the purpose of source code distribution.
 Due to licensing restrictions, this version cannot read proprietary data formats from mass spectrometry manufacturers.
@@ -65,4 +71,3 @@ The source code is licensed under GNU LESSER GENERAL PUBLIC LICENSE (LGPL) versi
 See LGPL.txt for full text of the license.
 This software uses third-party software.
 A full list of third-party software licenses in MsdialWorkbench is in the file THIRD-PARTY-LICENSE-README.txt.
-

--- a/src/MSDIAL4/MsDial/MSDIAL.csproj
+++ b/src/MSDIAL4/MsDial/MSDIAL.csproj
@@ -269,11 +269,12 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <PropertyGroup>
       <Lbm2Url>http://prime.psc.riken.jp/compms/msdial/download/lipidblast/Msp20221205132019_conventional_converted.lbm2</Lbm2Url>
+      <DownloadLibraries Condition="'$(DownloadLibraries)' == ''">false</DownloadLibraries>
     </PropertyGroup>
     <ItemGroup>
       <_DeployToItem Include="$(TargetDir)\*.lbm*" />
     </ItemGroup>
-    <DownloadFile SourceUrl="$(Lbm2Url)" DestinationFolder="$(TargetDir)" Condition="!Exists('%(_DeployToItem.FullPath)')" ContinueOnError="true"/>
+    <DownloadFile SourceUrl="$(Lbm2Url)" DestinationFolder="$(TargetDir)" Condition="!Exists('%(_DeployToItem.FullPath)') AND '$(DownloadLibraries)' == 'true'" ContinueOnError="true"/>
     <Exec Command="xcopy &quot;$(ProjectDir)CytoscapeLocalBrowser&quot; &quot;$(TargetDir)CytoscapeLocalBrowser&quot; /D/E/C/I/H/Y" />
   </Target>
 </Project>

--- a/src/MSDIAL5/MsdialGuiApp/MsdialGuiApp.csproj
+++ b/src/MSDIAL5/MsdialGuiApp/MsdialGuiApp.csproj
@@ -15,6 +15,7 @@
 		<MsdUrl>https://zenodo.org/records/12618137/files/MINEs-StructureDB-vs1.msd</MsdUrl>
 		<EsdUrl>https://zenodo.org/records/12618137/files/MsfinderStructureDB-VS15.esd</EsdUrl>
 		<EtmUrl>https://zenodo.org/records/12618137/files/MSMS-DBs-vs1.etm</EtmUrl>
+		<DownloadLibraries Condition="'$(DownloadLibraries)' == ''">false</DownloadLibraries>
     <Nullable>enable</Nullable>
 	</PropertyGroup>
 	<Target Name="DownloadContentFiles" BeforeTargets="Build">
@@ -25,11 +26,11 @@
 			<_DeployToItemEsd Include="$(OutputPath)\Resources\msfinderLibrary\*.esd" />
 			<_DeployToItemEtm Include="$(OutputPath)\Resources\msfinderLibrary\*.etm" />
 		</ItemGroup>
-		<DownloadFile SourceUrl="$(Lbm2Url)" DestinationFolder="$(OutputPath)" Condition="!Exists('%(_DeployToItem.FullPath)') AND '$(SkipLibraryDownload)' == ''" />
-		<DownloadFile SourceUrl="$(IcdUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemIcd.FullPath)') AND '$(SkipLibraryDownload)' == ''" />
-		<DownloadFile SourceUrl="$(MsdUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemMsd.FullPath)') AND '$(SkipLibraryDownload)' == ''" />
-		<DownloadFile SourceUrl="$(EsdUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemEsd.FullPath)') AND '$(SkipLibraryDownload)' == ''" />
-		<DownloadFile SourceUrl="$(EtmUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemEtm.FullPath)') AND '$(SkipLibraryDownload)' == ''" />
+		<DownloadFile SourceUrl="$(Lbm2Url)" DestinationFolder="$(OutputPath)" Condition="!Exists('%(_DeployToItem.FullPath)') AND '$(DownloadLibraries)' == 'true'" />
+		<DownloadFile SourceUrl="$(IcdUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemIcd.FullPath)') AND '$(DownloadLibraries)' == 'true'" />
+		<DownloadFile SourceUrl="$(MsdUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemMsd.FullPath)') AND '$(DownloadLibraries)' == 'true'" />
+		<DownloadFile SourceUrl="$(EsdUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemEsd.FullPath)') AND '$(DownloadLibraries)' == 'true'" />
+		<DownloadFile SourceUrl="$(EtmUrl)" DestinationFolder="$(OutputPath)\Resources\msfinderLibrary" Condition="!Exists('%(_DeployToItemEtm.FullPath)') AND '$(DownloadLibraries)' == 'true'" />
 	</Target>
 	<PropertyGroup>
 		<HighEntropyVA>false</HighEntropyVA>
@@ -230,28 +231,28 @@
     </ItemGroup>
 
 	<ItemGroup>
-		<None Update="Resources\msfinderLibrary\ChemOntologyDB_vs2.cho" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\ChemOntologyDB_vs2.cho" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\EiFragmentDB_vs1.eif" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\EiFragmentDB_vs1.eif" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\EIMS-DBs-vs1.egm" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\EIMS-DBs-vs1.egm" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\MsfinderFormulaDB-VS13.efd" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\MsfinderFormulaDB-VS13.efd" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\Msp20201228141756_converted.lbm2" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\Msp20201228141756_converted.lbm2" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\NeutralLossDB_vs2.ndb" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\NeutralLossDB_vs2.ndb" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\ProductIonLib_vs1.pid" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\ProductIonLib_vs1.pid" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-		<None Update="Resources\msfinderLibrary\UniqueFragmentLib_vs1.ufd" Condition="'$(SkipLibraryDownload)' == ''">
+		<None Update="Resources\msfinderLibrary\UniqueFragmentLib_vs1.ufd" Condition="'$(DownloadLibraries)' == 'true'">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>

--- a/src/MSFINDER/MsfinderCommonStandard/MsfinderCommonStandard.csproj
+++ b/src/MSFINDER/MsfinderCommonStandard/MsfinderCommonStandard.csproj
@@ -8,6 +8,7 @@
 	<MsdUrl>http://prime.psc.riken.jp/compms/code/MINEs-StructureDB-vs1.msd</MsdUrl>
 	<EsdUrl>http://prime.psc.riken.jp/compms/code/MsfinderStructureDB-VS15.esd</EsdUrl>
   <EtmUrl>http://prime.psc.riken.jp/compms/code/MSMS-DBs-vs1.etm</EtmUrl>
+  <DownloadLibraries Condition="'$(DownloadLibraries)' == ''">false</DownloadLibraries>
   </PropertyGroup>
   <Target Name="DownloadContentFiles" BeforeTargets="Build">
 	  <ItemGroup>
@@ -16,10 +17,10 @@
 		  <_DeployToItemEsd Include="$(ProjectDir)\Resources\*.esd" />
       <_DeployToItemEtm Include="$(ProjectDir)\Resources\*.etm" />
 	  </ItemGroup>
-	  <DownloadFile SourceUrl="$(IcdUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemIcd.FullPath)')"></DownloadFile>
-	  <DownloadFile SourceUrl="$(MsdUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemMsd.FullPath)')"></DownloadFile>
-	  <DownloadFile SourceUrl="$(EsdUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemEsd.FullPath)')"></DownloadFile>
-    <DownloadFile SourceUrl="$(EtmUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemEtm.FullPath)')"></DownloadFile>
+	  <DownloadFile SourceUrl="$(IcdUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemIcd.FullPath)') AND '$(DownloadLibraries)' == 'true'"></DownloadFile>
+	  <DownloadFile SourceUrl="$(MsdUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemMsd.FullPath)') AND '$(DownloadLibraries)' == 'true'"></DownloadFile>
+	  <DownloadFile SourceUrl="$(EsdUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemEsd.FullPath)') AND '$(DownloadLibraries)' == 'true'"></DownloadFile>
+    <DownloadFile SourceUrl="$(EtmUrl)" DestinationFolder="$(ProjectDir)\Resources" Condition="!Exists('%(_DeployToItemEtm.FullPath)') AND '$(DownloadLibraries)' == 'true'"></DownloadFile>
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

Builds currently attempt to download large library files from external services, which makes `dotnet build` unreliable when those services are unavailable or unstable.

## What changed

- Disabled library downloads by default in the MSDIAL4, MSDIAL5, and MS-FINDER project files.
- Added the `DownloadLibraries` MSBuild property as an explicit opt-in switch.
- Documented how to enable downloads with `-p:DownloadLibraries=true`.

Normal builds no longer perform these library downloads; existing library files remain available when present, and download behavior can be enabled explicitly when preparing a distribution build.