### PR TITLE
Migrate CommonStandard legacy HTTP APIs to HttpClient

### DIFF
--- a/docs/adr/0004-use-httpclient-for-legacy-http-apis.md
+++ b/docs/adr/0004-use-httpclient-for-legacy-http-apis.md
@@ -1,0 +1,56 @@
+# ADR 0004: Use HttpClient for legacy HTTP APIs
+
+## Status
+
+Accepted
+
+## Context
+
+`src/Common/CommonStandard/` emitted `SYSLIB0014` warnings for `WebClient`,
+`WebRequest.Create`, and `HttpWebRequest`. Microsoft recommends
+`System.Net.Http.HttpClient` for new code and migration of these legacy HTTP
+APIs.
+
+The affected code is used by PubChem structure searches and Classyfire
+requests. The existing public methods are synchronous, and the project targets
+`netstandard2.0`, `netstandard2.1`, `net472`, `net48`, and `net8.0`.
+
+## Decision
+
+Replace the legacy HTTP APIs in CommonStandard with shared static
+`HttpClient` instances:
+
+- Replace `WebClient.DownloadFile` with `GetAsync` and streamed response
+  content copied to a file.
+- Replace `WebClient.UploadString` with `PostAsync` and `StringContent`.
+- Replace `WebRequest.Create(...).GetResponse()` and `HttpWebRequest` GETs with
+  `GetAsync` and `HttpResponseMessage`.
+- Preserve the existing synchronous public method signatures for now by using
+  synchronous bridges at the HTTP boundary.
+- Reference `System.Net.Http` explicitly so all CommonStandard target
+  frameworks compile.
+
+The `HttpClient` instances are shared rather than created per request. The
+existing `KeepAlive`, HTTP/1.0, and infinite-timeout settings are not carried
+over mechanically; any required connection or timeout policy should be
+addressed separately when runtime behavior is validated.
+
+`NU1902` and `NU1903` remain temporary command-line-only build suppressions;
+they are not added to project configuration.
+
+## Consequences
+
+- CommonStandard no longer emits `SYSLIB0014` for the migrated call sites.
+- The migration applies consistently across all supported target frameworks.
+- Synchronous callers remain source-compatible, but HTTP calls still block the
+  calling thread.
+- Runtime smoke tests are required for PubChem SDF downloads and Classyfire
+  requests because compilation does not validate remote-service behavior.
+- A future async API redesign may remove the synchronous bridges.
+
+## References
+
+- [SYSLIB0014 warning](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0014)
+- [Migrate from HttpWebRequest to HttpClient](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest)
+- [HttpClient guidelines](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines)
+- [HttpClient API](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient)

