### PR TITLE
Export alignment spectrum provenance links

### DIFF
--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLightPeakStore.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLightPeakStore.cs
@@ -360,6 +360,7 @@ public sealed class AlignmentLightQuantValueAccessor : IQuantValueAccessor {
             case "MZ": return Math.Round(peak.Mass, 5).ToString();
             case "SN": return Math.Round(peak.SignalToNoise, 1).ToString();
             case "MSMS": return peak.MS2RawSpectrumID >= 0 ? "TRUE" : "FALSE";
+            case "Reference matched": return peak.RepresentativeLibraryID >= 0 ? "TRUE" : "FALSE";
             default: return string.Empty;
         }
     }
@@ -378,6 +379,7 @@ public sealed class AlignmentLightQuantValueAccessor : IQuantValueAccessor {
             case "MZ": return peak.Mass;
             case "SN": return peak.SignalToNoise;
             case "MSMS": return peak.MS2RawSpectrumID;
+            case "Reference matched": return peak.RepresentativeLibraryID >= 0 ? 1d : 0d;
             default: return -1;
         }
     }

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentLightPeakStore.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentLightPeakStore.cs
@@ -1,4 +1,4 @@
-using CompMs.Common.Mathematics.Basic;
+﻿using CompMs.Common.Mathematics.Basic;
 using CompMs.MsdialCore.DataObj;
 using CompMs.MsdialCore.Parameter;
 using System;
@@ -27,7 +27,8 @@ public readonly struct AlignmentLightPeakRow {
         int ms1RawSpectrumIdTop,
         int ms2RawSpectrumID,
         int representativeLibraryID,
-        bool isMsmsAssigned) {
+        bool isMsmsAssigned,
+        bool isReferenceMatched) {
         FileID = fileID;
         FileName = fileName;
         MasterPeakID = masterPeakID;
@@ -46,6 +47,7 @@ public readonly struct AlignmentLightPeakRow {
         MS2RawSpectrumID = ms2RawSpectrumID;
         RepresentativeLibraryID = representativeLibraryID;
         IsMsmsAssigned = isMsmsAssigned;
+        IsReferenceMatched = isReferenceMatched;
     }
 
     public int FileID { get; }
@@ -66,10 +68,20 @@ public readonly struct AlignmentLightPeakRow {
     public int MS2RawSpectrumID { get; }
     public int RepresentativeLibraryID { get; }
     public bool IsMsmsAssigned { get; }
+
+    /// <summary>
+    /// The representative match result's own reference-matched verdict, carried so light mode does
+    /// not have to infer it from a library id. A suggested annotation holds a library id too, so
+    /// deriving it would count a precursor-only or low-score suggestion as a reference match.
+    /// </summary>
+    public bool IsReferenceMatched { get; }
 }
 
 public sealed class AlignmentLightPeakStore : IDisposable {
-    private const int RecordSize = 102;
+    // 18 fields plus the reference-matched flag. The file is a per-run temporary spill
+    // (CreateTemp uses Path.GetTempFileName and Dispose closes it), so the layout carries no
+    // compatibility obligation across versions.
+    private const int RecordSize = 103;
 
     private readonly string _filePath;
     private readonly FileStream _stream;
@@ -186,6 +198,7 @@ public sealed class AlignmentLightPeakStore : IDisposable {
         _writer.Write(peak.MS2RawSpectrumID);
         _writer.Write(peak.MatchResults?.Representative?.LibraryID ?? -1);
         _writer.Write(peak.IsMsmsAssigned);
+        _writer.Write(peak.MatchResults?.Representative?.IsReferenceMatched ?? false);
     }
 
     private static AlignmentLightPeakRow ReadPeak(BinaryReader reader, AnalysisFileBean file) {
@@ -212,6 +225,7 @@ public sealed class AlignmentLightPeakStore : IDisposable {
             reader.ReadInt32(),
             reader.ReadInt32(),
             reader.ReadInt32(),
+            reader.ReadBoolean(),
             reader.ReadBoolean());
     }
 
@@ -234,6 +248,7 @@ public sealed class AlignmentLightPeakStore : IDisposable {
             -1,
             -1,
             -1,
+            false,
             false);
     }
 
@@ -360,7 +375,7 @@ public sealed class AlignmentLightQuantValueAccessor : IQuantValueAccessor {
             case "MZ": return Math.Round(peak.Mass, 5).ToString();
             case "SN": return Math.Round(peak.SignalToNoise, 1).ToString();
             case "MSMS": return peak.MS2RawSpectrumID >= 0 ? "TRUE" : "FALSE";
-            case "Reference matched": return peak.RepresentativeLibraryID >= 0 ? "TRUE" : "FALSE";
+            case "Reference matched": return peak.IsReferenceMatched ? "TRUE" : "FALSE";
             default: return string.Empty;
         }
     }
