### PR TITLE
Export every annotation candidate, and say "A or B" in mzTab-M

### DIFF
--- a/src/MSDIAL5/MsdialCore/Export/AlignmentCandidateExporter.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AlignmentCandidateExporter.cs
@@ -1,0 +1,211 @@
+using CompMs.Common.Components;
+using CompMs.Common.DataObj.Result;
+using CompMs.Common.Enum;
+using CompMs.MsdialCore.Algorithm.Annotation;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Utility;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CompMs.MsdialCore.Export;
+
+/// <summary>
+/// Exports every annotation candidate MS-DIAL kept for an alignment spot, one row per candidate, rather
+/// than only the representative one that the .mdalign columns carry.
+/// </summary>
+/// <remarks>
+/// A product-ion spectrum reports structure only indirectly, so a search often cannot choose between
+/// references whose spectra are indistinguishable. MS-DIAL already keeps the alternatives, up to
+/// NUMBER_OF_ANNOTATION_RESULTS per annotator, and alignment carries them from the representative peak
+/// into the spot. Publishing only the winner turns "the search could not decide" into "the search
+/// decided", which is the kind of unearned certainty this sidecar exists to remove.
+///
+/// Conventions follow the sibling <see cref="AlignmentProvenanceExporter"/> rather than the .mdalign
+/// text export, because the consumer is the same audit pipeline: tab separated, UTF-8 without a BOM, an
+/// empty cell wherever the run established nothing, and full round-trip precision instead of the display
+/// rounding of a spreadsheet column. A score that reads 0.977 in .mdalign therefore reads 0.977049112
+/// here; they are the same measurement.
+/// </remarks>
+public sealed class AlignmentCandidateExporter
+{
+    /// <summary>The value written wherever the run established nothing.</summary>
+    private const string NotApplicable = "";
+
+    private static readonly string[] Headers = [
+        "alignment_master_id",
+        "alignment_local_id",
+        "parent_alignment_id",
+        "candidate_rank",
+        "candidate_count",
+        "is_representative",
+        "annotator_id",
+        "database_id",
+        "source",
+        "priority",
+        "library_id",
+        "name",
+        "formula",
+        "ontology",
+        "inchikey",
+        "smiles",
+        "reference_mz",
+        "reference_rt_min",
+        "reference_adduct",
+        "annotation_tag_vs1",
+        "is_reference_matched",
+        "is_annotation_suggested",
+        "is_precursor_mz_match",
+        "is_spectrum_match",
+        "is_spectrum_comparison_performed",
+        "total_score",
+        "mz_similarity",
+        "rt_similarity",
+        "ri_similarity",
+        "ccs_similarity",
+        "isotope_similarity",
+        "simple_dot_product",
+        "weighted_dot_product",
+        "reverse_dot_product",
+        "matched_peaks_count",
+        "matched_peaks_percentage",
+    ];
+
+    private readonly IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?>? _refer;
+    private readonly IReadOnlyDictionary<string, string> _databaseIdByAnnotator;
+    private readonly MachineCategory _machineCategory;
+
+    public AlignmentCandidateExporter(
+        IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?>? refer,
+        DataBaseStorage? databases,
+        MachineCategory machineCategory)
+    {
+        _refer = refer;
+        _databaseIdByAnnotator = databases is null
+            ? new Dictionary<string, string>()
+            : AnnotationCandidates.DatabaseIdByAnnotator(databases);
+        _machineCategory = machineCategory;
+    }
+
+    public void Export(Stream stream, IEnumerable<AlignmentSpotProperty> spots)
+    {
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false), 1024, leaveOpen: true);
+        WriteRow(writer, Headers);
+        foreach (var spot in Flatten(spots)) {
+            var candidates = AnnotationCandidates.Of(spot.MatchResults);
+            var representative = spot.MatchResults?.Representative;
+            for (int rank = 0; rank < candidates.Count; rank++) {
+                var candidate = candidates[rank];
+                WriteCandidate(writer, spot, candidate, rank + 1, candidates.Count, ReferenceEquals(candidate, representative));
+            }
+        }
+    }
+
+    private static IEnumerable<AlignmentSpotProperty> Flatten(IEnumerable<AlignmentSpotProperty> spots)
+    {
+        foreach (var spot in spots) {
+            yield return spot;
+            foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? []) {
+                yield return driftSpot;
+            }
+        }
+    }
+
+    private void WriteCandidate(
+        StreamWriter writer,
+        AlignmentSpotProperty spot,
+        MsScanMatchResult candidate,
+        int rank,
+        int candidateCount,
+        bool isRepresentative)
+    {
+        var reference = _refer?.Refer(candidate);
+        var hadProductIonSpectrum = spot.IsMsmsAssigned;
+        // One decision, shared with the .mdalign and .mdpeak score columns: a spectral score exists only
+        // when a product-ion spectrum was actually compared against a reference spectrum. The rendering
+        // differs, an empty cell here against the text "null" there, but the condition must not.
+        var spectrumScored = AnnotationScoreFormat.IsComputed(candidate, hadProductIonSpectrum);
+        WriteRow(writer, [
+            spot.MasterAlignmentID.ToString(CultureInfo.InvariantCulture),
+            spot.AlignmentID.ToString(CultureInfo.InvariantCulture),
+            spot.ParentAlignmentID.ToString(CultureInfo.InvariantCulture),
+            rank.ToString(CultureInfo.InvariantCulture),
+            candidateCount.ToString(CultureInfo.InvariantCulture),
+            BooleanText(isRepresentative),
+            Sanitize(candidate.AnnotatorID),
+            DatabaseId(candidate),
+            SourceText(candidate.Source),
+            candidate.Priority.ToString(CultureInfo.InvariantCulture),
+            candidate.LibraryID.ToString(CultureInfo.InvariantCulture),
+            Sanitize(string.IsNullOrEmpty(candidate.Name) ? reference?.Name : candidate.Name),
+            Sanitize(reference?.Formula?.FormulaString),
+            Sanitize(string.IsNullOrEmpty(reference?.CompoundClass) ? reference?.Ontology : reference?.CompoundClass),
+            Sanitize(string.IsNullOrEmpty(candidate.InChIKey) ? reference?.InChIKey : candidate.InChIKey),
+            Sanitize(reference?.SMILES),
+            reference is null ? NotApplicable : Format(reference.PrecursorMz),
+            reference?.ChromXs is null ? NotApplicable : Format(reference.ChromXs.RT.Value),
+            Sanitize(reference?.AdductType?.AdductIonName),
+            DataAccess.GetAnnotationCode(candidate, _machineCategory).ToString(CultureInfo.InvariantCulture),
+            BooleanText(candidate.IsReferenceMatched),
+            BooleanText(candidate.IsAnnotationSuggested),
+            BooleanText(candidate.IsPrecursorMzMatch),
+            BooleanText(candidate.IsSpectrumMatch),
+            BooleanText(spectrumScored),
+            Format(candidate.TotalScore),
+            // The five similarity terms below have no equivalent of the -1 sentinel that marks an
+            // unattempted spectral comparison, so an unused term is stored as 0 and cannot be told apart
+            // from a term that was evaluated and scored 0. They are written as stored; a consumer that
+            // needs the distinction has to read which terms the run's parameter file enabled.
+            Format(candidate.AcurateMassSimilarity),
+            Format(candidate.RtSimilarity),
+            Format(candidate.RiSimilarity),
+            Format(candidate.CcsSimilarity),
+            Format(candidate.IsotopeSimilarity),
+            Score(spectrumScored, candidate.SimpleDotProduct),
+            Score(spectrumScored, candidate.WeightedDotProduct),
+            Score(spectrumScored, candidate.ReverseDotProduct),
+            Score(spectrumScored, candidate.MatchedPeaksCount),
+            Score(spectrumScored, candidate.MatchedPeaksPercentage),
+        ]);
+    }
+
+    private string DatabaseId(MsScanMatchResult candidate)
+        => candidate.AnnotatorID is string id && _databaseIdByAnnotator.TryGetValue(id, out var databaseId)
+            ? Sanitize(databaseId)
+            : NotApplicable;
+
+    /// <summary>Writes one row, refusing a field count that does not match the header.</summary>
+    private static void WriteRow(StreamWriter writer, string[] values)
+    {
+        if (values.Length != Headers.Length) {
+            throw new InvalidOperationException(
+                $"Alignment candidate row has {values.Length} fields but the header declares {Headers.Length}.");
+        }
+        writer.WriteLine(string.Join("\t", values));
+    }
+
+    private static string Score(bool computed, float value)
+        => computed ? Format(value) : NotApplicable;
+
+    /// <summary>
+    /// The stored score fields are Single, and G9 round-trips a Single exactly. The widening to double is
+    /// deliberate and matches <see cref="AnnotationScoreFormat"/>: .NET Framework formats a Single through
+    /// a 7-significant-digit intermediate, which shifts values that sit just below a rounding boundary.
+    /// </summary>
+    private static string Format(float value)
+        => ((double)value).ToString("G9", CultureInfo.InvariantCulture);
+
+    private static string Format(double value)
+        => value.ToString("G17", CultureInfo.InvariantCulture);
+
+    private static string SourceText(SourceType source)
+        => source.ToString().Replace(" ", string.Empty);
+
+    private static string BooleanText(bool value) => value ? "true" : "false";
+
+    private static string Sanitize(string? value)
+        => (value ?? string.Empty).Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+}

