### PR TITLE
Point the MSFINDER library downloads at Zenodo

### DIFF
--- a/src/MSFINDER/MsfinderCommonStandard/MsfinderCommonStandard.csproj
+++ b/src/MSFINDER/MsfinderCommonStandard/MsfinderCommonStandard.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>MsfinderCommon</AssemblyName>
     <Configurations>Debug;Release;Debug vendor unsupported;Release vendor unsupported</Configurations>
-	<IcdUrl>http://prime.psc.riken.jp/compms/code/InchikeyClassyfireDB-VS5.icd</IcdUrl>
-	<MsdUrl>http://prime.psc.riken.jp/compms/code/MINEs-StructureDB-vs1.msd</MsdUrl>
-	<EsdUrl>http://prime.psc.riken.jp/compms/code/MsfinderStructureDB-VS15.esd</EsdUrl>
-  <EtmUrl>http://prime.psc.riken.jp/compms/code/MSMS-DBs-vs1.etm</EtmUrl>
+	<IcdUrl>https://zenodo.org/records/12618137/files/InchikeyClassyfireDB-VS5.icd</IcdUrl>
+	<MsdUrl>https://zenodo.org/records/12618137/files/MINEs-StructureDB-vs1.msd</MsdUrl>
+	<EsdUrl>https://zenodo.org/records/12618137/files/MsfinderStructureDB-VS15.esd</EsdUrl>
+  <EtmUrl>https://zenodo.org/records/12618137/files/MSMS-DBs-vs1.etm</EtmUrl>
   <DownloadLibraries Condition="'$(DownloadLibraries)' == ''">false</DownloadLibraries>
   </PropertyGroup>
   <Target Name="DownloadContentFiles" BeforeTargets="Build">


### PR DESCRIPTION
## Problem

The Zenodo migration reached `src/MSDIAL5/MsdialGuiApp/MsdialGuiApp.csproj` but not `src/MSFINDER/MsfinderCommonStandard/MsfinderCommonStandard.csproj`, which still named the same four files on `prime.psc.riken.jp`:

| file | size on a developer machine |
|---|---|
| `InchikeyClassyfireDB-VS5.icd` | 80 MB |
| `MINEs-StructureDB-vs1.msd` | 124 MB |
| `MsfinderStructureDB-VS15.esd` | 180 MB |
| `MSMS-DBs-vs1.etm` | 97 MB |

All four are gitignored (`.gitignore` lines 238–241), so a clean checkout has none of them and the `DownloadFile` is the only way to obtain them. A developer machine that already holds them from an earlier build never exercises this path, which is why the dead host went unnoticed there.

`prime.psc.riken.jp` is currently unreachable — it answers a connection reset — so an opt-in library download fails. Zenodo record 12618137 already hosts all four under identical filenames and is the record `MsdialGuiApp` uses.

## Change

Four `PropertyGroup` URLs, nothing else. Both projects now name the same Zenodo record behind the same `DownloadLibraries` gate introduced in #787, so the two download targets differ only in destination folder — which is intended, since MSFINDER itself and MS-DIAL's use of MSFINDER are built separately.

`src/MSDIAL4/MsDial/MSDIAL.csproj` still names `prime.psc.riken.jp` for its `.lbm2`. It is left alone: MS-DIAL 4 is closed to development and under maintenance only, its download carries `ContinueOnError="true"` so it degrades to a warning, and its `.lbm2` is a different library version from the one on Zenodo record 11399747, which is a versioning decision rather than a URL swap.

## What this does not fix

This does not by itself make the opt-in download succeed, and the commit message records that. Verified by building with `-p:DownloadLibraries=true` against a checkout with the `.icd` absent:

```
error MSB3923: Failed to download file "https://zenodo.org/records/12618137/files/InchikeyClassyfireDB-VS5.icd".
Response status code does not indicate success: 403 (Forbidden).
```

The MSBuild `DownloadFile` task sends no `User-Agent` header, and Zenodo answers 403 to a request without one. Measured from the same machine:

| request | result |
|---|---|
| with a `User-Agent` | **206** |
| without one (what `DownloadFile` sends) | **403** |
| `?download=1`, `/api/records/<id>/files/<name>/content`, legacy `/record/` — all without a `User-Agent` | **403** |

So the URL form is not the cause and no URL change can fix it; `DownloadFile` has no parameter for a `User-Agent`. The failure mode simply moves from a connection reset to a 403.

**The already migrated `MsdialGuiApp` URLs carry the identical exposure** — all five, including the `.lbm2` on record 11399747, answer 403 without a `User-Agent`. This is therefore a pre-existing repository-wide issue about *how* the files are fetched rather than *where* they live, and it predates this PR. It needs a separate decision: replace `DownloadFile` with `Exec` + `curl -L` (curl ships on the Windows, Ubuntu and macOS runners, and sends a `User-Agent`), add a `RoslynCodeTaskFactory` task that sets one, or host the files somewhere that serves them without one.

## CI

No effect. Since #787 made library downloads opt-in, a normal build contacts neither host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