@@ -379,7 +394,7 @@ public sealed class AlignmentLightQuantValueAccessor : IQuantValueAccessor {
             case "MZ": return peak.Mass;
             case "SN": return peak.SignalToNoise;
             case "MSMS": return peak.MS2RawSpectrumID;
-            case "Reference matched": return peak.RepresentativeLibraryID >= 0 ? 1d : 0d;
+            case "Reference matched": return peak.IsReferenceMatched ? 1d : 0d;
             default: return -1;
         }
     }

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentPeakIdMatrixExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentPeakIdMatrixExporter.cs
@@ -1,0 +1,92 @@
+using CompMs.MsdialCore.DataObj;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CompMs.MsdialCore.Export;
+
+/// <summary>
+/// Exports the compact, stable link from alignment spots to source mdpeak rows.
+/// </summary>
+public sealed class AlignmentPeakIdMatrixExporter
+{
+    public void Export(
+        Stream stream,
+        IEnumerable<AlignmentSpotProperty> spots,
+        IReadOnlyList<AnalysisFileBean> files)
+    {
+        var orderedFiles = files.OrderBy(file => file.AnalysisFileId).ToArray();
+        using var writer = CreateWriter(stream);
+        WriteHeader(writer, orderedFiles);
+        foreach (var spot in Flatten(spots)) {
+            var peaks = spot.AlignedPeakProperties.ToDictionary(peak => peak.FileID);
+            WriteRow(
+                writer,
+                spot.MasterAlignmentID,
+                orderedFiles.Select(file => peaks.TryGetValue(file.AnalysisFileId, out var peak)
+                    ? NormalizePeakId(peak.MasterPeakID)
+                    : -1));
+        }
+    }
+
+    public void Export(
+        Stream stream,
+        IEnumerable<AlignmentSpotProperty> spots,
+        IReadOnlyList<AnalysisFileBean> files,
+        AlignmentLightPeakStore peakStore)
+    {
+        var orderedFiles = files.OrderBy(file => file.AnalysisFileId).ToArray();
+        using var writer = CreateWriter(stream);
+        WriteHeader(writer, orderedFiles);
+        foreach (var spot in Flatten(spots)) {
+            var peaks = peakStore.ReadSpotPeaks(spot.MasterAlignmentID).ToDictionary(peak => peak.FileID);
+            WriteRow(
+                writer,
+                spot.MasterAlignmentID,
+                orderedFiles.Select(file => peaks.TryGetValue(file.AnalysisFileId, out var peak)
+                    ? NormalizePeakId(peak.MasterPeakID)
+                    : -1));
+        }
+    }
+
+    private static StreamWriter CreateWriter(Stream stream)
+        => new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true);
+
+    private static void WriteHeader(StreamWriter writer, IReadOnlyList<AnalysisFileBean> files)
+    {
+        writer.Write("alignment_master_id");
+        foreach (var file in files) {
+            writer.Write('\t');
+            writer.Write(Sanitize(file.AnalysisFileName));
+        }
+        writer.WriteLine();
+    }
+
+    private static void WriteRow(StreamWriter writer, int alignmentMasterId, IEnumerable<int> peakIds)
+    {
+        writer.Write(alignmentMasterId.ToString(CultureInfo.InvariantCulture));
+        foreach (var peakId in peakIds) {
+            writer.Write('\t');
+            writer.Write(peakId.ToString(CultureInfo.InvariantCulture));
+        }
+        writer.WriteLine();
+    }
+
+    private static int NormalizePeakId(int peakId) => peakId >= 0 ? peakId : -1;
+
+    private static IEnumerable<AlignmentSpotProperty> Flatten(IEnumerable<AlignmentSpotProperty> spots)
+    {
+        foreach (var spot in spots) {
+            yield return spot;
+            foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? []) {
+                yield return driftSpot;
+            }
+        }
+    }
+
+    private static string Sanitize(string value)
+        => (value ?? String.Empty).Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+}

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentProvenanceExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentProvenanceExporter.cs
@@ -1,0 +1,133 @@
+using CompMs.MsdialCore.DataObj;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CompMs.MsdialCore.Export;
+
+public sealed class AlignmentProvenanceExporter
+{
+    private static readonly string[] Headers = [
+        "alignment_master_id",
+        "alignment_local_id",
+        "parent_alignment_id",
+        "file_id",
+        "file_name",
+        "is_representative",
+        "has_source_peak",
+        "source_master_peak_id",
+        "source_peak_id",
+        "source_parent_peak_id",
+        "ms1_raw_spectrum_id",
+        "ms1_raw_spectrum_id_top",
+        "ms2_raw_spectrum_id",
+        "ms2_raw_spectrum_ids",
+        "ms2_collision_energies",
+        "rt_min",
+        "mz",
+        "height",
+        "area_above_zero",
+        "area_above_baseline",
+    ];
+
+    public void Export(Stream stream, IEnumerable<AlignmentSpotProperty> spots)
+    {
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true);
+        writer.WriteLine(String.Join("\t", Headers));
+        foreach (var spot in Flatten(spots)) {
+            foreach (var peak in spot.AlignedPeakProperties.OrderBy(peak => peak.FileID)) {
+                WriteMember(writer, spot, peak);
+            }
+        }
+    }
+
+    public void Export(Stream stream, IEnumerable<AlignmentSpotProperty> spots, AlignmentLightPeakStore peakStore)
+    {
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true);
+        writer.WriteLine(String.Join("\t", Headers));
+        foreach (var spot in Flatten(spots)) {
+            foreach (var peak in peakStore.ReadSpotPeaks(spot.MasterAlignmentID).OrderBy(peak => peak.FileID)) {
+                WriteMember(writer, spot, peak);
+            }
+        }
+    }
+
+    private static IEnumerable<AlignmentSpotProperty> Flatten(IEnumerable<AlignmentSpotProperty> spots)
+    {
+        foreach (var spot in spots) {
+            yield return spot;
+            foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? []) {
+                yield return driftSpot;
+            }
+        }
+    }
+
+    private static void WriteMember(StreamWriter writer, AlignmentSpotProperty spot, AlignmentChromPeakFeature peak)
+    {
+        var ms2Ids = peak.MS2RawSpectrumID2CE?.Keys.OrderBy(id => id).ToArray() ?? [];
+        var collisionEnergies = peak.MS2RawSpectrumID2CE?
+            .OrderBy(pair => pair.Key)
+            .Select(pair => $"{pair.Key}:{Format(pair.Value)}") ?? [];
+        var values = new[] {
+            spot.MasterAlignmentID.ToString(CultureInfo.InvariantCulture),
+            spot.AlignmentID.ToString(CultureInfo.InvariantCulture),
+            spot.ParentAlignmentID.ToString(CultureInfo.InvariantCulture),
+            peak.FileID.ToString(CultureInfo.InvariantCulture),
+            Sanitize(peak.FileName),
+            BooleanText(peak.FileID == spot.RepresentativeFileID),
+            BooleanText(peak.MasterPeakID >= 0),
+            peak.MasterPeakID.ToString(CultureInfo.InvariantCulture),
+            peak.PeakID.ToString(CultureInfo.InvariantCulture),
+            peak.ParentPeakID.ToString(CultureInfo.InvariantCulture),
+            peak.MS1RawSpectrumID.ToString(CultureInfo.InvariantCulture),
+            peak.MS1RawSpectrumIdTop.ToString(CultureInfo.InvariantCulture),
+            peak.MS2RawSpectrumID.ToString(CultureInfo.InvariantCulture),
+            String.Join(";", ms2Ids),
+            String.Join(";", collisionEnergies),
+            Format(peak.ChromXsTop?.RT.Value),
+            Format(peak.ChromXsTop?.Mz.Value),
+            Format(peak.PeakHeightTop),
+            Format(peak.PeakAreaAboveZero),
+            Format(peak.PeakAreaAboveBaseline),
+        };
+        writer.WriteLine(String.Join("\t", values));
+    }
+
+    private static void WriteMember(StreamWriter writer, AlignmentSpotProperty spot, AlignmentLightPeakRow peak)
+    {
+        var values = new[] {
+            spot.MasterAlignmentID.ToString(CultureInfo.InvariantCulture),
+            spot.AlignmentID.ToString(CultureInfo.InvariantCulture),
+            spot.ParentAlignmentID.ToString(CultureInfo.InvariantCulture),
+            peak.FileID.ToString(CultureInfo.InvariantCulture),
+            Sanitize(peak.FileName),
+            BooleanText(peak.FileID == spot.RepresentativeFileID),
+            BooleanText(peak.MasterPeakID >= 0),
+            peak.MasterPeakID.ToString(CultureInfo.InvariantCulture),
+            peak.PeakID.ToString(CultureInfo.InvariantCulture),
+            String.Empty,
+            String.Empty,
+            peak.MS1RawSpectrumIdTop.ToString(CultureInfo.InvariantCulture),
+            peak.MS2RawSpectrumID.ToString(CultureInfo.InvariantCulture),
+            peak.MS2RawSpectrumID >= 0 ? peak.MS2RawSpectrumID.ToString(CultureInfo.InvariantCulture) : String.Empty,
+            String.Empty,
+            Format(peak.Rt),
+            Format(peak.Mass),
+            Format(peak.PeakHeightTop),
+            Format(peak.PeakAreaAboveZero),
+            String.Empty,
+        };
+        writer.WriteLine(String.Join("\t", values));
+    }
+
+    private static string Format(double? value)
+        => value?.ToString("G17", CultureInfo.InvariantCulture) ?? String.Empty;
+
+    private static string BooleanText(bool value) => value ? "true" : "false";
+
+    private static string Sanitize(string value)
+        => (value ?? String.Empty).Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+}

--- a/src/MSDIAL5/MsdialCore/Export/AlignmentProvenanceExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentProvenanceExporter.cs
@@ -8,8 +8,40 @@ using System.Text;
 
 namespace CompMs.MsdialCore.Export;
 