--- a/src/MSDIAL5/MsdialCore/Export/AnnotationCandidates.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AnnotationCandidates.cs
@@ -1,0 +1,74 @@
+using CompMs.Common.DataObj.Result;
+using CompMs.MsdialCore.DataObj;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CompMs.MsdialCore.Export;
+
+/// <summary>
+/// The one definition of which annotation candidates an export publishes for a peak spot, and of the
+/// database each candidate's annotator drew from.
+/// </summary>
+/// <remarks>
+/// MS-DIAL keeps up to <c>NUMBER_OF_ANNOTATION_RESULTS</c> threshold-passing results per annotator, but
+/// every text export so far published only <see cref="MsScanMatchResultContainer.Representative"/>. The
+/// alternatives were computed, carried through alignment, and then dropped at the file boundary, so a
+/// reader could not tell an unambiguous match from one where the search did not choose between two
+/// references it could not tell apart.
+///
+/// The order is <see cref="MsScanMatchResultContainer.TopResults"/>, which is the same order that picks
+/// the representative: manual assignment, then reference match, then suggestion, then annotator
+/// priority, then total score. A reference match with a lower annotator priority therefore still
+/// outranks a higher-priority precursor-only suggestion, which is the intended scientific precedence.
+/// </remarks>
+public static class AnnotationCandidates
+{
+    /// <summary>
+    /// The candidates of one spot or peak, best first, or an empty list when nothing was annotated.
+    /// </summary>
+    public static IReadOnlyList<MsScanMatchResult> Of(MsScanMatchResultContainer? results)
+    {
+        if (results is null) {
+            return [];
+        }
+        return results.TopResults.Where(IsPublishable).ToArray();
+    }
+
+    /// <summary>
+    /// True for a candidate that names a reference. Decoys are already excluded upstream by
+    /// <see cref="MsScanMatchResultContainer.TopResults"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two things are deliberately not candidates. An empty container reports a single synthetic
+    /// unknown result, and "set unknown" in the GUI stores a real one, both carrying
+    /// <see cref="SourceType.Unknown"/>; neither names a molecule. A result that matched no database at
+    /// all carries no evidence to publish either. A manual assignment keeps the database bit it was
+    /// promoted from, so it stays a candidate and simply sorts first.
+    /// </remarks>
+    private static bool IsPublishable(MsScanMatchResult? result)
+        => result is not null && !result.IsUnknown && result.AnyMatched;
+
+    /// <summary>
+    /// Maps each annotator identifier to the identifier of the database it searched.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> DatabaseIdByAnnotator(DataBaseStorage storage)
+    {
+        var map = new Dictionary<string, string>();
+        foreach (var db in storage.MetabolomicsDataBases) {
+            foreach (var pair in db.Pairs) {
+                map.Add(pair.AnnotatorID, db.DataBaseID);
+            }
+        }
+        foreach (var db in storage.ProteomicsDataBases) {
+            foreach (var pair in db.Pairs) {
+                map.Add(pair.AnnotatorID, db.DataBaseID);
+            }
+        }
+        foreach (var db in storage.EadLipidomicsDatabases) {
+            foreach (var pair in db.Pairs) {
+                map.Add(pair.AnnotatorID, db.DataBaseID);
+            }
+        }
+        return map;
+    }
+}

--- a/src/MSDIAL5/MsdialCore/Export/AnnotationScoreFormat.cs
+++ b/src/MSDIAL5/MsdialCore/Export/AnnotationScoreFormat.cs
@@ -52,13 +52,25 @@ namespace CompMs.MsdialCore.Export
         /// </param>
         /// <param name="format">A numeric format string, for example "F3".</param>
         public static string Score(MsScanMatchResult? result, bool hadProductIonSpectrum, Func<MsScanMatchResult, double> value, string format) {
-            if (result is null || !result.IsSpectrumComparisonPerformed) {
-                return NotComputed;
-            }
-            if (!hadProductIonSpectrum && IsScoreBlockUnset(result)) {
+            if (!IsComputed(result, hadProductIonSpectrum)) {
                 return NotComputed;
             }
             return value(result).ToString(format);
+        }
+
+        /// <summary>
+        /// Whether the spectral score fields of <paramref name="result"/> hold measurements.
+        /// </summary>
+        /// <remarks>
+        /// Exposed separately because the audit sidecars render an absent value as an empty cell rather
+        /// than as the text "null" that the .mdpeak and .mdalign columns use. The decision of whether a
+        /// score exists must not fork with the rendering, so both go through this.
+        /// </remarks>
+        public static bool IsComputed(MsScanMatchResult? result, bool hadProductIonSpectrum) {
+            if (result is null || !result.IsSpectrumComparisonPerformed) {
+                return false;
+            }
+            return hadProductIonSpectrum || !IsScoreBlockUnset(result);
         }
 
         /// <summary>

--- a/src/MSDIAL5/MsdialCore/Export/IMetadataAccessor.cs
+++ b/src/MSDIAL5/MsdialCore/Export/IMetadataAccessor.cs
@@ -30,6 +30,16 @@ namespace CompMs.MsdialCore.Export
             _trimSpectrumToExcelLimit = trimSpectrumToExcelLimit;
         }
         public ParameterBase Parameter => _parameter;
+
+        /// <summary>
+        /// The reference lookup this accessor resolves the representative match result through.
+        /// </summary>
+        /// <remarks>
+        /// Exposed for exports that describe candidates other than the representative one, which need the
+        /// same lookup applied to a different match result. <see cref="Parameter"/> is already read the
+        /// same way by the mzTab-M exporter.
+        /// </remarks>
+        public IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?>? Refer => _refer;
         public string[] GetHeaders() => GetHeadersCore();
 
         IReadOnlyDictionary<string, string> IMetadataAccessor.GetContent(AlignmentSpotProperty spot, IMSScanProperty msdec) {

--- a/src/MSDIAL5/MsdialCore/Export/MztabFormatExport.cs
+++ b/src/MSDIAL5/MsdialCore/Export/MztabFormatExport.cs
@@ -1,5 +1,7 @@
-﻿using CompMs.Common.DataObj.Result;
+﻿using CompMs.Common.Components;
+using CompMs.Common.DataObj.Result;
 using CompMs.Common.Enum;
+using CompMs.MsdialCore.Algorithm.Annotation;
 using CompMs.MsdialCore.DataObj;
 using CompMs.MsdialCore.MSDec;
 using CompMs.MsdialCore.Parameter;
@@ -74,7 +76,12 @@ namespace CompMs.MsdialCore.Export
 
             var exportFileName = Path.GetFileNameWithoutExtension(outfile);
             var mztabId = exportFileName; // as filename
-            var meta = (metaAccessor as BaseMetadataAccessor).Parameter;
+            var baseAccessor = metaAccessor as BaseMetadataAccessor;
+            var meta = baseAccessor.Parameter;
+            // The accessor resolves a reference only for the representative match result. A row for
+            // any other candidate needs the same lookup applied to that candidate, so the refer
+            // itself is borrowed rather than the already-resolved metadata.
+            var refer = baseAccessor.Refer;
             using var sw = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true);
 
             //set common parameter
@@ -123,6 +130,13 @@ namespace CompMs.MsdialCore.Export
 
             sw.WriteLine();
 
+            // The SMF section is written before the SME section but has to reference it, so the evidence
+            // rows are laid out first. Sourcing the references from this table rather than re-deriving
+            // them in the SMF writer also means a reference cannot survive a row that was never written:
+            // the two conditions used to be written out separately and did not agree, the SMF side
+            // omitting the MS/MS-assigned, blank-filtered and internal-standard tests.
+            var smeGroups = AssignSmeGroups(spots, meta);
+
             //SMF section
             var SmfDataHeader = WriteSmfHeader(sw, meta, RawFileMetadataDic);
             //SMF data
@@ -131,13 +145,13 @@ namespace CompMs.MsdialCore.Export
                 var metadata = metaAccessor.GetContent(spot, msdecResults[spot.MasterAlignmentID]);
                 WriteSmfDataLine(
                     sw, spot, meta, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
-                    SmfDataHeader, internalStandardDic, metadata
+                    SmfDataHeader, internalStandardDic, metadata, GroupOf(smeGroups, spot)
                     );
                 foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>())
                 {
                     WriteSmfDataLine(
                         sw, driftSpot, meta, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
-                        SmfDataHeader, internalStandardDic, metadata
+                        SmfDataHeader, internalStandardDic, metadata, GroupOf(smeGroups, driftSpot)
                         );
                 }
             }
