### PR TITLE
Optimize imaging spectrum bin accumulation

### DIFF
--- a/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
+++ b/src/MSDIAL5/MsdialCore/Utility/DataAccess.cs
@@ -1044,14 +1044,14 @@ namespace CompMs.MsdialCore.Utility {
                 var massSpectra = spectrum.Spectrum;
                 foreach (var s in massSpectra) {
                     var massBin = (int)(s.Mz * 1000);
-                    if (!spectrumBin.ContainsKey(massBin)) {
+                    if (!spectrumBin.TryGetValue(massBin, out var binnedSpectrum)) {
                         spectrumBin[massBin] = new double[3] { s.Mz, s.Intensity, s.Intensity };
                     }
                     else {
-                        spectrumBin[massBin][1] += s.Intensity;
-                        if (spectrumBin[massBin][2] < s.Intensity) {
-                            spectrumBin[massBin][0] = s.Mz;
-                            spectrumBin[massBin][2] = s.Intensity;
+                        binnedSpectrum[1] += s.Intensity;
+                        if (binnedSpectrum[2] < s.Intensity) {
+                            binnedSpectrum[0] = s.Mz;
+                            binnedSpectrum[2] = s.Intensity;
                         }
                     }
                 }
@@ -1072,15 +1072,15 @@ namespace CompMs.MsdialCore.Utility {
                 var massSpectra = spectrum.Spectrum;
                 foreach (var s in massSpectra) {
                     var massBin = (int)(s.Mz * 1000);
-                    if (!spectrumBin.ContainsKey(massBin)) {
+                    if (!spectrumBin.TryGetValue(massBin, out var binnedSpectrum)) {
                         // [accurate mass, intensity, max intensity]
                         spectrumBin[massBin] = new double[3] { s.Mz, s.Intensity, s.Intensity };
                     }
                     else {
-                        spectrumBin[massBin][1] += s.Intensity;
-                        if (spectrumBin[massBin][2] < s.Intensity) {
-                            spectrumBin[massBin][0] = s.Mz;
-                            spectrumBin[massBin][2] = s.Intensity;
+                        binnedSpectrum[1] += s.Intensity;
+                        if (binnedSpectrum[2] < s.Intensity) {
+                            binnedSpectrum[0] = s.Mz;
+                            binnedSpectrum[2] = s.Intensity;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- replace repeated `ContainsKey`/indexer lookups with a single `TryGetValue` in the imaging spectrum binning hot path
- preserve existing binning and maximum-intensity behavior

## Performance rationale
Each incoming peak previously performed a dictionary membership lookup and then additional indexer lookups. The new code performs one lookup and reuses the retrieved bin, reducing hash-table work and indexer overhead for every accumulated peak.

## Performance improvement candidates identified
1. Imaging spectrum bin accumulation — implemented; highest impact/lowest effort.
2. Spectrum viewer drag-drop membership — use a keyed set for repeated `DisplayScans.Contains` checks.
3. MSDIAL5 peak conversion — avoid sorting all MS2 spectra when acquisition mode only needs a bounded window.
4. Normalized MS2 filtering — combine max-intensity calculation and filtering into one pass where semantics permit.
5. Deisotoping output ordering — avoid a second sort when isotope estimation already provides ordered peak IDs.
6. Chromatogram peak feature materialization — remove unnecessary `ToList` before consumers that accept enumerables.
7. Raw spectrum export — stream transformed results instead of eagerly materializing arrays.
8. Library peptide ordering — cache sorted peptide results for repeated access.
9. Spot annotation grouping — build lookup dictionaries once and reuse them across chart refreshes.
10. Imaging feature element construction — avoid duplicate projection/materialization across equivalent processing paths.

## Validation
- Focused `DataAccessTests` passed.
- `MsdialCore` build passed after restore; restore reported existing package vulnerability/compatibility warnings.