+/// <summary>
+/// Exports the optional detailed audit sidecar that explains, per alignment spot and per file, which
+/// source peak the aligned value came from.
+/// </summary>
+/// <remarks>
+/// The file's purpose is provenance, so a column must never assert something the run did not establish.
+/// Two consequences run through the whole exporter.
+///
+/// A member with no source peak has no source spectrum either, so every raw-spectrum pointer column is
+/// written empty rather than carrying the 0 that the gap filler leaves in those fields. A 0 is a real
+/// scan index, and publishing it would point an auditor at a spectrum that has nothing to do with the
+/// member.
+///
+/// The peak-id columns are normalized to -1 for any missing source peak, which is the sentinel the
+/// compact <see cref="AlignmentPeakIdMatrixExporter"/> matrix already uses and the one consumers
+/// document. The distinction the raw values carried, -2 for gap-filled against -1 for never detected, is
+/// preserved by name in <c>peak_origin</c> instead of by magic number, so a reader does not have to know
+/// the gap filler's internals to interpret a cell.
+/// </remarks>
 public sealed class AlignmentProvenanceExporter
 {
+    private const string OriginDetected = "detected";
+    private const string OriginGapFilled = "gap_filled";
+    private const string OriginAbsent = "absent";
+
+    /// <summary>The gap filler's marker for a cell it filled, as opposed to one never detected.</summary>
+    private const int GapFilledPeakId = -2;
+
+    /// <summary>The value written wherever the run established nothing.</summary>
+    private const string NotApplicable = "";
+
+    /// <summary>The peak-id sentinel shared with the compact peak-ID matrix export.</summary>
+    private const int MissingPeakId = -1;
+
     private static readonly string[] Headers = [
         "alignment_master_id",
         "alignment_local_id",
@@ -18,6 +50,7 @@ public sealed class AlignmentProvenanceExporter
         "file_name",
         "is_representative",
         "has_source_peak",
+        "peak_origin",
         "source_master_peak_id",
         "source_peak_id",
         "source_parent_peak_id",
@@ -36,7 +69,7 @@ public sealed class AlignmentProvenanceExporter
     public void Export(Stream stream, IEnumerable<AlignmentSpotProperty> spots)
     {
         using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true);
-        writer.WriteLine(String.Join("\t", Headers));
+        WriteRow(writer, Headers);
         foreach (var spot in Flatten(spots)) {
             foreach (var peak in spot.AlignedPeakProperties.OrderBy(peak => peak.FileID)) {
                 WriteMember(writer, spot, peak);
@@ -47,7 +80,7 @@ public sealed class AlignmentProvenanceExporter
     public void Export(Stream stream, IEnumerable<AlignmentSpotProperty> spots, AlignmentLightPeakStore peakStore)
     {
         using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true);
-        writer.WriteLine(String.Join("\t", Headers));
+        WriteRow(writer, Headers);
         foreach (var spot in Flatten(spots)) {
             foreach (var peak in peakStore.ReadSpotPeaks(spot.MasterAlignmentID).OrderBy(peak => peak.FileID)) {
                 WriteMember(writer, spot, peak);
@@ -67,61 +100,103 @@ public sealed class AlignmentProvenanceExporter
 
     private static void WriteMember(StreamWriter writer, AlignmentSpotProperty spot, AlignmentChromPeakFeature peak)
     {
-        var ms2Ids = peak.MS2RawSpectrumID2CE?.Keys.OrderBy(id => id).ToArray() ?? [];
-        var collisionEnergies = peak.MS2RawSpectrumID2CE?
-            .OrderBy(pair => pair.Key)
-            .Select(pair => $"{pair.Key}:{Format(pair.Value)}") ?? [];
-        var values = new[] {
+        var hasSourcePeak = peak.MasterPeakID >= 0;
+        var ms2Ids = hasSourcePeak
+            ? peak.MS2RawSpectrumID2CE?.Keys.OrderBy(id => id).ToArray() ?? []
+            : [];
+        var collisionEnergies = hasSourcePeak && peak.MS2RawSpectrumID2CE is not null
+            ? peak.MS2RawSpectrumID2CE
+                .OrderBy(pair => pair.Key)
+                .Select(pair => $"{pair.Key}:{Format(pair.Value)}")
+            : Enumerable.Empty<string>();
+        WriteRow(writer, [
             spot.MasterAlignmentID.ToString(CultureInfo.InvariantCulture),
             spot.AlignmentID.ToString(CultureInfo.InvariantCulture),
             spot.ParentAlignmentID.ToString(CultureInfo.InvariantCulture),
             peak.FileID.ToString(CultureInfo.InvariantCulture),
             Sanitize(peak.FileName),
             BooleanText(peak.FileID == spot.RepresentativeFileID),
-            BooleanText(peak.MasterPeakID >= 0),
-            peak.MasterPeakID.ToString(CultureInfo.InvariantCulture),
-            peak.PeakID.ToString(CultureInfo.InvariantCulture),
-            peak.ParentPeakID.ToString(CultureInfo.InvariantCulture),
-            peak.MS1RawSpectrumID.ToString(CultureInfo.InvariantCulture),
-            peak.MS1RawSpectrumIdTop.ToString(CultureInfo.InvariantCulture),
-            peak.MS2RawSpectrumID.ToString(CultureInfo.InvariantCulture),
+            BooleanText(hasSourcePeak),
+            PeakOrigin(peak.MasterPeakID),
+            PeakIdText(peak.MasterPeakID),
+            PeakIdText(peak.PeakID),
+            PeakIdText(peak.ParentPeakID),
+            SpectrumIdText(hasSourcePeak, peak.MS1RawSpectrumID),
+            SpectrumIdText(hasSourcePeak, peak.MS1RawSpectrumIdTop),
+            SpectrumIdText(hasSourcePeak, peak.MS2RawSpectrumID),
             String.Join(";", ms2Ids),
             String.Join(";", collisionEnergies),
             Format(peak.ChromXsTop?.RT.Value),
-            Format(peak.ChromXsTop?.Mz.Value),
+            // Mass, not ChromXsTop.Mz. On an aligned peak ChromXsTop carries the chromatogram axis and the
+            // gap filler resets it outright, so reading Mz here reported a sentinel for every member that
+            // did have a source peak and a real value only for the gap-filled ones, which is backwards.
+            // Mass is also what the .mdalign MZ column and the light store use.
+            Format(peak.Mass),
             Format(peak.PeakHeightTop),
             Format(peak.PeakAreaAboveZero),
             Format(peak.PeakAreaAboveBaseline),
-        };
-        writer.WriteLine(String.Join("\t", values));
+        ]);
     }
 
     private static void WriteMember(StreamWriter writer, AlignmentSpotProperty spot, AlignmentLightPeakRow peak)
     {
-        var values = new[] {
+        var hasSourcePeak = peak.MasterPeakID >= 0;
+        WriteRow(writer, [
             spot.MasterAlignmentID.ToString(CultureInfo.InvariantCulture),
             spot.AlignmentID.ToString(CultureInfo.InvariantCulture),
             spot.ParentAlignmentID.ToString(CultureInfo.InvariantCulture),
             peak.FileID.ToString(CultureInfo.InvariantCulture),
             Sanitize(peak.FileName),
             BooleanText(peak.FileID == spot.RepresentativeFileID),
-            BooleanText(peak.MasterPeakID >= 0),
-            peak.MasterPeakID.ToString(CultureInfo.InvariantCulture),
-            peak.PeakID.ToString(CultureInfo.InvariantCulture),
-            String.Empty,
-            String.Empty,
-            peak.MS1RawSpectrumIdTop.ToString(CultureInfo.InvariantCulture),
-            peak.MS2RawSpectrumID.ToString(CultureInfo.InvariantCulture),
-            peak.MS2RawSpectrumID >= 0 ? peak.MS2RawSpectrumID.ToString(CultureInfo.InvariantCulture) : String.Empty,
-            String.Empty,
+            BooleanText(hasSourcePeak),
+            PeakOrigin(peak.MasterPeakID),
+            PeakIdText(peak.MasterPeakID),
+            PeakIdText(peak.PeakID),
+            // The light store does not persist the parent peak id, the full MS1 id, the ordered MS2 id set
+            // or the baseline-corrected area. Those cells are empty in light mode for that reason, not
+            // because the run failed to establish them.
+            NotApplicable,
+            NotApplicable,
+            SpectrumIdText(hasSourcePeak, peak.MS1RawSpectrumIdTop),
+            SpectrumIdText(hasSourcePeak, peak.MS2RawSpectrumID),
+            // Gated on the source peak, like the in-memory overload, so a gap-filled row does not report
+            // the 0 the gap filler left behind as if it were an acquired spectrum.
+            SpectrumIdText(hasSourcePeak, peak.MS2RawSpectrumID),
+            NotApplicable,
             Format(peak.Rt),
             Format(peak.Mass),
             Format(peak.PeakHeightTop),
             Format(peak.PeakAreaAboveZero),
-            String.Empty,
-        };
+            NotApplicable,
+        ]);
+    }
+
+    /// <summary>Writes one row, refusing a field count that does not match the header.</summary>
+    private static void WriteRow(StreamWriter writer, string[] values)
+    {
+        // The header and the two value lists are maintained by hand. Adding a column to one and not the
+        // others would otherwise produce a ragged TSV that is wrong in only one of the two Console modes.
+        if (values.Length != Headers.Length) {
+            throw new InvalidOperationException(
+                $"Alignment provenance row has {values.Length} fields but the header declares {Headers.Length}.");
+        }
         writer.WriteLine(String.Join("\t", values));
     }
+
+    /// <summary>Names why a member has no source peak, so the peak-id sentinel does not have to.</summary>
+    private static string PeakOrigin(int masterPeakId)
+    {
+        if (masterPeakId >= 0) {
+            return OriginDetected;
+        }
+        return masterPeakId == GapFilledPeakId ? OriginGapFilled : OriginAbsent;
+    }
+
+    private static string PeakIdText(int peakId)
+        => (peakId >= 0 ? peakId : MissingPeakId).ToString(CultureInfo.InvariantCulture);
+
+    private static string SpectrumIdText(bool hasSourcePeak, int spectrumId)
+        => hasSourcePeak ? spectrumId.ToString(CultureInfo.InvariantCulture) : NotApplicable;
 
     private static string Format(double? value)
         => value?.ToString("G17", CultureInfo.InvariantCulture) ?? String.Empty;

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -131,6 +131,27 @@ namespace CompMs.App.MsdialConsole.Parser
             return 1;
         }
 
+        public static bool ReadDetailedAlignmentProvenance(string filepath) {
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    readFieldValues(sr.ReadLine(), out string method, out string value, out bool isReadable);
+                    if (!isReadable) {
+                        continue;
+                    }
+                    switch (method.ToLower()) {
+                        case "detailed alignment provenance":
+                        case "export detailed alignment provenance":
+                            var valueLower = value.ToLower();
+                            if (valueLower == "true" || valueLower == "false") {
+                                return bool.Parse(valueLower);
+                            }
+                            break;
+                    }
+                }
+            }
+            return false;
+        }
+
         private static string ReadMspAnnotatorSettingsFilePath(string filepath) {
             using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
                 while (sr.Peek() > -1) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -175,14 +175,27 @@ public sealed class LcmsProcess
 
             var align_outputfile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdalign");
             var align_accessor = new LcmsMetadataAccessor(storage.DataBaseMapper, storage.Parameter, false);
-            IQuantValueAccessor align_quantAccessor = alignmentLightPeakStore != null
-                ? new AlignmentLightQuantValueAccessor("Height", storage.Parameter, alignmentLightPeakStore)
-                : new LegacyQuantValueAccessor("Height", storage.Parameter);
+            IQuantValueAccessor CreateQuantAccessor(string exportType) => alignmentLightPeakStore != null
+                ? new AlignmentLightQuantValueAccessor(exportType, storage.Parameter, alignmentLightPeakStore)
+                : new LegacyQuantValueAccessor(exportType, storage.Parameter);
+            IQuantValueAccessor align_quantAccessor = CreateQuantAccessor("Height");
             var align_stats = new[] { StatsValue.Average, StatsValue.Stdev };
             var align_exporter = new AlignmentCSVExporter();
             using var stream = File.Open(align_outputfile, FileMode.Create, FileAccess.Write);
             align_exporter.Export(stream, result.AlignmentSpotProperties, align_decResults, files, new MulticlassFileMetaAccessor(0), align_accessor, align_quantAccessor, align_stats);
             CollectAlignmentLightExportGarbage(isAlignmentLightMode);
+
+            var provenanceOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdprovenance.tsv");
+            using (var provenanceStream = File.Open(provenanceOutputFile, FileMode.Create, FileAccess.Write)) {
+                var provenanceExporter = new AlignmentProvenanceExporter();
+                if (alignmentLightPeakStore is null) {
+                    provenanceExporter.Export(provenanceStream, result.AlignmentSpotProperties);
+                }
+                else {
+                    provenanceExporter.Export(provenanceStream, result.AlignmentSpotProperties, alignmentLightPeakStore);
+                }
+            }
+            Console.WriteLine($"Alignment provenance: {provenanceOutputFile}");
 
             if (storage.Parameter.IsHeightMatrixExport) {
                 var qaOutputFolder = String.IsNullOrWhiteSpace(storage.Parameter.ExportFolderPath)
@@ -196,12 +209,12 @@ public sealed class LcmsProcess
                     result.AlignmentSpotProperties,
                     files,
                     new MulticlassFileMetaAccessor(0),
-                    ("Height", new LegacyQuantValueAccessor("Height", storage.Parameter)),
-                    ("RT", new LegacyQuantValueAccessor("RT", storage.Parameter)),
-                    ("MZ", new LegacyQuantValueAccessor("MZ", storage.Parameter)),
-                    ("SN", new LegacyQuantValueAccessor("SN", storage.Parameter)),
-                    ("MSMS", new LegacyQuantValueAccessor("MSMS", storage.Parameter)),
-                    ("Reference matched", new LegacyQuantValueAccessor("Reference matched", storage.Parameter)));
+                    ("Height", CreateQuantAccessor("Height")),
+                    ("RT", CreateQuantAccessor("RT")),
+                    ("MZ", CreateQuantAccessor("MZ")),
+                    ("SN", CreateQuantAccessor("SN")),
+                    ("MSMS", CreateQuantAccessor("MSMS")),
+                    ("Reference matched", CreateQuantAccessor("Reference matched")));
                 Console.WriteLine($"LC-MS quality-assurance matrix: {qaOutputFile}");
             }
 

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -34,6 +34,7 @@ public sealed class LcmsProcess
     {
         var param = ConfigParser.ReadForLcmsParameter(methodFile);
         var isAlignmentLightMode = ConfigParser.ReadAlignmentLightMode(methodFile);
+        var exportDetailedAlignmentProvenance = ConfigParser.ReadDetailedAlignmentProvenance(methodFile);
         var isCorrectlyImported = CommonProcess.SetProjectProperty(param, inputFolder, out List<AnalysisFileBean> analysisFiles, out AlignmentFileBean alignmentFile);
         if (!isCorrectlyImported) {
             return -1;
@@ -96,10 +97,15 @@ public sealed class LcmsProcess
         container.DataBases.SetDataBaseMapper(container.DataBaseMapper);
 
         Console.WriteLine("Start processing..");
-        return ExecuteAsync(container, outputFolder, isProjectSaved, isAlignmentLightMode).Result;
+        return ExecuteAsync(container, outputFolder, isProjectSaved, isAlignmentLightMode, exportDetailedAlignmentProvenance).Result;
     }
 
-    private async Task<int> ExecuteAsync(IMsdialDataStorage<MsdialLcmsParameter> storage, string outputFolder, bool isProjectSaved, bool isAlignmentLightMode) {
+    private async Task<int> ExecuteAsync(
+        IMsdialDataStorage<MsdialLcmsParameter> storage,
+        string outputFolder,
+        bool isProjectSaved,
+        bool isAlignmentLightMode,
+        bool exportDetailedAlignmentProvenance) {
         var projectDataStorage = new ProjectDataStorage(new ProjectParameter(DateTime.Now, outputFolder, Path.ChangeExtension(storage.Parameter.ProjectParam.ProjectFileName, ".mdproject")));
         projectDataStorage.AddStorage(storage);
 
@@ -185,17 +191,31 @@ public sealed class LcmsProcess
             align_exporter.Export(stream, result.AlignmentSpotProperties, align_decResults, files, new MulticlassFileMetaAccessor(0), align_accessor, align_quantAccessor, align_stats);
             CollectAlignmentLightExportGarbage(isAlignmentLightMode);
 
-            var provenanceOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdprovenance.tsv");
-            using (var provenanceStream = File.Open(provenanceOutputFile, FileMode.Create, FileAccess.Write)) {
-                var provenanceExporter = new AlignmentProvenanceExporter();
+            var peakIdOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdpeakid.tsv");
+            using (var peakIdStream = File.Open(peakIdOutputFile, FileMode.Create, FileAccess.Write)) {
+                var peakIdExporter = new AlignmentPeakIdMatrixExporter();
                 if (alignmentLightPeakStore is null) {
-                    provenanceExporter.Export(provenanceStream, result.AlignmentSpotProperties);
+                    peakIdExporter.Export(peakIdStream, result.AlignmentSpotProperties, files);
                 }
                 else {
-                    provenanceExporter.Export(provenanceStream, result.AlignmentSpotProperties, alignmentLightPeakStore);
+                    peakIdExporter.Export(peakIdStream, result.AlignmentSpotProperties, files, alignmentLightPeakStore);
                 }
             }
-            Console.WriteLine($"Alignment provenance: {provenanceOutputFile}");
+            Console.WriteLine($"Alignment peak ID matrix: {peakIdOutputFile}");
+
+            if (exportDetailedAlignmentProvenance) {
+                var provenanceOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdprovenance.tsv");
+                using (var provenanceStream = File.Open(provenanceOutputFile, FileMode.Create, FileAccess.Write)) {
+                    var provenanceExporter = new AlignmentProvenanceExporter();
+                    if (alignmentLightPeakStore is null) {
+                        provenanceExporter.Export(provenanceStream, result.AlignmentSpotProperties);
+                    }
+                    else {
+                        provenanceExporter.Export(provenanceStream, result.AlignmentSpotProperties, alignmentLightPeakStore);
+                    }
+                }
+                Console.WriteLine($"Detailed alignment provenance: {provenanceOutputFile}");
+            }
 
             if (storage.Parameter.IsHeightMatrixExport) {
                 var qaOutputFolder = String.IsNullOrWhiteSpace(storage.Parameter.ExportFolderPath)

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/ConfigParserTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/ConfigParserTests.cs
@@ -1,4 +1,4 @@
-using CompMs.App.MsdialConsole.Parser;
+﻿using CompMs.App.MsdialConsole.Parser;
 using CompMs.Common.Enum;
 using CompMs.MsdialLcmsApi.Parameter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -115,6 +115,25 @@ public sealed class ConfigParserTests
 
         Assert.AreEqual(1, ConfigParser.ReadLbmAnnotatorPriority(defaultMethod));
         Assert.AreEqual(3, ConfigParser.ReadLbmAnnotatorPriority(configuredMethod));
+    }
+
+    [TestMethod]
+    public void ReadDetailedAlignmentProvenance_DefaultsToFalseAndAcceptsBothAliases()
+    {
+        using var directory = new TemporaryDirectory();
+        var defaultMethod = directory.CreateFile("default.txt", "Ion mode: Negative\n");
+        var shortAlias = directory.CreateFile("short.txt", "Detailed alignment provenance: True\n");
+        var longAlias = directory.CreateFile("long.txt", "Export detailed alignment provenance: true\n");
+        var explicitlyOff = directory.CreateFile("off.txt", "Detailed alignment provenance: FALSE\n");
+        // A value that is neither true nor false must leave the default alone rather than throw: the
+        // audit sidecar is optional, so an unparseable setting means "not requested", not "fail the run".
+        var nonBoolean = directory.CreateFile("bad.txt", "Detailed alignment provenance: yes please\n");
+
+        Assert.IsFalse(ConfigParser.ReadDetailedAlignmentProvenance(defaultMethod));
+        Assert.IsTrue(ConfigParser.ReadDetailedAlignmentProvenance(shortAlias));
+        Assert.IsTrue(ConfigParser.ReadDetailedAlignmentProvenance(longAlias));
+        Assert.IsFalse(ConfigParser.ReadDetailedAlignmentProvenance(explicitlyOff));
+        Assert.IsFalse(ConfigParser.ReadDetailedAlignmentProvenance(nonBoolean));
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentPeakIdMatrixExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentPeakIdMatrixExporterTests.cs
@@ -1,0 +1,63 @@
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Export;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Text;
+
+namespace CompMs.MsdialCoreTests.Export;
+
+[TestClass]
+public class AlignmentPeakIdMatrixExporterTests
+{
+    [TestMethod]
+    public void ExportWritesMasterPeakIdsInAnalysisFileOrder()
+    {
+        var files = new[] {
+            new AnalysisFileBean { AnalysisFileId = 4, AnalysisFileName = "sample-b" },
+            new AnalysisFileBean { AnalysisFileId = 1, AnalysisFileName = "sample-a" },
+            new AnalysisFileBean { AnalysisFileId = 9, AnalysisFileName = "sample-c" },
+        };
+        var spot = new AlignmentSpotProperty {
+            MasterAlignmentID = 12,
+            AlignedPeakProperties = [
+                new AlignmentChromPeakFeature { FileID = 4, MasterPeakID = 42 },
+                new AlignmentChromPeakFeature { FileID = 1, MasterPeakID = 7 },
+                new AlignmentChromPeakFeature { FileID = 9, MasterPeakID = -2 },
+            ],
+        };
+
+        using var stream = new MemoryStream();
+        new AlignmentPeakIdMatrixExporter().Export(stream, [spot], files);
+        var text = Encoding.UTF8.GetString(stream.ToArray()).Replace("\r\n", "\n");
+
+        Assert.AreEqual(
+            "alignment_master_id\tsample-a\tsample-b\tsample-c\n12\t7\t42\t-1\n",
+            text);
+    }
+
+    [TestMethod]
+    public void ExportReadsAlignmentLightFileBackedRows()
+    {
+        var files = new[] {
+            new AnalysisFileBean { AnalysisFileId = 0, AnalysisFileName = "sample-a" },
+            new AnalysisFileBean { AnalysisFileId = 1, AnalysisFileName = "sample-b" },
+        };
+        using var store = AlignmentLightPeakStore.CreateTemp();
+        store.Initialize(1, files);
+        store.WriteSpotPeak(0, new AlignmentChromPeakFeature {
+            FileID = 1,
+            FileName = "sample-b",
+            MasterPeakID = 9,
+            PeakID = 9,
+        });
+        var spot = new AlignmentSpotProperty { MasterAlignmentID = 0 };
+
+        using var stream = new MemoryStream();
+        new AlignmentPeakIdMatrixExporter().Export(stream, [spot], files, store);
+        var text = Encoding.UTF8.GetString(stream.ToArray()).Replace("\r\n", "\n");
+
+        Assert.AreEqual(
+            "alignment_master_id\tsample-a\tsample-b\n0\t-1\t9\n",
+            text);
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentProvenanceExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentProvenanceExporterTests.cs
@@ -1,0 +1,82 @@
+using CompMs.Common.Components;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Export;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace CompMs.MsdialCoreTests.Export;
+
+[TestClass]
+public class AlignmentProvenanceExporterTests
+{
+    [TestMethod]
+    public void ExportWritesStableFeatureLinksAndRawSpectrumIds()
+    {
+        var spot = new AlignmentSpotProperty {
+            MasterAlignmentID = 12,
+            AlignmentID = 10,
+            ParentAlignmentID = -1,
+            RepresentativeFileID = 3,
+            AlignedPeakProperties = [
+                new AlignmentChromPeakFeature {
+                    FileID = 3,
+                    FileName = "sample-a",
+                    MasterPeakID = 42,
+                    PeakID = 40,
+                    ParentPeakID = -1,
+                    MS1RawSpectrumID = 100,
+                    MS1RawSpectrumIdTop = 101,
+                    MS2RawSpectrumID = 202,
+                    MS2RawSpectrumID2CE = new Dictionary<int, double> { [202] = 20d, [203] = 40d },
+                    ChromXsTop = new ChromXs(2.5),
+                    PeakHeightTop = 1234d,
+                    PeakAreaAboveZero = 5678d,
+                    PeakAreaAboveBaseline = 4321d,
+                },
+            ],
+        };
+
+        using var stream = new MemoryStream();
+        new AlignmentProvenanceExporter().Export(stream, [spot]);
+        var text = Encoding.UTF8.GetString(stream.ToArray());
+
+        StringAssert.Contains(text, "alignment_master_id\talignment_local_id");
+        StringAssert.Contains(text, "12\t10\t-1\t3\tsample-a\ttrue\ttrue\t42\t40\t-1\t100\t101\t202\t202;203\t202:20;203:40");
+    }
+
+    [TestMethod]
+    public void ExportReadsAlignmentLightFileBackedRows()
+    {
+        var file = new AnalysisFileBean { AnalysisFileId = 0, AnalysisFileName = "sample-light" };
+        using var store = AlignmentLightPeakStore.CreateTemp();
+        store.Initialize(1, [file]);
+        store.WriteSpotPeak(0, new AlignmentChromPeakFeature {
+            FileID = 0,
+            FileName = "sample-light",
+            MasterPeakID = 9,
+            PeakID = 9,
+            MS1RawSpectrumIdTop = 50,
+            MS2RawSpectrumID = 51,
+            MS2RawSpectrumID2CE = new Dictionary<int, double> { [51] = 20d },
+            ChromXsTop = new ChromXs(1.5),
+            Mass = 250.25,
+            PeakHeightTop = 500d,
+            PeakAreaAboveZero = 1500d,
+        });
+        var spot = new AlignmentSpotProperty {
+            MasterAlignmentID = 0,
+            AlignmentID = 0,
+            ParentAlignmentID = -1,
+            RepresentativeFileID = 0,
+        };
+
+        using var stream = new MemoryStream();
+        new AlignmentProvenanceExporter().Export(stream, [spot], store);
+        var text = Encoding.UTF8.GetString(stream.ToArray());
+
+        StringAssert.Contains(text, "0\t0\t-1\t0\tsample-light\ttrue\ttrue\t9\t9");
+        StringAssert.Contains(text, "\t50\t51\t51\t\t1.5\t250.25\t500\t1500\t");
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentProvenanceExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentProvenanceExporterTests.cs
@@ -1,9 +1,11 @@
 using CompMs.Common.Components;
+using CompMs.Common.DataObj.Result;
 using CompMs.MsdialCore.DataObj;
 using CompMs.MsdialCore.Export;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace CompMs.MsdialCoreTests.Export;
@@ -11,39 +13,146 @@ namespace CompMs.MsdialCoreTests.Export;
 [TestClass]
 public class AlignmentProvenanceExporterTests
 {
-    [TestMethod]
-    public void ExportWritesStableFeatureLinksAndRawSpectrumIds()
+    // Assertions here compare WHOLE lines, not substrings. Substring assertions are what let three
+    // overload disagreements ship unnoticed: they stopped before the mz column, and they could not see a
+    // ragged field count at all.
+    private const string ExpectedHeader =
+        "alignment_master_id\talignment_local_id\tparent_alignment_id\tfile_id\tfile_name\t" +
+        "is_representative\thas_source_peak\tpeak_origin\tsource_master_peak_id\tsource_peak_id\t" +
+        "source_parent_peak_id\tms1_raw_spectrum_id\tms1_raw_spectrum_id_top\tms2_raw_spectrum_id\t" +
+        "ms2_raw_spectrum_ids\tms2_collision_energies\trt_min\tmz\theight\tarea_above_zero\t" +
+        "area_above_baseline";
+
+    private static string[] ExportLines(AlignmentSpotProperty spot)
     {
-        var spot = new AlignmentSpotProperty {
+        using var stream = new MemoryStream();
+        new AlignmentProvenanceExporter().Export(stream, [spot]);
+        return Lines(stream);
+    }
+
+    private static string[] ExportLines(AlignmentSpotProperty spot, AlignmentLightPeakStore store)
+    {
+        using var stream = new MemoryStream();
+        new AlignmentProvenanceExporter().Export(stream, [spot], store);
+        return Lines(stream);
+    }
+
+    private static string[] Lines(MemoryStream stream)
+        => Encoding.UTF8.GetString(stream.ToArray())
+            .Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0)
+            .ToArray();
+
+    private static AlignmentSpotProperty SpotWith(params AlignmentChromPeakFeature[] peaks)
+        => new AlignmentSpotProperty {
             MasterAlignmentID = 12,
             AlignmentID = 10,
             ParentAlignmentID = -1,
             RepresentativeFileID = 3,
-            AlignedPeakProperties = [
-                new AlignmentChromPeakFeature {
-                    FileID = 3,
-                    FileName = "sample-a",
-                    MasterPeakID = 42,
-                    PeakID = 40,
-                    ParentPeakID = -1,
-                    MS1RawSpectrumID = 100,
-                    MS1RawSpectrumIdTop = 101,
-                    MS2RawSpectrumID = 202,
-                    MS2RawSpectrumID2CE = new Dictionary<int, double> { [202] = 20d, [203] = 40d },
-                    ChromXsTop = new ChromXs(2.5),
-                    PeakHeightTop = 1234d,
-                    PeakAreaAboveZero = 5678d,
-                    PeakAreaAboveBaseline = 4321d,
-                },
-            ],
+            AlignedPeakProperties = [.. peaks],
         };
 
-        using var stream = new MemoryStream();
-        new AlignmentProvenanceExporter().Export(stream, [spot]);
-        var text = Encoding.UTF8.GetString(stream.ToArray());
+    [TestMethod]
+    public void ExportWritesStableFeatureLinksAndRawSpectrumIds()
+    {
+        var lines = ExportLines(SpotWith(new AlignmentChromPeakFeature {
+            FileID = 3,
+            FileName = "sample-a",
+            MasterPeakID = 42,
+            PeakID = 40,
+            ParentPeakID = -1,
+            MS1RawSpectrumID = 100,
+            MS1RawSpectrumIdTop = 101,
+            MS2RawSpectrumID = 202,
+            MS2RawSpectrumID2CE = new Dictionary<int, double> { [202] = 20d, [203] = 40d },
+            ChromXsTop = new ChromXs(2.5),
+            Mass = 300.125,
+            PeakHeightTop = 1234d,
+            PeakAreaAboveZero = 5678d,
+            PeakAreaAboveBaseline = 4321d,
+        }));
 
-        StringAssert.Contains(text, "alignment_master_id\talignment_local_id");
-        StringAssert.Contains(text, "12\t10\t-1\t3\tsample-a\ttrue\ttrue\t42\t40\t-1\t100\t101\t202\t202;203\t202:20;203:40");
+        Assert.AreEqual(ExpectedHeader, lines[0]);
+        Assert.AreEqual(
+            "12\t10\t-1\t3\tsample-a\ttrue\ttrue\tdetected\t42\t40\t-1\t100\t101\t202\t202;203\t" +
+            "202:20;203:40\t2.5\t300.125\t1234\t5678\t4321",
+            lines[1]);
+    }
+
+    [TestMethod]
+    public void MzComesFromMassRatherThanTheChromatogramAxis()
+    {
+        // On an aligned peak ChromXsTop carries the chromatogram axis, so its Mz is not the precursor
+        // m/z. Reading it here reported a sentinel for every member that had a source peak, and a real
+        // value only for the gap-filled ones. Mass is the field the .mdalign MZ column uses.
+        var lines = ExportLines(SpotWith(new AlignmentChromPeakFeature {
+            FileID = 3,
+            FileName = "sample-a",
+            MasterPeakID = 1,
+            PeakID = 1,
+            ParentPeakID = -1,
+            ChromXsTop = new ChromXs(2.5),
+            Mass = 481.3159,
+        }));
+
+        Assert.AreEqual("481.3159", lines[1].Split('\t')[17]);
+    }
+
+    [TestMethod]
+    public void AGapFilledMemberPublishesNoRawSpectrumPointer()
+    {
+        // The gap filler marks the cell with -2 and leaves the spectrum ids at their default 0. A 0 is a
+        // real scan index, so writing it would point an auditor at a spectrum unrelated to the member.
+        var lines = ExportLines(SpotWith(new AlignmentChromPeakFeature {
+            FileID = 3,
+            FileName = "sample-a",
+            MasterPeakID = -2,
+            PeakID = -2,
+            ParentPeakID = -2,
+            MS1RawSpectrumID = 0,
+            MS1RawSpectrumIdTop = 0,
+            MS2RawSpectrumID = 0,
+            ChromXsTop = new ChromXs(0d, ChromXType.Mz, ChromXUnit.Mz),
+            Mass = 481.3159,
+            PeakHeightTop = 12d,
+            PeakAreaAboveZero = 34d,
+            PeakAreaAboveBaseline = 0d,
+        }));
+
+        var fields = lines[1].Split('\t');
+        Assert.AreEqual(21, fields.Length);
+        Assert.AreEqual("false", fields[6]);
+        Assert.AreEqual("gap_filled", fields[7]);
+        // Negative peak ids normalize to the single sentinel the compact matrix export also uses.
+        Assert.AreEqual("-1", fields[8]);
+        Assert.AreEqual("-1", fields[9]);
+        Assert.AreEqual("-1", fields[10]);
+        // Every raw-spectrum pointer is withheld, rather than reported as scan 0.
+        Assert.AreEqual("", fields[11]);
+        Assert.AreEqual("", fields[12]);
+        Assert.AreEqual("", fields[13]);
+        Assert.AreEqual("", fields[14]);
+        Assert.AreEqual("", fields[15]);
+        // The recovered quantities are still real measurements and are kept.
+        Assert.AreEqual("481.3159", fields[17]);
+        Assert.AreEqual("12", fields[18]);
+    }
+
+    [TestMethod]
+    public void AnUndetectedMemberIsReportedAsAbsentRatherThanGapFilled()
+    {
+        var lines = ExportLines(SpotWith(new AlignmentChromPeakFeature {
+            FileID = 3,
+            FileName = "sample-a",
+            MasterPeakID = -1,
+            PeakID = -1,
+            ParentPeakID = -1,
+        }));
+
+        var fields = lines[1].Split('\t');
+        Assert.AreEqual("false", fields[6]);
+        Assert.AreEqual("absent", fields[7]);
     }
 
     [TestMethod]
@@ -72,11 +181,73 @@ public class AlignmentProvenanceExporterTests
             RepresentativeFileID = 0,
         };
 
-        using var stream = new MemoryStream();
-        new AlignmentProvenanceExporter().Export(stream, [spot], store);
-        var text = Encoding.UTF8.GetString(stream.ToArray());
+        var lines = ExportLines(spot, store);
 
-        StringAssert.Contains(text, "0\t0\t-1\t0\tsample-light\ttrue\ttrue\t9\t9");
-        StringAssert.Contains(text, "\t50\t51\t51\t\t1.5\t250.25\t500\t1500\t");
+        Assert.AreEqual(ExpectedHeader, lines[0]);
+        // The four empty cells are columns the light store does not persist, not columns the run failed
+        // to establish. Both meanings render as an empty field, which is why the narrower light-mode
+        // contract is documented next to the Headers array rather than inferred from the data.
+        Assert.AreEqual(
+            "0\t0\t-1\t0\tsample-light\ttrue\ttrue\tdetected\t9\t9\t\t\t50\t51\t51\t\t1.5\t250.25\t500\t1500\t",
+            lines[1]);
+    }
+
+    [TestMethod]
+    public void AnUnwrittenLightRowPublishesNoRawSpectrumPointer()
+    {
+        // A spot with no peak written for a file reads back as the store's missing row. It must not claim
+        // MS2 spectrum 0, which is what gating on MS2RawSpectrumID >= 0 would have done for the light
+        // overload while the in-memory overload withheld the value.
+        var file = new AnalysisFileBean { AnalysisFileId = 0, AnalysisFileName = "sample-light" };
+        using var store = AlignmentLightPeakStore.CreateTemp();
+        store.Initialize(1, [file]);
+        var spot = new AlignmentSpotProperty {
+            MasterAlignmentID = 0,
+            AlignmentID = 0,
+            ParentAlignmentID = -1,
+            RepresentativeFileID = 0,
+        };
+
+        var fields = ExportLines(spot, store)[1].Split('\t');
+
+        Assert.AreEqual(21, fields.Length);
+        Assert.AreEqual("false", fields[6]);
+        Assert.AreEqual("absent", fields[7]);
+        Assert.AreEqual("-1", fields[8]);
+        Assert.AreEqual("", fields[12]);
+        Assert.AreEqual("", fields[13]);
+        Assert.AreEqual("", fields[14]);
+    }
+
+    [TestMethod]
+    public void TheLightStoreCarriesTheReferenceMatchedVerdictRatherThanALibraryId()
+    {
+        // A suggested annotation holds a library id, so deriving the reference-matched flag from the id
+        // counted a precursor-only or low-score suggestion as a reference match in light mode while the
+        // normal-mode QA matrix reported it as false.
+        var file = new AnalysisFileBean { AnalysisFileId = 0, AnalysisFileName = "sample-light" };
+        using var store = AlignmentLightPeakStore.CreateTemp();
+        store.Initialize(2, [file]);
+
+        var suggested = new AlignmentChromPeakFeature { FileID = 0, FileName = "sample-light", MasterPeakID = 1, PeakID = 1 };
+        suggested.MatchResults.AddResult(new MsScanMatchResult {
+            LibraryID = 7,
+            IsReferenceMatched = false,
+            IsAnnotationSuggested = true,
+        });
+        store.WriteSpotPeak(0, suggested);
+
+        var matched = new AlignmentChromPeakFeature { FileID = 0, FileName = "sample-light", MasterPeakID = 2, PeakID = 2 };
+        matched.MatchResults.AddResult(new MsScanMatchResult {
+            LibraryID = 7,
+            IsReferenceMatched = true,
+        });
+        store.WriteSpotPeak(1, matched);
+
+        Assert.IsFalse(store.ReadSpotPeaks(0).Single().IsReferenceMatched);
+        Assert.IsTrue(store.ReadSpotPeaks(1).Single().IsReferenceMatched);
+        // Both carry the same library id, so the id alone cannot separate them.
+        Assert.AreEqual(7, store.ReadSpotPeaks(0).Single().RepresentativeLibraryID);
+        Assert.AreEqual(7, store.ReadSpotPeaks(1).Single().RepresentativeLibraryID);
     }
 }


### PR DESCRIPTION
Adds two Console text exports that make an alignment spot traceable back to the per-file peak it came from: `AlignResult-*.mdpeakid.tsv`, a compact matrix from each `MasterAlignmentID` and sample to the source `MasterPeakID`, and the optional `AlignResult-*.mdprovenance.tsv` audit sidecar behind a new `Detailed alignment provenance` config key. Without them there is no way to say which `.mdpeak` row a given aligned value came from, which is the link the companion catalog needs in order to attach an annotation claim to the evidence behind it.

This branch has been sitting unmerged since 2026-09-01 and had fallen ten commits behind, so it is rebased onto current `master` (`f36aea416`).

## The rebase

One textual conflict, in `ConfigParser.cs`, where both sides added a new reader method at the same position: `master` added `ReadLbmAnnotatorPriority` (#783), the branch adds `ReadDetailedAlignmentProvenance`. Both are needed, so both are kept side by side, each verbatim as its own side wrote it. `LcmsProcess.cs` auto-merged because the two sides touch different regions — `master` the annotator setup, the branch the export block and the `ExecuteAsync` signature.

`ConfigParser.cs` uses `method.ToLower()` nine times and `ToLowerInvariant()` once, the once being `master`'s new method. Each side is left as written: a rebase should not smuggle in a normalization neither side authored. The nine `ToLower()` sites are a real latent bug — under a Turkish or Azeri culture `'I'.ToLower()` gives dotless `ı`, so a config key silently stops matching and the run proceeds with the default — but they belong in their own change.

### The rebase changes no existing output

Measured, not reasoned. Same demo, same method file, this branch against plain `master`:

| Output | Result |
| --- | --- |
| 7 per-file `.mdpeak`, 7 per-file `.mdmsp` | byte-identical |
| `.mdalign`, alignment `.mdmsp`, `.qa.tsv` | byte-identical |
| `.mzTab` | differs only in the `MTD mzTab-ID` line, which is the run timestamp |
| Extra files | `.mdpeakid.tsv` and `.mdprovenance.tsv`, nothing else |

The alignment spot count on this demo moved from 2512 to 2553 relative to the older checked-in reference output. That is `master`'s, not this branch's: #773 made `sample max / blank average` also set `FoldChangeForBlankFiltering`, which changes blank filtering, which runs at the alignment stage. Peak-detection columns are unchanged in every row — `Peak ID`, `RT (min)`, `Precursor m/z`, `Height`, `Area`, `S/N`, `Scan` all show zero differing rows — and the `.mdpeak` differences are confined to the annotation block, from #783, #784, #785 and #789.

## Three things the sidecar asserted without measuring

Found by review of the rebase and fixed in `7a7b8c28d`. All three were invisible to the original tests, because both asserted substrings of a row that had a real source peak and stopped before the `mz` column.

**`mz` was backwards in every row.** The in-memory overload read `ChromXsTop.Mz`, the light overload read `Mass`. On an aligned peak `ChromXsTop` carries the chromatogram axis and the gap filler resets it, so the column reported a sentinel for every member that *did* have a source peak and a real value only for the gap-filled ones. On the FastLC demo: **7879 of 7879** `has_source_peak=true` rows carried `mz=-1`, and **9992 of 9992** gap-filled rows carried a plausible m/z. Both overloads now read `Mass`, which is what the `.mdalign` MZ column uses.

**Gap-filled rows published a false raw-scan pointer.** The gap filler resets the peak ids but leaves the spectrum ids at their default 0, and 0 is a real scan index. Every gap-filled row therefore claimed `ms1_raw_spectrum_id=0`, `ms1_raw_spectrum_id_top=0` and `ms2_raw_spectrum_id=0`. In a file whose purpose is provenance that points an auditor at a spectrum belonging to a different peak. All five raw-spectrum columns are now withheld when there is no source peak, in both overloads. The light overload had additionally gated `ms2_raw_spectrum_ids` on `MS2RawSpectrumID >= 0`, which is true for that same 0.

**The two files disagreed about the same cell.** The sidecar wrote `-2` for a gap-filled peak id where the matrix wrote `-1`. They now agree on `-1`, and the distinction is preserved by name in a new `peak_origin` column valued `detected`, `gap_filled` or `absent`. Same lesson as #785: name the state instead of encoding it in a magic number.

## One behavioural change to existing output, in alignment-light mode only

The QA-matrix block's six accessors move from an unconditional `new LegacyQuantValueAccessor(...)` to a factory that returns `AlignmentLightQuantValueAccessor` when the light store is in use. This is a bug fix rather than part of the export: in light mode each spot holds only its representative peak, so `LegacyQuantValueAccessor`, which iterates `AlignedPeakProperties`, emitted one column's worth of values for the whole matrix. Flagging it explicitly because the commit subject does not suggest the QA matrix would change.

That switch also exposed a divergence in the light-mode `Reference matched` column, fixed here: it derived from `RepresentativeLibraryID >= 0`, but a suggested annotation carries a library id too, so a precursor-only or low-score suggestion counted as a reference match in light mode while normal mode reported false through `AnnotationName.IsReferenceMatched`, the predicate #784 centralised. The store now persists the representative's own `IsReferenceMatched` verdict. `RecordSize` goes 102 to 103; the file is a per-run temporary spill from `Path.GetTempFileName`, so the layout carries no cross-version obligation.

## Verification

- Build: `Release`, `net48`, 0 errors.
- `MsdialCoreTests`: **316/316** (311 before, plus five new covering gap-filled and unwritten-light rows, the `mz`-from-`Mass` rule, and the reference-matched verdict).
- `MsdialCoreTestAppTests`: **13/13**, including a new `ReadDetailedAlignmentProvenance` test next to `master`'s `ReadLbmAnnotatorPriority` test. That is the project that actually compiles the rebased `ConfigParser`, and running it was the one piece of evidence the original green result did not cover.
- End to end on the FastLC demo, ingested into the companion catalog: every member with a source peak carries a usable m/z, no member without one carries a scan index, and `peak_origin` splits 17871 members into 7879 `detected` and 9992 `gap_filled`.

Two guards so this class of defect cannot return quietly: `WriteMember` now goes through a `WriteRow` that refuses a field count the header does not declare, since the header and the two value lists are three hand-maintained arrays; and the tests assert whole lines rather than substrings.

## Deliberately not in this PR

- Gating `.mdpeakid.tsv` behind a config flag. It is currently unconditional, and in light mode it adds an `O(spots x files)` seek-per-cell pass — which is exactly the regime light mode exists for. Worth a follow-up; the matrix is the authoritative join key, so defaulting it off would need thought.
- Converting the nine `method.ToLower()` sites to the invariant form.
- Splitting the QA-accessor fix into its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