@@ -151,40 +165,11 @@ namespace CompMs.MsdialCore.Export
             ////SME data
             foreach (var spot in spots)
             {
-                if (spot.IsMsmsAssigned != true) { continue; }
-                if (spot.IsManuallyModifiedForAnnotation == true) { continue; }
-                if (spot.MatchResults.IsTextDbBasedRepresentative == true) { continue; }
-
-                if (spot.Name == "") { continue; }
-                if (spot.IsBlankFilteredByPostCurator) { continue; }
-                if (meta.IsNormalizeSplash && spot.InternalStandardAlignmentID == -1)
-                {
-                    continue;
-                }
-                if (meta.IsNormalizeIS && spot.InternalStandardAlignmentID == -1)
-                {
-                    continue;
-                }
-                //if (analysisParamForLC.IsNormalizeSplash && splashQuant == 0 && alignedSpots[i].InternalStandardAlignmentID != -1) { return; }
-                //else if (analysisParamForLC.IsNormalizeSplash && splashQuant == 1 && alignedSpots[i].InternalStandardAlignmentID == -1) { return; }
-
-                var metadata = metaAccessor.GetContent(spot, msdecResults[spot.MasterAlignmentID]);
-                if(metadata["Metabolite name"].Contains("no MS2")){ continue; }
-
-                WriteSmeDataLine(
-                    sw, spot, meta, msdecResults[spot.MasterAlignmentID],
-                    database, RawFileMetadataDic, idConfidenceMeasure, files, metadata
-                        );
+                WriteSmeDataLines(sw, spot, meta, refer, RawFileMetadataDic, idConfidenceMeasure, GroupOf(smeGroups, spot));
                 foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>())
                 {
-                    if (!driftSpot.IsMsmsAssigned) { continue; }
-
-                    WriteSmeDataLine(
-                        sw, driftSpot, meta, msdecResults[spot.MasterAlignmentID],
-                        database, RawFileMetadataDic, idConfidenceMeasure, files, metadata
-                            );
+                    WriteSmeDataLines(sw, driftSpot, meta, refer, RawFileMetadataDic, idConfidenceMeasure, GroupOf(smeGroups, driftSpot));
                 }
-                sw.WriteLine("");
             }
             sw.WriteLine("");
         }
@@ -202,7 +187,12 @@ namespace CompMs.MsdialCore.Export
         {
             var exportFileName = Path.GetFileNameWithoutExtension(outfile);
             var mztabId = exportFileName; // as filename
-            var meta = (metaAccessor as BaseMetadataAccessor).Parameter;
+            var baseAccessor = metaAccessor as BaseMetadataAccessor;
+            var meta = baseAccessor.Parameter;
+            // The accessor resolves a reference only for the representative match result. A row for
+            // any other candidate needs the same lookup applied to that candidate, so the refer
+            // itself is borrowed rather than the already-resolved metadata.
+            var refer = baseAccessor.Refer;
             using var sw = new StreamWriter(stream, Encoding.ASCII, bufferSize: 1024, leaveOpen: true);
 
             var idConfidenceMeasure = SetIdConfidenceMeasure(meta.MachineCategory, idConfidenceDefault);
@@ -220,6 +210,7 @@ namespace CompMs.MsdialCore.Export
                     .ToDictionary(x => x.Key, x => x.Value);
 
             var internalStandardDic = SetStandardDic(spots);
+            var smeGroups = AssignSmeGroups(spots, meta);
             WriteMtdSection(sw, mztabId, meta, spots, RawFileMetadataDic, AnalysisFileClassDic, idConfidenceMeasure, database);
             sw.WriteLine();
 
@@ -247,8 +238,9 @@ namespace CompMs.MsdialCore.Export
                             );
                         WriteSmfDataLine(
                             smfWriter, spot, meta, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
-                            SmfDataHeader, internalStandardDic, metadata
+                            SmfDataHeader, internalStandardDic, metadata, GroupOf(smeGroups, spot)
                             );
+                        WriteSmeDataLines(smeWriter, spot, meta, refer, RawFileMetadataDic, idConfidenceMeasure, GroupOf(smeGroups, spot));
                         foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>())
                         {
                             WriteSmlDataLine(
@@ -257,28 +249,10 @@ namespace CompMs.MsdialCore.Export
                                 );
                             WriteSmfDataLine(
                                 smfWriter, driftSpot, meta, quantAccessor, stats, RawFileMetadataDic, AnalysisFileClassDic,
-                                SmfDataHeader, internalStandardDic, metadata
+                                SmfDataHeader, internalStandardDic, metadata, GroupOf(smeGroups, driftSpot)
                                 );
+                            WriteSmeDataLines(smeWriter, driftSpot, meta, refer, RawFileMetadataDic, idConfidenceMeasure, GroupOf(smeGroups, driftSpot));
                         }
-
-                        if (!ShouldWriteSmeLine(spot, meta, metadata)) {
-                            continue;
-                        }
-
-                        WriteSmeDataLine(
-                            smeWriter, spot, meta, msdec,
-                            database, RawFileMetadataDic, idConfidenceMeasure, files, metadata
-                            );
-                        foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>())
-                        {
-                            if (!driftSpot.IsMsmsAssigned) { continue; }
-
-                            WriteSmeDataLine(
-                                smeWriter, driftSpot, meta, msdec,
-                                database, RawFileMetadataDic, idConfidenceMeasure, files, metadata
-                                );
-                        }
-                        smeWriter.WriteLine("");
                     }
                 }
 
@@ -295,19 +269,91 @@ namespace CompMs.MsdialCore.Export
             }
         }
 
-        private static bool ShouldWriteSmeLine(
-            AlignmentSpotProperty spot,
-            ParameterBase meta,
-            IReadOnlyDictionary<string, string> metadata) {
+        /// <summary>
+        /// Whether a spot contributes evidence rows at all.
+        /// </summary>
+        /// <remarks>
+        /// The "no MS2" test used to read the metadata dictionary, whose "Metabolite name" entry is the
+        /// spot name with an empty one replaced by "Unknown". Reading the spot directly is the same test
+        /// once the empty name is excluded above, and it lets the assignment pass run without building a
+        /// metadata dictionary per spot.
+        /// </remarks>
+        private static bool ShouldWriteSmeLine(AlignmentSpotProperty spot, ParameterBase meta) {
             if (spot.IsMsmsAssigned != true) { return false; }
             if (spot.IsManuallyModifiedForAnnotation == true) { return false; }
             if (spot.MatchResults.IsTextDbBasedRepresentative == true) { return false; }
-            if (spot.Name == "") { return false; }
+            if (string.IsNullOrEmpty(spot.Name)) { return false; }
             if (spot.IsBlankFilteredByPostCurator) { return false; }
             if (meta.IsNormalizeSplash && spot.InternalStandardAlignmentID == -1) { return false; }
             if (meta.IsNormalizeIS && spot.InternalStandardAlignmentID == -1) { return false; }
-            return !metadata["Metabolite name"].Contains("no MS2");
+            return !spot.Name.Contains("no MS2");
         }
+
+        /// <summary>
+        /// The evidence rows one spot contributes: its annotation candidates, best first, paired with the
+        /// file-unique SME identifiers they will be written under.
+        /// </summary>
+        private sealed class SmeGroup
+        {
+            public SmeGroup(IReadOnlyList<MsScanMatchResult> candidates, int firstSmeId) {
+                Candidates = candidates;
+                FirstSmeId = firstSmeId;
+            }
+
+            public IReadOnlyList<MsScanMatchResult> Candidates { get; }
+
+            /// <summary>The identifier of the rank 1 row; the rest follow it consecutively.</summary>
+            public int FirstSmeId { get; }
+
+            public int SmeId(int index) => FirstSmeId + index;
+
+            /// <summary>
+            /// The mzTab-M ambiguity code for the SMF row that references this group: 1 when the group
+            /// holds alternative identifications of the same feature, and null when there is nothing to
+            /// be ambiguous about. Code 2, several evidence streams for one molecule, does not apply
+            /// because every row here comes from the same input spectrum.
+            /// </summary>
+            public string AmbiguityCode => Candidates.Count > 1 ? "1" : "null";
+
+            public string SmeIdRefs => string.Join("|", Enumerable.Range(0, Candidates.Count).Select(i => SmeId(i).ToString()));
+        }
+
+        /// <summary>
+        /// Lays out the SME section ahead of writing, so the SMF rows can reference identifiers that are
+        /// guaranteed to exist and the ranks within one input spectrum are consecutive.
+        /// </summary>
+        /// <remarks>
+        /// Keyed by spot instance rather than by alignment identifier: a drift spot of an ion-mobility run
+        /// is written with its parent's metadata dictionary, so the identifier alone does not distinguish
+        /// the two.
+        /// </remarks>
+        private static Dictionary<AlignmentSpotProperty, SmeGroup> AssignSmeGroups(
+            IReadOnlyList<AlignmentSpotProperty> spots,
+            ParameterBase meta) {
+            var groups = new Dictionary<AlignmentSpotProperty, SmeGroup>();
+            var nextSmeId = 1;
+            foreach (var spot in spots) {
+                if (!ShouldWriteSmeLine(spot, meta)) { continue; }
+                nextSmeId = Assign(groups, spot, nextSmeId);
+                foreach (var driftSpot in spot.AlignmentDriftSpotFeatures ?? Enumerable.Empty<AlignmentSpotProperty>()) {
+                    if (!driftSpot.IsMsmsAssigned) { continue; }
+                    nextSmeId = Assign(groups, driftSpot, nextSmeId);
+                }
+            }
+            return groups;
+        }
+
+        private static int Assign(Dictionary<AlignmentSpotProperty, SmeGroup> groups, AlignmentSpotProperty spot, int nextSmeId) {
+            var candidates = AnnotationCandidates.Of(spot.MatchResults);
+            if (candidates.Count == 0) {
+                return nextSmeId;
+            }
+            groups[spot] = new SmeGroup(candidates, nextSmeId);
+            return nextSmeId + candidates.Count;
+        }
+
+        private static SmeGroup? GroupOf(Dictionary<AlignmentSpotProperty, SmeGroup> groups, AlignmentSpotProperty spot)
+            => groups.TryGetValue(spot, out var group) ? group : null;
 
         private static void ReplayTemporarySection(StreamWriter sw, string path) {
             using var reader = new StreamReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read), Encoding.ASCII);