--- a/src/Common/CommonStandard/ClassyfireApiStandard/ClassfireProtocol.cs
+++ b/src/Common/CommonStandard/ClassyfireApiStandard/ClassfireProtocol.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -86,6 +86,7 @@ namespace CompMs.Common.ClassyfireApiStandard
     public class ClassfireApi
     {
         private static string prolog = @"http://classyfire.wishartlab.com";
+        private static readonly HttpClient HttpClient = new HttpClient();
 
         public void DownloadClassyfireJson(string entryID, string path)
         {
@@ -94,7 +95,15 @@ namespace CompMs.Common.ClassyfireApiStandard
 
             try
             {
-                new WebClient().DownloadFile(uri, path);
+                using (var response = HttpClient.GetAsync(uri).GetAwaiter().GetResult())
+                {
+                    response.EnsureSuccessStatusCode();
+                    using (var input = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
+                    using (var output = File.Create(path))
+                    {
+                        input.CopyTo(output);
+                    }
+                }
             }
             catch (Exception e)
             {
@@ -109,36 +118,34 @@ namespace CompMs.Common.ClassyfireApiStandard
             var url = prolog + "/queries/";
             var entryID = -1;
 
-            using (var client = new WebClient())
+            using (var content = new StringContent(JsonConvert.SerializeObject(new ClassyfireRequest()
             {
-                client.Headers[HttpRequestHeader.ContentType] = "application/json";
-                client.Headers[HttpRequestHeader.Accept] = "application/json";
-                client.Encoding = Encoding.UTF8;
-                //create json client
-                var request = new ClassyfireRequest()
-                {
-                    label = label,
-                    query_input = smiles,
-                    query_type = "STRUCTURE"
-                };
-                var json = JsonConvert.SerializeObject(request, Formatting.Indented);
+                label = label,
+                query_input = smiles,
+                query_type = "STRUCTURE"
+            }, Formatting.Indented), Encoding.UTF8, "application/json"))
+            {
                 try
                 {
-                    var res = client.UploadString(url, "POST", json);
-                    var response = JsonConvert.DeserializeObject<ClassyfireResponse>(res);
-                    if (response.id == null)
-                        return -1;
-                    else
+                    using (var response = HttpClient.PostAsync(url, content).GetAwaiter().GetResult())
                     {
-                        if (int.TryParse(response.id, out entryID))
-                            return entryID;
-                        else
+                        response.EnsureSuccessStatusCode();
+                        var res = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                        var classyfireResponse = JsonConvert.DeserializeObject<ClassyfireResponse>(res);
+                        if (classyfireResponse.id == null)
                             return -1;
+                        else
+                        {
+                            if (int.TryParse(classyfireResponse.id, out entryID))
+                                return entryID;
+                            else
+                                return -1;
+                        }
                     }
                 }
-                catch (WebException ex)
+                catch (HttpRequestException ex)
                 {
-                    Debug.WriteLine("{0}: {1}", ex.Status, ex.Message);
+                    Debug.WriteLine(ex.Message);
                 }
                 catch (System.IO.IOException ex)
                 {
@@ -163,26 +170,21 @@ namespace CompMs.Common.ClassyfireApiStandard
         public ClassyfireEntity ReadClassyfireEntityByInChIKey(string inchikey)
         {
             var url = prolog + "/entities/" + inchikey + ".json";
-            var req = (HttpWebRequest)WebRequest.Create(url);
-            req.KeepAlive = false;
-            req.Timeout = System.Threading.Timeout.Infinite;
-            req.ProtocolVersion = HttpVersion.Version10;
-
             ClassyfireEntity result = null;
             try
             {
-                using (var res = req.GetResponse())
+                using (var res = getWebResponse(url))
                 {
-                    using (var sr = new StreamReader(res.GetResponseStream()))
+                    using (var sr = new StreamReader(res.Content.ReadAsStreamAsync().GetAwaiter().GetResult()))
                     {
                         var resString = sr.ReadToEnd();
                         result = JsonConvert.DeserializeObject<ClassyfireEntity>(resString);
                     }
                 }
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
-                Console.WriteLine("{0}: {1}", ex.Status, ex.Message);
+                Console.WriteLine("{0}: {1}", ex.HResult, ex.Message);
                 return null;
             }
             catch (System.IO.IOException ex)
@@ -207,26 +209,21 @@ namespace CompMs.Common.ClassyfireApiStandard
         public ClassyfireEntity ReadClassyfireEntityByEntryID(string entryID)
         {
             var url = prolog + "/queries/" + entryID + ".json";
-            var req = (HttpWebRequest)WebRequest.Create(url);
-            req.KeepAlive = false;
-            req.Timeout = System.Threading.Timeout.Infinite;
-            req.ProtocolVersion = HttpVersion.Version10;
-
             ClassyfireEntity result = null;
             try
             {
-                using (var res = req.GetResponse())
+                using (var res = getWebResponse(url))
                 {
-                    using (var sr = new StreamReader(res.GetResponseStream()))
+                    using (var sr = new StreamReader(res.Content.ReadAsStreamAsync().GetAwaiter().GetResult()))
                     {
                         var resString = sr.ReadToEnd();
                         result = JsonConvert.DeserializeObject<ClassyfireEntity>(resString);
                     }
                 }
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
-                Console.WriteLine("{0}: {1}", ex.Status, ex.Message);
+                Console.WriteLine("{0}: {1}", ex.HResult, ex.Message);
                 return null;
             }
             catch (System.IO.IOException ex)
@@ -251,26 +248,21 @@ namespace CompMs.Common.ClassyfireApiStandard
         public ClassyfireEntity ReadClassyfireEntityAsSdfByEntryID(string entryID)
         {
             var url = prolog + "/queries/" + entryID + ".sdf";
-            var req = (HttpWebRequest)WebRequest.Create(url);
-            req.KeepAlive = false;
-            req.Timeout = System.Threading.Timeout.Infinite;
-            req.ProtocolVersion = HttpVersion.Version10;
-
             ClassyfireEntity result = null;
             try
             {
-                using (var res = req.GetResponse())
+                using (var res = getWebResponse(url))
                 {
-                    using (var sr = new StreamReader(res.GetResponseStream()))
+                    using (var sr = new StreamReader(res.Content.ReadAsStreamAsync().GetAwaiter().GetResult()))
                     {
                         var resString = sr.ReadToEnd();
                         result = readSdfClassyfireEntity(resString);
                     }
                 }
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
-                Console.WriteLine("{0}: {1}", ex.Status, ex.Message);
+                Console.WriteLine("{0}: {1}", ex.HResult, ex.Message);
                 return null;
             }
             catch (System.IO.IOException ex)
@@ -341,26 +333,21 @@ namespace CompMs.Common.ClassyfireApiStandard
         public ClassyfireResult ReadClassyfireResultByEntryID(string entryID)
         {
             var url = prolog + "/queries/" + entryID + ".json";
-            var req = (HttpWebRequest)WebRequest.Create(url);
-            req.KeepAlive = false;
-            req.Timeout = System.Threading.Timeout.Infinite;
-            req.ProtocolVersion = HttpVersion.Version10;
-
             ClassyfireResult result = null;
             try
             {
-                using (var res = req.GetResponse())
+                using (var res = getWebResponse(url))
                 {
-                    using (var sr = new StreamReader(res.GetResponseStream()))
+                    using (var sr = new StreamReader(res.Content.ReadAsStreamAsync().GetAwaiter().GetResult()))
                     {
                         var resString = sr.ReadToEnd();
                         result = JsonConvert.DeserializeObject<ClassyfireResult>(resString);
                     }
                 }
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
-                Console.WriteLine("{0}: {1}", ex.Status, ex.Message);
+                Console.WriteLine("{0}: {1}", ex.HResult, ex.Message);
                 return null;
             }
             catch (System.IO.IOException ex)
@@ -382,17 +369,18 @@ namespace CompMs.Common.ClassyfireApiStandard
             return result;
         }
 
-        private WebResponse getWebResponse(WebRequest req)
+        private HttpResponseMessage getWebResponse(string url)
         {
-            WebResponse res = null;
+            HttpResponseMessage res = null;
 
             try
             {
-                res = req.GetResponse();
+                res = HttpClient.GetAsync(url).GetAwaiter().GetResult();
+                res.EnsureSuccessStatusCode();
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
-                Console.WriteLine("{0}: {1}", ex.Status, ex.Message);
+                Console.WriteLine("{0}: {1}", ex.HResult, ex.Message);
                 res = null;
             }
             finally

--- a/src/Common/CommonStandard/ClassyfireApiStandard/ClassfireProtocol.cs
+++ b/src/Common/CommonStandard/ClassyfireApiStandard/ClassfireProtocol.cs
@@ -95,7 +95,7 @@ namespace CompMs.Common.ClassyfireApiStandard
 
             try
             {
-                using (var response = HttpClient.GetAsync(uri).GetAwaiter().GetResult())
+                using (var response = HttpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult())
                 {
                     response.EnsureSuccessStatusCode();
                     using (var input = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
@@ -375,16 +375,14 @@ namespace CompMs.Common.ClassyfireApiStandard
 
             try
             {
-                res = HttpClient.GetAsync(url).GetAwaiter().GetResult();
+                res = HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
                 res.EnsureSuccessStatusCode();
             }
             catch (HttpRequestException ex)
             {
                 Console.WriteLine("{0}: {1}", ex.HResult, ex.Message);
+                res?.Dispose();
                 res = null;
-            }
-            finally
-            {
             }
             return res;
         }

--- a/src/Common/CommonStandard/CommonStandard.csproj
+++ b/src/Common/CommonStandard/CommonStandard.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/src/Common/CommonStandard/PugRestApiStandard/DownloadClient.cs
+++ b/src/Common/CommonStandard/PugRestApiStandard/DownloadClient.cs
@@ -14,7 +14,7 @@ namespace CompMs.Common.PugRestApiStandard
 
             try
             {
-                using (var response = HttpClient.GetAsync(uri).GetAwaiter().GetResult())
+                using (var response = HttpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult())
                 {
                     response.EnsureSuccessStatusCode();
                     using (var input = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult())

--- a/src/Common/CommonStandard/PugRestApiStandard/DownloadClient.cs
+++ b/src/Common/CommonStandard/PugRestApiStandard/DownloadClient.cs
@@ -1,18 +1,28 @@
 ﻿using System;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 
 namespace CompMs.Common.PugRestApiStandard
 {
     public sealed class DownloadClient
     {
+        private static readonly HttpClient HttpClient = new HttpClient();
+
         public static void DownloadSdf(string url, string path)
         {
             var uri = new Uri(url);
 
             try
             {
-                new WebClient().DownloadFile(uri, path);
+                using (var response = HttpClient.GetAsync(uri).GetAwaiter().GetResult())
+                {
+                    response.EnsureSuccessStatusCode();
+                    using (var input = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
+                    using (var output = File.Create(path))
+                    {
+                        input.CopyTo(output);
+                    }
+                }
             }
             catch (IOException e)
             {
@@ -22,29 +32,6 @@ namespace CompMs.Common.PugRestApiStandard
             {
                 Console.WriteLine("failed: {0}, {1}", url, e.Message);
             }
-
-            //var client = new WebClient();
-            //var uri = new Uri(url);
-
-            //client.DownloadProgressChanged += client_DownloadProgressChanged;
-            //client.DownloadFileCompleted += client_DownloadFileCompleted;
-
-            //client.DownloadFileAsync(uri, path);
-        }
-
-        private static void client_DownloadFileCompleted(object sender, System.ComponentModel.AsyncCompletedEventArgs e)
-        {
-            if (e.Cancelled)
-                Console.WriteLine("Canceled");
-            else if (e.Error != null)
-                Console.WriteLine("Error:{0}", e.Error.Message);
-            else
-                Console.WriteLine("Download complete");
-        }
-
-        private static void client_DownloadProgressChanged(object sender, DownloadProgressChangedEventArgs e)
-        {
-            Console.WriteLine("{0}% ({1}byte/{2}byte) downloaded", e.ProgressPercentage, e.TotalBytesToReceive, e.BytesReceived);
         }
     }
 }

--- a/src/Common/CommonStandard/PugRestApiStandard/PubRestProtocol.cs
+++ b/src/Common/CommonStandard/PugRestApiStandard/PubRestProtocol.cs
@@ -229,21 +229,20 @@ namespace CompMs.Common.PugRestApiStandard
 
             try
             {
-                res = HttpClient.GetAsync(url).GetAwaiter().GetResult();
+                res = HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
                 res.EnsureSuccessStatusCode();
             }
             catch (HttpRequestException ex)
             {
                 Console.WriteLine("Formula: {0}, Message: {1}", this.formula, ex.Message);
+                res?.Dispose();
                 res = null;
             }
             catch (System.OperationCanceledException ex)
             {
                 Console.WriteLine("Formula: {0}, Status: {1}, Message: {2}", this.formula, ex.HResult, ex.Message);
+                res?.Dispose();
                 res = null;
-            }
-            finally
-            {
             }
             return res;
         }

--- a/src/Common/CommonStandard/PugRestApiStandard/PubRestProtocol.cs
+++ b/src/Common/CommonStandard/PugRestApiStandard/PubRestProtocol.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
 using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
 
@@ -14,6 +14,7 @@ namespace CompMs.Common.PugRestApiStandard
         private static string inputFormula = @"/compound/formula/";
         private static string inputListKey = @"/compound/listkey/";
         private static string inputCid = @"/compound/cid/";
+        private static readonly HttpClient HttpClient = new HttpClient();
         private string formula;
 
         private PubResponse result;
@@ -27,8 +28,7 @@ namespace CompMs.Common.PugRestApiStandard
             if (maxRecords < 0) return false;
 
             var url = prolog + inputFormula + formula + "/JSON";
-            var req = WebRequest.Create(url);
-            var res = getWebResponse(req);
+            var res = getWebResponse(url);
 
             if (res == null) return false;
 
@@ -68,8 +68,7 @@ namespace CompMs.Common.PugRestApiStandard
                 if (counter == 100 || i == this.result.IdentifierList.CID.Count - 1)
                 {
                     var url = prolog + inputCid + cids + "/property/InChIKey/JSON";
-                    var req = WebRequest.Create(url);
-                    var res = getWebResponse(req);
+                    var res = getWebResponse(url);
 
                     if (res == null) return;
 
@@ -91,7 +90,7 @@ namespace CompMs.Common.PugRestApiStandard
             }
         }
 
-        private List<Properties> getPubRestInChIKeys(WebResponse res)
+        private List<Properties> getPubRestInChIKeys(HttpResponseMessage res)
         {
             var result = getPugRestSeviceResult(res);
             if (result == null) return null;
@@ -111,8 +110,7 @@ namespace CompMs.Common.PugRestApiStandard
 
         private bool listKeySearch(string url, PubResponse result)
         {
-            var req = WebRequest.Create(url);
-            var res = getWebResponse(req);
+            var res = getWebResponse(url);
 
             if (res == null)
             {
@@ -125,7 +123,7 @@ namespace CompMs.Common.PugRestApiStandard
             return true;
         }
 
-        private void setPubRestCids(WebResponse res)
+        private void setPubRestCids(HttpResponseMessage res)
         {
             this.result = getPugRestSeviceResult(res);
             if (this.result == null) return;
@@ -148,7 +146,7 @@ namespace CompMs.Common.PugRestApiStandard
             }
         }
 
-        private PubResponse getPubRestSynonyms(WebResponse res)
+        private PubResponse getPubRestSynonyms(HttpResponseMessage res)
         {
             if (res == null) return null;
             var pubResult = getPugRestSeviceResult(res);
@@ -174,8 +172,7 @@ namespace CompMs.Common.PugRestApiStandard
 
         private bool listKeySearch(string url, out PubResponse pubResponse)
         {
-            var req = WebRequest.Create(url);
-            var res = getWebResponse(req);
+            var res = getWebResponse(url);
 
             if (res == null)
             {
@@ -190,8 +187,7 @@ namespace CompMs.Common.PugRestApiStandard
 
         private bool listKeySearch(string url)
         {
-            var req = WebRequest.Create(url);
-            var res = getWebResponse(req);
+            var res = getWebResponse(url);
 
             if (res == null)
             {
@@ -203,7 +199,7 @@ namespace CompMs.Common.PugRestApiStandard
             return true;
         }
 
-        private PubResponse getPugRestSeviceResult(WebResponse res)
+        private PubResponse getPugRestSeviceResult(HttpResponseMessage res)
         {
             PubResponse result = null;
 
@@ -211,7 +207,7 @@ namespace CompMs.Common.PugRestApiStandard
             {
                 using (res)
                 {
-                    using (var resStream = res.GetResponseStream())
+                    using (var resStream = res.Content.ReadAsStreamAsync().GetAwaiter().GetResult())
                     {
                         var serializer = new DataContractJsonSerializer(typeof(PubResponse));
                         result = (PubResponse)serializer.ReadObject(resStream);
@@ -227,17 +223,18 @@ namespace CompMs.Common.PugRestApiStandard
             return result;
         }
 
-        private WebResponse getWebResponse(WebRequest req)
+        private HttpResponseMessage getWebResponse(string url)
         {
-            WebResponse res = null;
+            HttpResponseMessage res = null;
 
             try
             {
-                res = req.GetResponse();
+                res = HttpClient.GetAsync(url).GetAwaiter().GetResult();
+                res.EnsureSuccessStatusCode();
             }
-            catch (WebException ex)
+            catch (HttpRequestException ex)
             {
-                Console.WriteLine("Formula: {0}, Status: {1}, Message: {2}", this.formula, ex.Status, ex.Message);
+                Console.WriteLine("Formula: {0}, Message: {1}", this.formula, ex.Message);
                 res = null;
             }
             catch (System.OperationCanceledException ex)
@@ -309,8 +306,7 @@ namespace CompMs.Common.PugRestApiStandard
                     url = url.Substring(0, url.Length - 1) + "/synonyms/JSON";
                     endID = i;
 
-                    var req = WebRequest.Create(url);
-                    var res = getWebResponse(req);
+                    var res = getWebResponse(url);
                     var pubResult = getPubRestSynonyms(res);
 
                     setPubRestSynonyms(properties, pubResult, startID, endID);
@@ -326,8 +322,7 @@ namespace CompMs.Common.PugRestApiStandard
                 url = url.Substring(0, url.Length - 1) + "/synonyms/JSON";
                 endID = properties.Count - 1;
 
-                var req = WebRequest.Create(url);
-                var res = getWebResponse(req);
+                var res = getWebResponse(url);
                 var pubResult = getPubRestSynonyms(res);
 
                 setPubRestSynonyms(properties, pubResult, startID, endID);


### PR DESCRIPTION
## Why

CommonStandard emitted SYSLIB0014 warnings for legacy `WebClient`, `WebRequest.Create`, and `HttpWebRequest` usage. This change removes those warnings while preserving the existing synchronous public APIs used by PubChem and Classyfire integrations.

## What changed

- Replaced legacy HTTP calls with shared `HttpClient` instances.
- Streamed PubChem and Classyfire downloads directly to files.
- Replaced Classyfire `UploadString` with `PostAsync` and `StringContent`.
- Added the explicit `System.Net.Http` package reference required by all CommonStandard target frameworks.
- Recorded the migration decision and remaining runtime validation considerations in ADR 0004.

## Validation

- CommonStandard builds successfully for `net472`, `net48`, `netstandard2.0`, `netstandard2.1`, and `net8.0` with zero warnings and errors.
- `NU1902` and `NU1903` remain command-line-only temporary suppressions and were not added to project configuration.

## Review notes

The public APIs remain synchronous and use synchronous bridges at the HTTP boundary. Existing `KeepAlive`, HTTP/1.0, and infinite-timeout settings were not carried over mechanically, so PubChem SDF download and Classyfire request smoke tests should be performed before merging.