@@ -452,7 +498,8 @@ namespace CompMs.MsdialCore.Export
             IReadOnlyDictionary<int, string> AnalysisFileClassDic,
             IReadOnlyList<string> SmfDataHeader,
             IReadOnlyDictionary<int, string> internalStandardDic,
-            IReadOnlyDictionary<string, string> metadata
+            IReadOnlyDictionary<string, string> metadata,
+            SmeGroup? smeGroup
             )
         {
             var smfPrefix = "SMF";
@@ -460,9 +507,10 @@ namespace CompMs.MsdialCore.Export
             var matchResult = spot.MatchResults.Representative;
 
             var smfID = metadata["Alignment ID"];
-            var smeIDrefs = "null";
-
-            var smeIDrefAmbiguity_code = "null";
+            // Taken from the evidence layout rather than re-derived here, so the reference set and the
+            // rows that actually get written cannot disagree.
+            var smeIDrefs = smeGroup?.SmeIdRefs ?? "null";
+            var smeIDrefAmbiguity_code = smeGroup?.AmbiguityCode ?? "null";
             var isotopomer = "null";
             var expMassToCharge = spot.MassCenter.ToString();
 
@@ -488,17 +536,6 @@ namespace CompMs.MsdialCore.Export
                 charge = "-" + charge;
             }
 
-            if (spot.Name is not null 
-                && spot.Name != "Unknown"
-                && spot.Name != "null"
-                && spot.Name != ""
-                && !metadata["Metabolite name"].Contains("no MS2")
-                && spot.MatchResults.IsTextDbBasedRepresentative != true
-                && spot.IsManuallyModifiedForAnnotation != true)
-            {
-                smeIDrefs = smfID.ToString();
-            }
-
             var LineMetaData = new List<string>() {
                         smfPrefix,smfID.ToString(), smeIDrefs.ToString(), smeIDrefAmbiguity_code,
                             adductIons, isotopomer, expMassToCharge, charge , retentionTime.ToString(),retentionTimeStart.ToString(),retentionTimeEnd.ToString()
@@ -520,30 +557,63 @@ namespace CompMs.MsdialCore.Export
             sw.WriteLine(string.Join(Separator, LineMetaData) + Separator + string.Join(Separator, LineData));
         }
 
-        public void WriteSmeDataLine(
+        /// <summary>
+        /// Writes one evidence row per annotation candidate of a spot.
+        /// </summary>
+        /// <remarks>
+        /// mzTab-M already has a way to say "A or B": evidence rows that share an evidence_input_id came
+        /// from the same input spectrum, rank orders them, and the feature row that references them
+        /// carries ambiguity code 1. MS-DIAL keeps up to NUMBER_OF_ANNOTATION_RESULTS threshold-passing
+        /// candidates per annotator and alignment carries them into the spot, so the alternatives existed
+        /// all along and were discarded at the file boundary, leaving every identification looking
+        /// unambiguous. Rank 1 is the representative and its columns are unchanged.
+        /// </remarks>
+        private void WriteSmeDataLines(
             StreamWriter sw,
             AlignmentSpotProperty spot,
             ParameterBase param,
-            MSDecResult msdec,
-            IReadOnlyList<Database> database,
+            IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?>? refer,
             IReadOnlyDictionary<int, RawFileMetadata> RawFileMetadataDic,
             IReadOnlyDictionary<int, string> idConfidenceMeasure,
-            IReadOnlyList<AnalysisFileBean> analysisFiles,
-            IReadOnlyDictionary<string, string> metadata
+            SmeGroup? smeGroup
+            )
+        {
+            if (smeGroup is null) {
+                return;
+            }
+            for (int index = 0; index < smeGroup.Candidates.Count; index++) {
+                WriteSmeDataLine(
+                    sw, spot, param, refer, RawFileMetadataDic, idConfidenceMeasure,
+                    smeGroup.Candidates[index], smeGroup.SmeId(index), index + 1);
+            }
+        }
+
+        private void WriteSmeDataLine(
+            StreamWriter sw,
+            AlignmentSpotProperty spot,
+            ParameterBase param,
+            IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?>? refer,
+            IReadOnlyDictionary<int, RawFileMetadata> RawFileMetadataDic,
+            IReadOnlyDictionary<int, string> idConfidenceMeasure,
+            MsScanMatchResult candidate,
+            int smeID,
+            int rank
             )
         {
             var smePrefix = "SME";
-            var smeID = metadata["Alignment ID"];
-            var evidenceInputID = metadata["Alignment ID"]; ; // need to consider
+            // The spot this row describes, not the parent whose metadata dictionary the caller reused, so
+            // an ion-mobility drift row is not grouped with its parent as an alternative for one input.
+            var evidenceInputID = spot.MasterAlignmentID;
+            var reference = refer?.Refer(candidate);
             var inchi = "null";
             var uri = "null";
-            var adductIons = SetAdductTypeString(metadata["Adduct type"]?.ToString() ?? "null");
+            var adductIons = SetAdductTypeString(spot.AdductType?.AdductIonName ?? "null");
 
             var expMassToCharge = spot.MassCenter.ToString(); // 
             var derivatizedForm = "null";
             var identificationMethod = idConfidenceDefault;
             var manualCurationScore = "null";
-            if (spot.IsManuallyModifiedForAnnotation == true)
+            if (candidate.IsManuallyModified)
             {
                 manualCurationScore = "100";
                 identificationMethod = idConfidenceManual;
@@ -556,11 +626,17 @@ namespace CompMs.MsdialCore.Export
                 charge = "-" + spot.AdductType.ChargeNumber.ToString();
             }
 
-            var repName = spot.MatchResults.Representative.Name.Split('|').Last();
-            var repLibraryID = spot.MatchResults.Representative.LibraryID;
-            var chemicalFormula = metadata["Formula"];
-            var smiles = metadata["SMILES"];
-            var theoreticalMassToCharge = metadata.TryGetValue("Reference m/z", out var refmz) ? refmz : "0";
+            var repName = (candidate.Name ?? string.Empty).Split('|').Last();
+            var repLibraryID = candidate.LibraryID;
+            var chemicalFormula = ValueOrNull(reference?.Formula?.FormulaString);
+            var smiles = ValueOrNull(reference?.SMILES);
+            // Resolved from this candidate rather than read from the representative's metadata. A
+            // reference that does not resolve is the mzTab null token; it used to be the number 0, which
+            // is not a mass.
+            var theoreticalMassToCharge = reference is null ? "null" : reference.PrecursorMz.ToString("F5");
+            // The member spectra whose own top annotation is this candidate. A lower-ranked alternative
+            // usually has none, and reports null: no file independently chose it. That the alternatives
+            // were scored against the same query spectrum is already stated by evidence_input_id.
             var spectraRefList = new List<string>();  //  multiple files
             if (_lightPeakStore is null) {
                 var properties = spot.AlignedPeakProperties;
@@ -591,17 +667,12 @@ namespace CompMs.MsdialCore.Export
                 msLevel = "[MS, MS:1000511, ms level, 2]";
             }
 
-            var rank = "1"; // need to consider
-
-
             var databaseIdentifier = "null";
-            var rep = spot?.MatchResults?.Representative;
-            if (rep != null &&
-                rep.AnnotatorID != null &&
-                _annotatorID2DataBaseID.TryGetValue(rep.AnnotatorID, out var databaseID) &&
-                !string.IsNullOrEmpty(rep.Name))
+            if (candidate.AnnotatorID != null &&
+                _annotatorID2DataBaseID.TryGetValue(candidate.AnnotatorID, out var databaseID) &&
+                !string.IsNullOrEmpty(candidate.Name))
             {
-                databaseIdentifier = _annotatorID2DataBaseID[rep.AnnotatorID!] + ":" + rep.Name.Split('|').Last();
+                databaseIdentifier = databaseID + ":" + candidate.Name.Split('|').Last();
             }
 
             var SmeLine = new List<string>() {
@@ -610,11 +681,13 @@ namespace CompMs.MsdialCore.Export
                     spectraRef, identificationMethod, msLevel
                     };
 
-            SmeLine.AddRange(SetExportScoreList(idConfidenceMeasure, spot.MatchResults.Representative, manualCurationScore));
+            SmeLine.AddRange(SetExportScoreList(idConfidenceMeasure, candidate, manualCurationScore));
 
-            SmeLine.Add(rank);
-            sw.Write(String.Join("\t", SmeLine.Select(item => string.IsNullOrEmpty(item) ? "null" : item).ToList()) + "\t");
-
+            SmeLine.Add(rank.ToString());
+            // One line per evidence row. The previous form wrote the row without a terminator and let the
+            // caller close it, which appended a trailing separator to every line and would have run the
+            // candidates of one spot together on a single physical line.
+            sw.WriteLine(String.Join("	", SmeLine.Select(item => string.IsNullOrEmpty(item) ? "null" : item).ToList()));
         }
 
         private static void AddSpectraRef(List<string> spectraRefList, int msRunID, int ms1ScanID, int ms2ScanID) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Parser/ConfigParser.cs
@@ -152,6 +152,27 @@ namespace CompMs.App.MsdialConsole.Parser
             return false;
         }
 
+        public static bool ReadAnnotationCandidateExport(string filepath) {
+            using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
+                while (sr.Peek() > -1) {
+                    readFieldValues(sr.ReadLine(), out string method, out string value, out bool isReadable);
+                    if (!isReadable) {
+                        continue;
+                    }
+                    switch (method.ToLower()) {
+                        case "annotation candidates":
+                        case "export annotation candidates":
+                            var valueLower = value.ToLower();
+                            if (valueLower == "true" || valueLower == "false") {
+                                return bool.Parse(valueLower);
+                            }
+                            break;
+                    }
+                }
+            }
+            return false;
+        }
+
         private static string ReadMspAnnotatorSettingsFilePath(string filepath) {
             using (var sr = new StreamReader(filepath, Encoding.ASCII)) {
                 while (sr.Peek() > -1) {

--- a/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
+++ b/tests/MSDIAL5/MsdialCoreTestApp/Process/LcmsProcess.cs
@@ -35,6 +35,7 @@ public sealed class LcmsProcess
         var param = ConfigParser.ReadForLcmsParameter(methodFile);
         var isAlignmentLightMode = ConfigParser.ReadAlignmentLightMode(methodFile);
         var exportDetailedAlignmentProvenance = ConfigParser.ReadDetailedAlignmentProvenance(methodFile);
+        var exportAnnotationCandidates = ConfigParser.ReadAnnotationCandidateExport(methodFile);
         var isCorrectlyImported = CommonProcess.SetProjectProperty(param, inputFolder, out List<AnalysisFileBean> analysisFiles, out AlignmentFileBean alignmentFile);
         if (!isCorrectlyImported) {
             return -1;
@@ -97,7 +98,7 @@ public sealed class LcmsProcess
         container.DataBases.SetDataBaseMapper(container.DataBaseMapper);
 
         Console.WriteLine("Start processing..");
-        return ExecuteAsync(container, outputFolder, isProjectSaved, isAlignmentLightMode, exportDetailedAlignmentProvenance).Result;
+        return ExecuteAsync(container, outputFolder, isProjectSaved, isAlignmentLightMode, exportDetailedAlignmentProvenance, exportAnnotationCandidates).Result;
     }
 
     private async Task<int> ExecuteAsync(
@@ -105,7 +106,8 @@ public sealed class LcmsProcess
         string outputFolder,
         bool isProjectSaved,
         bool isAlignmentLightMode,
-        bool exportDetailedAlignmentProvenance) {
+        bool exportDetailedAlignmentProvenance,
+        bool exportAnnotationCandidates) {
         var projectDataStorage = new ProjectDataStorage(new ProjectParameter(DateTime.Now, outputFolder, Path.ChangeExtension(storage.Parameter.ProjectParam.ProjectFileName, ".mdproject")));
         projectDataStorage.AddStorage(storage);
 
@@ -202,6 +204,15 @@ public sealed class LcmsProcess
                 }
             }
             Console.WriteLine($"Alignment peak ID matrix: {peakIdOutputFile}");
+
+            if (exportAnnotationCandidates) {
+                var candidateOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdcandidate.tsv");
+                using (var candidateStream = File.Open(candidateOutputFile, FileMode.Create, FileAccess.Write)) {
+                    new AlignmentCandidateExporter(storage.DataBaseMapper, storage.DataBases, storage.Parameter.MachineCategory)
+                        .Export(candidateStream, result.AlignmentSpotProperties);
+                }
+                Console.WriteLine($"Annotation candidates: {candidateOutputFile}");
+            }
 
             if (exportDetailedAlignmentProvenance) {
                 var provenanceOutputFile = Path.Combine(outputFolder, alignmentFile.FileName + ".mdprovenance.tsv");

--- a/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/ConfigParserTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTestAppTests/Parser/ConfigParserTests.cs
@@ -136,6 +136,23 @@ public sealed class ConfigParserTests
         Assert.IsFalse(ConfigParser.ReadDetailedAlignmentProvenance(nonBoolean));
     }
 
+    [TestMethod]
+    public void ReadAnnotationCandidateExport_DefaultsToFalseAndAcceptsBothAliases()
+    {
+        using var directory = new TemporaryDirectory();
+        var defaultMethod = directory.CreateFile("default.txt", "Ion mode: Negative\n");
+        var shortAlias = directory.CreateFile("short.txt", "Annotation candidates: True\n");
+        var longAlias = directory.CreateFile("long.txt", "Export annotation candidates: true\n");
+        var explicitlyOff = directory.CreateFile("off.txt", "Annotation candidates: FALSE\n");
+        var nonBoolean = directory.CreateFile("bad.txt", "Annotation candidates: all of them\n");
+
+        Assert.IsFalse(ConfigParser.ReadAnnotationCandidateExport(defaultMethod));
+        Assert.IsTrue(ConfigParser.ReadAnnotationCandidateExport(shortAlias));
+        Assert.IsTrue(ConfigParser.ReadAnnotationCandidateExport(longAlias));
+        Assert.IsFalse(ConfigParser.ReadAnnotationCandidateExport(explicitlyOff));
+        Assert.IsFalse(ConfigParser.ReadAnnotationCandidateExport(nonBoolean));
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
         public TemporaryDirectory()

--- a/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentCandidateExporterTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/AlignmentCandidateExporterTests.cs
@@ -1,0 +1,204 @@
+using CompMs.Common.Components;
+using CompMs.Common.DataObj.Property;
+using CompMs.Common.DataObj.Result;
+using CompMs.Common.Enum;
+using CompMs.MsdialCore.Algorithm.Annotation;
+using CompMs.MsdialCore.DataObj;
+using CompMs.MsdialCore.Export;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CompMs.MsdialCoreTests.Export;
+
+[TestClass]
+public class AlignmentCandidateExporterTests
+{
+    // Whole-line assertions, for the same reason the provenance exporter tests use them: a substring
+    // assertion cannot see a ragged field count, and this file has three hand-maintained column lists.
+    private const string ExpectedHeader =
+        "alignment_master_id\talignment_local_id\tparent_alignment_id\tcandidate_rank\tcandidate_count\t" +
+        "is_representative\tannotator_id\tdatabase_id\tsource\tpriority\tlibrary_id\tname\tformula\t" +
+        "ontology\tinchikey\tsmiles\treference_mz\treference_rt_min\treference_adduct\t" +
+        "annotation_tag_vs1\tis_reference_matched\tis_annotation_suggested\tis_precursor_mz_match\t" +
+        "is_spectrum_match\tis_spectrum_comparison_performed\ttotal_score\tmz_similarity\t" +
+        "rt_similarity\tri_similarity\tccs_similarity\tisotope_similarity\tsimple_dot_product\t" +
+        "weighted_dot_product\treverse_dot_product\tmatched_peaks_count\tmatched_peaks_percentage";
+
+    [TestMethod]
+    public void EveryCandidateIsExportedOnceInRankOrder()
+    {
+        var best = ReferenceMatch("Quercetin", libraryId: 7, totalScore: 0.75f);
+        var alternative = ReferenceMatch("Morin", libraryId: 8, totalScore: 0.5f);
+        var spot = SpotWith(best, alternative);
+
+        var lines = ExportLines(spot, Refer((7, ReferenceFor("Quercetin")), (8, ReferenceFor("Morin"))));
+
+        Assert.AreEqual(ExpectedHeader, lines[0]);
+        Assert.AreEqual(3, lines.Length);
+        Assert.AreEqual(
+            "12\t10\t-1\t1\t2\ttrue\tmsp\t\tMspDB\t1\t7\tQuercetin\tC15H10O7\tflavonoid\tQUERCETIN-KEY\tc1cc(O)ccc1\t" +
+            "300.125\t2.5\t[M+H]+\t430\ttrue\tfalse\ttrue\ttrue\ttrue\t0.75\t0.5\t0\t0\t0\t0\t0.5\t0.25\t0.75\t12\t0.5",
+            lines[1]);
+        Assert.AreEqual(
+            "12\t10\t-1\t2\t2\tfalse\tmsp\t\tMspDB\t1\t8\tMorin\tC15H10O7\tflavonoid\tMORIN-KEY\tc1cc(O)ccc1\t" +
+            "300.125\t2.5\t[M+H]+\t430\ttrue\tfalse\ttrue\ttrue\ttrue\t0.5\t0.5\t0\t0\t0\t0\t0.5\t0.25\t0.75\t12\t0.5",
+            lines[2]);
+    }
+
+    /// <summary>
+    /// The precedence that picks the representative is the precedence the file publishes: a reference
+    /// match outranks a precursor-only suggestion even when the suggestion's annotator has the higher
+    /// priority.
+    /// </summary>
+    [TestMethod]
+    public void AReferenceMatchOutranksAHigherPrioritySuggestion()
+    {
+        var suggestion = ReferenceMatch("Suggested", libraryId: 8, totalScore: 0.5f);
+        suggestion.IsReferenceMatched = false;
+        suggestion.IsAnnotationSuggested = true;
+        suggestion.IsSpectrumMatch = false;
+        suggestion.Priority = 9;
+        var match = ReferenceMatch("Matched", libraryId: 7, totalScore: 0.5f);
+
+        var lines = ExportLines(SpotWith(suggestion, match), Refer());
+
+        CollectionAssert.AreEqual(
+            new[] { "Matched", "Suggested" },
+            lines.Skip(1).Select(line => line.Split('\t')[11]).ToArray());
+        CollectionAssert.AreEqual(
+            new[] { "true", "false" },
+            lines.Skip(1).Select(line => line.Split('\t')[5]).ToArray());
+    }
+
+    /// <summary>
+    /// A spectral score that was never computed is an empty cell, never a 0. The distinction is the same
+    /// one <see cref="AnnotationScoreFormat"/> makes for the .mdalign columns.
+    /// </summary>
+    [TestMethod]
+    public void AnUncomparedSpectrumPublishesNoSpectralScore()
+    {
+        var precursorOnly = ReferenceMatch("Suggested", libraryId: 7, totalScore: 0.5f);
+        precursorOnly.IsSpectrumMatch = false;
+        // The scoring functions return -1 when there was no product-ion spectrum to compare.
+        precursorOnly.SquaredSimpleDotProduct = -1f;
+        precursorOnly.SquaredWeightedDotProduct = -1f;
+        precursorOnly.SquaredReverseDotProduct = -1f;
+        precursorOnly.MatchedPeaksCount = -1f;
+        precursorOnly.MatchedPeaksPercentage = -1f;
+
+        var fields = ExportLines(SpotWith(precursorOnly), Refer())[1].Split('\t');
+
+        Assert.AreEqual("false", fields[24], "is_spectrum_comparison_performed");
+        CollectionAssert.AreEqual(
+            new[] { "", "", "", "", "" },
+            new[] { fields[31], fields[32], fields[33], fields[34], fields[35] });
+        Assert.AreEqual("0.5", fields[25], "the aggregate total score is still a measurement");
+    }
+
+    [TestMethod]
+    public void AnUnannotatedSpotContributesNoRow()
+    {
+        var lines = ExportLines(SpotWith(), Refer());
+
+        Assert.AreEqual(ExpectedHeader, lines[0]);
+        Assert.AreEqual(1, lines.Length);
+    }
+
+    /// <summary>
+    /// "Set unknown" stores a real match result carrying the unknown flag. It names no molecule, so it is
+    /// not a candidate.
+    /// </summary>
+    [TestMethod]
+    public void ASetUnknownAssignmentIsNotACandidate()
+    {
+        var unknown = new MsScanMatchResult { Source = SourceType.Manual | SourceType.Unknown, };
+
+        var lines = ExportLines(SpotWith(unknown), Refer());
+
+        Assert.AreEqual(1, lines.Length);
+    }
+
+    /// <summary>
+    /// A candidate whose reference cannot be resolved still publishes its own evidence; the columns that
+    /// come from the reference are empty rather than invented.
+    /// </summary>
+    [TestMethod]
+    public void AnUnresolvableReferenceLeavesTheReferenceColumnsEmpty()
+    {
+        var fields = ExportLines(SpotWith(ReferenceMatch("Quercetin", libraryId: 7, totalScore: 0.5f)), Refer())[1].Split('\t');
+
+        Assert.AreEqual("Quercetin", fields[11], "the name is on the match result itself");
+        CollectionAssert.AreEqual(
+            new[] { "", "", "", "", "" },
+            new[] { fields[12], fields[13], fields[15], fields[16], fields[17] });
+    }
+
+    private static MsScanMatchResult ReferenceMatch(string name, int libraryId, float totalScore)
+        => new() {
+            Name = name,
+            Source = SourceType.MspDB,
+            AnnotatorID = "msp",
+            Priority = 1,
+            LibraryID = libraryId,
+            TotalScore = totalScore,
+            IsReferenceMatched = true,
+            IsPrecursorMzMatch = true,
+            IsSpectrumMatch = true,
+            AcurateMassSimilarity = 0.5f,
+            SquaredSimpleDotProduct = 0.25f,
+            SquaredWeightedDotProduct = 0.0625f,
+            SquaredReverseDotProduct = 0.5625f,
+            MatchedPeaksCount = 12f,
+            MatchedPeaksPercentage = 0.5f,
+        };
+
+    private static MoleculeMsReference ReferenceFor(string name)
+        => new() {
+            Name = name,
+            Formula = new Formula { FormulaString = "C15H10O7", },
+            Ontology = "flavonoid",
+            InChIKey = name.ToUpperInvariant() + "-KEY",
+            SMILES = "c1cc(O)ccc1",
+            PrecursorMz = 300.125,
+            ChromXs = new ChromXs(2.5),
+            AdductType = AdductIon.GetAdductIon("[M+H]+"),
+        };
+
+    private static AlignmentSpotProperty SpotWith(params MsScanMatchResult[] results)
+    {
+        var spot = new AlignmentSpotProperty {
+            MasterAlignmentID = 12,
+            AlignmentID = 10,
+            ParentAlignmentID = -1,
+            AlignedPeakProperties = [],
+        };
+        spot.MatchResults.AddResults(results);
+        return spot;
+    }
+
+    private static string[] ExportLines(AlignmentSpotProperty spot, IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?> refer)
+    {
+        using var stream = new MemoryStream();
+        new AlignmentCandidateExporter(refer, null, MachineCategory.LCMS).Export(stream, [spot]);
+        return Encoding.UTF8.GetString(stream.ToArray())
+            .Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0)
+            .ToArray();
+    }
+
+    private static IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?> Refer(params (int LibraryId, MoleculeMsReference Reference)[] references)
+        => new StubRefer(references.ToDictionary(pair => pair.LibraryId, pair => pair.Reference));
+
+    private sealed class StubRefer(Dictionary<int, MoleculeMsReference> byLibraryId)
+        : IMatchResultRefer<MoleculeMsReference?, MsScanMatchResult?>
+    {
+        public string Key => "stub";
+
+        public MoleculeMsReference? Refer(MsScanMatchResult? result)
+            => result is not null && byLibraryId.TryGetValue(result.LibraryID, out var reference) ? reference : null;
+    }
+}

--- a/tests/MSDIAL5/MsdialCoreTests/Export/MztabFormatExportTests.cs
+++ b/tests/MSDIAL5/MsdialCoreTests/Export/MztabFormatExportTests.cs
@@ -54,6 +54,122 @@ namespace CompMs.MsdialCore.Export.Tests
             CollectionAssert.AreEqual(buffer, stream.GetBuffer());
         }
 
+        /// <summary>
+        /// A spot whose search kept more than one candidate publishes them all as ranked evidence rows of
+        /// one input spectrum, which is how mzTab-M says "A or B".
+        /// </summary>
+        [TestMethod()]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11.mddata", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11_Loaded.msp2", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11_Loaded.msp2.dbs", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06.arf2", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06_PeakProperties.arf", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06.dcl", @"Resources\Export")]
+        public async Task AnIndistinguishableAlternativeIsPublishedAsASecondRankedEvidenceRow() {
+            var (storage, container, msdecs) = await LoadExportFixtureAsync();
+
+            var spot = container.AlignmentSpotProperties.First(s => s.Name == "Quercetin");
+            var alternative = spot.MatchResults.Representative.Clone();
+            alternative.Name = "Morin";
+            alternative.LibraryID = spot.MatchResults.Representative.LibraryID + 1000;
+            // Strictly lower on the last term of the ordering only, so the representative does not change
+            // and the alternative is unambiguously rank 2.
+            alternative.TotalScore = spot.MatchResults.Representative.TotalScore - 0.1f;
+            spot.MatchResults.AddResult(alternative);
+
+            var lines = ExportToLines(storage, container, msdecs);
+
+            var evidence = lines.Where(line => line.StartsWith("SME\t")).Select(line => line.Split('\t')).ToArray();
+            var forThisSpot = evidence.Where(f => f[2] == spot.MasterAlignmentID.ToString()).ToArray();
+            Assert.AreEqual(2, forThisSpot.Length, "both candidates should be published");
+            CollectionAssert.AreEqual(new[] { "Quercetin", "Morin" }, forThisSpot.Select(f => f[7]).ToArray());
+            CollectionAssert.AreEqual(new[] { "1", "2" }, forThisSpot.Select(f => f[f.Length - 1]).ToArray());
+            Assert.AreEqual("small_test_msp:Morin", forThisSpot[1][3]);
+
+            // The rows carry consecutive, file-unique identifiers and the feature row references both.
+            var smeIds = forThisSpot.Select(f => f[1]).ToArray();
+            Assert.AreEqual(int.Parse(smeIds[0]) + 1, int.Parse(smeIds[1]));
+            var feature = lines.Select(line => line.Split('\t'))
+                .Single(f => f[0] == "SMF" && f[1] == spot.MasterAlignmentID.ToString());
+            Assert.AreEqual(string.Join("|", smeIds), feature[2]);
+            Assert.AreEqual("1", feature[3], "two alternatives for one feature is ambiguity code 1");
+        }
+
+        /// <summary>
+        /// One candidate is not an ambiguity, so the feature row leaves the code null.
+        /// </summary>
+        [TestMethod()]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11.mddata", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11_Loaded.msp2", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11_Loaded.msp2.dbs", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06.arf2", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06_PeakProperties.arf", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06.dcl", @"Resources\Export")]
+        public async Task ASingleCandidateLeavesTheAmbiguityCodeNull() {
+            var (storage, container, msdecs) = await LoadExportFixtureAsync();
+            var spot = container.AlignmentSpotProperties.First(s => s.Name == "Quercetin");
+
+            var lines = ExportToLines(storage, container, msdecs);
+
+            var feature = lines.Select(line => line.Split('\t'))
+                .Single(f => f[0] == "SMF" && f[1] == spot.MasterAlignmentID.ToString());
+            Assert.AreEqual("null", feature[3]);
+            Assert.IsFalse(feature[2].Contains("|"), "a single reference needs no separator");
+        }
+
+        /// <summary>
+        /// A feature row must not reference an evidence row that was never written. The reference set and
+        /// the rows come from the same layout pass, so this holds for every row of the file.
+        /// </summary>
+        [TestMethod()]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11.mddata", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11_Loaded.msp2", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\Dataset_2025_07_31_12_31_11_Loaded.msp2.dbs", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06.arf2", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06_PeakProperties.arf", @"Resources\Export")]
+        [DeploymentItem(@"Resources\Export\AlignmentResult_2025_07_31_12_33_06.dcl", @"Resources\Export")]
+        public async Task EveryFeatureReferenceResolvesToAnEvidenceRow() {
+            var (storage, container, msdecs) = await LoadExportFixtureAsync();
+
+            var lines = ExportToLines(storage, container, msdecs);
+            var rows = lines.Select(line => line.Split('\t')).ToArray();
+
+            var written = rows.Where(f => f[0] == "SME").Select(f => f[1]).ToArray();
+            var referenced = rows.Where(f => f[0] == "SMF" && f[2] != "null").SelectMany(f => f[2].Split('|')).ToArray();
+            CollectionAssert.AreEquivalent(written, referenced);
+            CollectionAssert.AllItemsAreUnique(written);
+        }
+
+        private static async Task<(IMsdialDataStorage<ParameterBase>, AlignmentResultContainer, List<MSDec.MSDecResult>)> LoadExportFixtureAsync() {
+            IMsdialDataStorage<ParameterBase> storage;
+            using (var streamManager = new DirectoryTreeStreamManager("./Resources/Export")) {
+                storage = await MsdialDataStorage.Serializer.LoadAsync(streamManager, "Dataset_2025_07_31_12_31_11.mddata", "", "");
+                storage.FixDatasetFolder("./Resources/Export");
+            }
+            var alignmentFile = storage.AlignmentFiles.Last();
+            var container = AlignmentResultContainer.Load(alignmentFile);
+            var loader = new MSDec.MSDecLoader(alignmentFile.SpectraFilePath, []);
+            return (storage, container, loader.LoadMSDecResults());
+        }
+
+        private static string[] ExportToLines(
+            IMsdialDataStorage<ParameterBase> storage,
+            AlignmentResultContainer container,
+            List<MSDec.MSDecResult> msdecs) {
+            var exporter = new MztabFormatExporter(storage.DataBases);
+            using var stream = new MemoryStream();
+            exporter.MztabFormatExporterCore(
+                stream,
+                [.. container.AlignmentSpotProperties],
+                msdecs,
+                storage.AnalysisFiles,
+                new StubMetadataAccessor(storage.DataBaseMapper, storage.Parameter),
+                new LegacyQuantValueAccessor("Height", storage.Parameter),
+                [StatsValue.Average, StatsValue.Stdev,],
+                "mztab_test");
+            return System.Text.Encoding.ASCII.GetString(stream.ToArray()).Split('\n').Select(line => line.TrimEnd('\r')).ToArray();
+        }
+
 
         [TestMethod()]
         //[DeploymentItem(@"Resources\Export\small_test_project.mdproject", @"Resources\Export")]

--- a/tests/MSDIAL5/MsdialCoreTests/Resources/Export/test_mztab.mzTab.txt
+++ b/tests/MSDIAL5/MsdialCoreTests/Resources/Export/test_mztab.mzTab.txt
@@ -63,7 +63,7 @@ SMF	0	null	null	[M+H]1+	null	300.1852722167969	1	115.687	115.687	115.687	1017	17
 SMF	1	1	null	[M+H]1+	null	301.0346374511719	1	119.6405	118.444	120.83699999999999	12642	20826
 SMF	2	null	null	[M+H]1+	null	302.0978088378906	1	118.857	118.857	118.857	5881	15691
 SMF	3	null	null	[M+H]1+	null	302.1385192871094	1	118.804	118.804	118.804	1285	2241
-SMF	4	4	null	[M+H]1+	null	303.0500183105469	1	118.8305	118.62400000000001	119.037	536230	1837469
+SMF	4	2	null	[M+H]1+	null	303.0500183105469	1	118.8305	118.62400000000001	119.037	536230	1837469
 SMF	5	null	null	[M+H]1+	null	303.12347412109375	1	119.397	119.397	119.397	314	5489
 SMF	6	null	null	[M+H]1+	null	303.3472595214844	1	118.677	118.677	118.677	479	1459
 SMF	7	null	null	[M+H]1+	null	303.7848205566406	1	118.4705	118.084	118.857	1451	10300
@@ -73,6 +73,6 @@ SMF	10	null	null	[M+H]1+	null	304.62640380859375	1	118.857	118.857	118.857	268	1
 SMF	11	null	null	[M+H]1+	null	304.8061828613281	1	119.037	119.037	119.037	384	1553
 
 SEH	SME_ID	evidence_input_id	database_identifier	chemical_formula	smiles	inchi	chemical_name	uri	derivatized_form	adduct_ion	exp_mass_to_charge	charge	theoretical_mass_to_charge	spectra_ref	identification_method	ms_level	id_confidence_measure[1]	id_confidence_measure[2]	id_confidence_measure[3]	id_confidence_measure[4]	id_confidence_measure[5]	id_confidence_measure[6]	id_confidence_measure[7]	id_confidence_measure[8]	rank
-SME	1	1	small_test_msp:Isodemethylwedelolactone	C15H8O7	O=C1OC=2C(O)=CC(O)=CC2C=3OC=4C=C(O)C(O)=CC4C13	null	Isodemethylwedelolactone	null	null	[M+H]1+	301.0346374511719	1	0	ms_run[2]:ms1scanID=3490 ms2scanID=3488	[,, MS-DIAL algorithm matching score, ]	[MS, MS:1000511, ms level, 2]	1.5242083	0	0.8979989	0.646961	0.69420624	0.88054246	4	0.6666667	1	
-SME	4	4	small_test_msp:Quercetin	C15H10O7	C1=CC(=C(C=C1C2=C(C(=O)C3=C(C=C(C=C3O2)O)O)O)O)O	null	Quercetin	null	null	[M+H]1+	303.0500183105469	1	0	ms_run[1]:ms1scanID=3510 ms2scanID=3468| ms_run[2]:ms1scanID=3440 ms2scanID=3418	[,, MS-DIAL algorithm matching score, ]	[MS, MS:1000511, ms level, 2]	1.6437206	0	0.9999581	0.6832075	0.7282375	0.8728807	15	0.88235295	1	
+SME	1	1	small_test_msp:Isodemethylwedelolactone	C15H8O7	O=C1OC=2C(O)=CC(O)=CC2C=3OC=4C=C(O)C(O)=CC4C13	null	Isodemethylwedelolactone	null	null	[M+H]1+	301.0346374511719	1	301.03000	ms_run[2]:ms1scanID=3490 ms2scanID=3488	[,, MS-DIAL algorithm matching score, ]	[MS, MS:1000511, ms level, 2]	1.5242083	0	0.8979989	0.646961	0.69420624	0.88054246	4	0.6666667	1
+SME	2	4	small_test_msp:Quercetin	C15H10O7	C1=CC(=C(C=C1C2=C(C(=O)C3=C(C=C(C=C3O2)O)O)O)O)O	null	Quercetin	null	null	[M+H]1+	303.0500183105469	1	303.04993	ms_run[1]:ms1scanID=3510 ms2scanID=3468| ms_run[2]:ms1scanID=3440 ms2scanID=3418	[,, MS-DIAL algorithm matching score, ]	[MS, MS:1000511, ms level, 2]	1.6437206	0	0.9999581	0.6832075	0.7282375	0.8728807	15	0.88235295	1
 


### PR DESCRIPTION
MS-DIAL keeps up to `NUMBER_OF_ANNOTATION_RESULTS` threshold-passing results per annotator, and alignment carries all of them from the representative peak into the spot. Every export then published only the representative. A product-ion spectrum reports structure indirectly, so a search that cannot separate two references is the common case rather than the corner case, and dropping the alternatives at the file boundary turns "the search did not choose" into "the search chose".

On the FastLC demo, of the **1919 annotated alignment spots only 335 have a single candidate**: 115 have two and 1469 have three. Four fifths of the annotations were published as unambiguous when the run had not established that.

This adds the two exports that let a file say otherwise: a per-candidate audit sidecar, and the mzTab-M mechanism that already exists for exactly this.

## `AlignResult-*.mdcandidate.tsv`

One row per spot and candidate, ranked by the same precedence that picks the representative, so rank 1 is the representative in every row of the file. 36 columns: the annotator and database, the library entry, the resolved reference fields, and the full score block. That is what a downstream record needs in order to state an annotation claim and the evidence behind it.

Off by default, requested with `Annotation candidates: True` in a Console parameter file, alongside the existing `Detailed alignment provenance`.

Conventions follow the `.mdprovenance.tsv` sidecar rather than the `.mdalign` columns, because the consumer is the same audit pipeline: an empty cell wherever the run established nothing, and round-trip precision instead of display rounding. A score that reads `0.977` in `.mdalign` reads `0.977049112` here; same measurement.

Three things the file is careful about:

- **A spectral score is written only when a comparison happened.** That condition now lives in one place, `AnnotationScoreFormat.IsComputed`, which the `.mdalign` and `.mdpeak` columns already went through. On the demo, 2744 of the 4972 rows are precursor-only suggestions and carry five empty score cells rather than five zeros.
- **The five non-spectral similarity terms have no equivalent of the `-1` sentinel.** An unused term is stored as `0` and cannot be told apart from a term evaluated as `0`. The file says so in a comment rather than implying a measurement it cannot support.
- **The annotator identifier is an absolute library path in a Console run.** It is kept verbatim because it is the join key back to `.mdalign`'s Comment column and to the parameter file, which both already record it. `database_id` beside it carries the short database name (`LbmDB`) for anything that should not repeat a local path.

## mzTab-M: `SME_ID_REF_ambiguity_code`, real ranks, one row per candidate

mzTab-M already has a way to report that a search did not choose: evidence rows sharing an `evidence_input_id` came from the same input spectrum, `rank` orders them, and the feature row that references them carries ambiguity code 1. The exporter wrote one evidence row per feature, hardcoded `rank` to `"1"` and the ambiguity code to `"null"`.

On the demo the evidence section goes from 848 rows to 2228, and **714 of the 848 identified features have alternatives** the search kept and the file used to drop. Feature 108 is a good example: three separate RIKEN N-VS1 records at the same nominal mass, and the third is the one a *different* run file independently chose, which the old file had no way to show.

```
SME  11  108  LbmDB:RIKEN N-VS1 ID-97 ...   158.97440  ms_run[1]:... | ms_run[2]:...  rank 1
SME  12  108  LbmDB:RIKEN N-VS1 ID-103 ...  158.97479  null                           rank 2
SME  13  108  LbmDB:RIKEN N-VS1 ID-104 ...  158.97510  ms_run[3]:...                  rank 3
SMF 108  SME_ID_REFS 11|12|13  ambiguity_code 1
```

### Identifiers are laid out before the sections are written

The feature section is written before the evidence section but has to reference it, so a layout pass assigns the evidence identifiers first. Two things follow.

**A reference cannot outlive a row that was never written.** The two conditions used to be spelled out separately and did not agree: the feature side omitted the MS/MS-assigned, blank-filtered and internal-standard tests, so a feature could reference an evidence row the evidence loop had skipped. The demo does not happen to exercise the difference; sourcing both from one table removes the possibility, and a test asserts the two sets are equal for every row of the file.

**The identifiers are file-unique.** They used to be the alignment identifier, which is not unique across an ion-mobility run: a drift spot is written with its parent's metadata dictionary and so reported the parent's number. For the same reason `evidence_input_id` now comes from the spot the row describes — a drift row and its parent are different input spectra and must not be grouped as alternatives for one another.

### Each row is resolved from its own candidate

Database identifier, name, formula, SMILES, theoretical m/z and the score block. Two notes:

- `theoretical_mass_to_charge` was read from the representative's metadata dictionary under a key only the LC and IM accessors provide, so a **GC-MS file reported the number `0`** for it. It now goes through the same reference lookup for every row, and an unresolvable reference is the null token rather than a mass of zero. This is visible in the updated golden file, where `0` becomes `301.03000`.
- `spectra_ref` keeps its existing rule — the member files whose own top annotation is this library entry — applied to the row's own candidate. 79 of the 1380 lower-ranked rows have one; the rest report null because no file independently chose them. That the alternatives were scored against the same query spectrum is already stated by `evidence_input_id`.

### A trailing separator on every evidence row, removed

The row used to be written without a terminator, the caller closing it afterwards, which appended a trailing tab to every one. The built-in mzTab-M structural check reports

```
SME column count 27 differs from its header count 26; ... (848 lines total)
```

on a current `master` run of this demo, and reports nothing on this branch. With more than one candidate per feature that form would also have run them together on a single physical line.

## Verification

Measured against `master` at `6b8e3e9d3`, same demo and method file:

| Output | Result |
| --- | --- |
| 7 per-file `.mdpeak`, 7 per-file `.mdmsp` | byte-identical |
| `.mdalign`, alignment `.mdmsp`, `.mdpeakid.tsv`, `.qa.tsv` | byte-identical |
| `.mzTab` MTD section | differs only in the `mzTab-ID` line, which is the run timestamp |
| `.mzTab` SML section | byte-identical, 2553 rows |
| `.mzTab` SMF section | 2553 rows, and only fields 2 and 3 move — the evidence reference list on 848 rows and the ambiguity code on 714 |
| `.mzTab` SME section | 848 -> 2228 rows; 26 fields per row against a 26-field header, was 27 |

mzTab-M validation: `passed` on this branch, `warning` on `master`.

Alignment-light mode produces the same 4972 candidate rows and the same 2228 evidence rows, and its mzTab validates. It diverges from regular mode on **6 of 4972 candidate rows**, which are the same 4 spots on which the `.mdalign` files of the two modes already diverge on `master` — a pre-existing representative-selection difference, not something this introduces.

- Build: `Release`, `net48`, 0 errors, including `MsdialGuiApp`.
- `MsdialCoreTests`: **325/325** (316 before, plus six for the candidate exporter and three for the mzTab evidence section).
- `MsdialCoreTestAppTests`: **14/14**, including the new config key.

The new tests assert whole lines, not substrings, for the reason the provenance exporter tests do: a substring assertion cannot see a ragged field count, and this change adds another hand-maintained column list.

## Deliberately not in this PR

- Applying the same per-candidate treatment to `.mdalign` and `.mdpeak`. Those are widely parsed fixed-column formats; the sidecar carries the alternatives without moving anything in them.
- The drift-spot metadata reuse in the SML and SMF sections. Rows for a drift spot are written with the parent's metadata dictionary, so they carry the parent's identifier and adduct. The evidence section no longer depends on that, but fixing it properly changes ion-mobility output across three sections and belongs in its own change.
- Gating the mzTab-M behaviour behind a flag. A Console parameter cannot reach the GUI exporter, and the previous file asserted an unambiguous identification the run had not made, so this is a correction rather than an option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
